### PR TITLE
fix: use PR-based merge for releases to comply with branch protection

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -523,25 +523,65 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-          # Configure git to use VERSION_BUMP_PAT for authentication to bypass branch protection
+          # Configure git to use VERSION_BUMP_PAT for authentication
           git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
 
-          # Stage enriched outputs (NOT .version - it no longer exists)
+          BRANCH="release/v${VERSION}"
+
+          # Create release branch from current state
+          git checkout -b "$BRANCH"
+
+          # Stage enriched outputs
           # Use -f to add docs/specifications/api/ and docs/api-reference/ which are in .gitignore
           git add -f CHANGELOG.md .github_release docs/specifications/api/ docs/api-reference/
 
           if ! git diff --staged --quiet; then
-            # Create release commit with [skip ci] to prevent recursive workflow triggers
             git commit -m "chore: release v${VERSION} (${BUMP_TYPE}) [skip ci]"
 
-            # Create annotated tag
-            git tag -a "v${VERSION}" -m "Release v${VERSION} (${BUMP_TYPE})"
+            # Push release branch
+            git push origin "$BRANCH"
 
-            # Push commit and tag atomically
-            git push origin main
+            # Create PR (release/* branches are excluded from linked-issue check)
+            PR_URL=$(gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore: release v${VERSION} (${BUMP_TYPE})" \
+              --body "Automated release v${VERSION} (${BUMP_TYPE}). Created by the sync-and-enrich workflow.")
+
+            echo "Created release PR: ${PR_URL}"
+
+            # Enable auto-merge (squash) — merges when required checks pass
+            gh pr merge "$BRANCH" --squash --auto --delete-branch
+
+            # Wait for PR to merge (poll up to 5 minutes)
+            for i in $(seq 1 30); do
+              STATE=$(gh pr view "$BRANCH" --json state --jq '.state')
+              if [ "$STATE" = "MERGED" ]; then
+                echo "PR merged successfully"
+                break
+              fi
+              if [ "$STATE" = "CLOSED" ]; then
+                echo "::error::PR was closed without merging"
+                exit 1
+              fi
+              echo "Waiting for PR merge... (attempt $i/30)"
+              sleep 10
+            done
+
+            if [ "$STATE" != "MERGED" ]; then
+              echo "::error::PR did not merge within timeout"
+              exit 1
+            fi
+
+            # Switch back to main and pull the merge commit
+            git checkout main
+            git pull origin main
+
+            # Create annotated tag on the merge commit
+            git tag -a "v${VERSION}" -m "Release v${VERSION} (${BUMP_TYPE})"
             git push origin "v${VERSION}"
 
-            echo "::notice::Released v${VERSION} with direct commit + tag (no PR race condition)"
+            echo "::notice::Released v${VERSION} via PR merge + tag"
           else
             echo "No changes to commit"
           fi


### PR DESCRIPTION
## Summary

- Refactored the "Commit and tag release" step in `sync-and-enrich.yml` to use a PR-based merge flow instead of direct pushes to main
- Release commits now create a `release/v{VERSION}` branch, open a PR, and auto-merge when checks pass, then tag on main
- The `release/*` branch pattern is already excluded from the linked-issue check in docs-control, so release PRs are not blocked

Closes #12

## Test plan

- [ ] CI checks pass on this PR
- [ ] Verify the workflow YAML is syntactically valid
- [ ] Next automated release run uses the PR-based merge path successfully