### PR TITLE
fix: resolve MARKDOWN, NATURAL_LANGUAGE, PYTHON_RUFF, PYTHON_ISORT, SHELL_SHFMT, and SHELLCHECK lint errors

### DIFF
--- a/examples/constraints/README.md
+++ b/examples/constraints/README.md
@@ -1,6 +1,6 @@
 # F5 XC API Constraint Validation Examples
 
-**Purpose**: Demonstrate constraint validation using curl and the live F5 XC API.
+**Purpose**: Demonstrate constraint validation using cURL and the live F5 XC API.
 
 These scripts validate the constraints documented in `x-f5xc-constraints` extensions against the actual API behavior.
 
@@ -37,21 +37,25 @@ export F5XC_NAMESPACE="test"  # Use a test namespace!
 **Tests**: Resource name constraints (x-f5xc-constraints for `metadata.name`)
 
 **Constraint**:
+
 - Pattern: `^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
 - Length: 1-63 characters
 - Format: dns-label (RFC 1123)
 
 **Usage**:
+
 ```bash
 chmod +x validate_dns_label.sh
 ./validate_dns_label.sh
 ```
 
 **Test Cases**:
+
 - ✅ Valid: `my-service`, `api-gateway`, `web`
 - ❌ Invalid: `My-Service` (uppercase), `-my-service` (hyphen at start), `my_service` (underscore)
 
 **Expected Behavior**:
+
 - Valid names: HTTP 200 (created) or 409 (already exists)
 - Invalid names: HTTP 400 (bad request) with validation error message
 
@@ -62,21 +66,25 @@ chmod +x validate_dns_label.sh
 **Tests**: Port number constraints (x-f5xc-constraints for `spec.port`)
 
 **Constraint**:
+
 - Type: number (integer)
 - Minimum: 1
 - Maximum: 65535
 
 **Usage**:
+
 ```bash
 chmod +x validate_port_number.sh
 ./validate_port_number.sh
 ```
 
 **Test Cases**:
+
 - ✅ Valid: `80`, `443`, `8080`, `1`, `65535`
 - ❌ Invalid: `0`, `-1`, `65536`, `100000`
 
 **Expected Behavior**:
+
 - Valid ports: HTTP 200 (created) or 409 (already exists)
 - Invalid ports: HTTP 400 with validation error
 
@@ -87,21 +95,25 @@ chmod +x validate_port_number.sh
 **Tests**: Array constraints (x-f5xc-constraints for arrays)
 
 **Constraint**:
+
 - Type: array
 - minItems: 1
 - maxItems: 50
 
 **Usage**:
+
 ```bash
 chmod +x validate_array_size.sh
 ./validate_array_size.sh
 ```
 
 **Test Cases**:
+
 - ✅ Valid: 1 item, 5 items, 50 items
 - ❌ Invalid: 0 items (empty array)
 
 **Expected Behavior**:
+
 - Valid sizes: HTTP 200 (created)
 - Invalid sizes: HTTP 400 with validation error
 
@@ -112,6 +124,7 @@ chmod +x validate_array_size.sh
 ### Success Indicators
 
 ✅ **Name format accepted** (HTTP 200/409)
+
 - HTTP 200: Resource created successfully
 - HTTP 409: Resource already exists (name format valid)
 - The constraint allows this value
@@ -119,12 +132,14 @@ chmod +x validate_array_size.sh
 ### Failure Indicators
 
 ❌ **Name format rejected** (HTTP 400)
+
 - HTTP 400: Bad request - constraint violation
 - The API validation matches the documented constraint
 
 ### Warnings
 
 ⚠️ **Unexpected behavior**
+
 - Expected valid but got HTTP 400: Constraint may be incorrect or incomplete
 - Expected invalid but got HTTP 200/409: Constraint may be too permissive
 
@@ -135,7 +150,7 @@ chmod +x validate_array_size.sh
 These scripts help verify:
 
 1. **Constraint Accuracy**: Do documented constraints match API behavior?
-2. **Pattern Correctness**: Does the regex pattern accurately describe valid values?
+2. **Pattern Correctness**: Does the regular expression pattern accurately describe valid values?
 3. **Confidence Scores**: Are high-confidence (deterministic) constraints reliable?
 4. **Discovery Integration**: Does discovery data improve constraint accuracy?
 
@@ -164,16 +179,19 @@ done
 ## Interpreting Results
 
 ### High Match Rate (>95%)
+
 - Constraints are highly accurate
 - Safe for AI generation with `deterministic: true`
 - Recommend using for CLI validation
 
 ### Medium Match Rate (80-95%)
+
 - Constraints are mostly accurate
 - Use for advisory hints, not strict enforcement
 - May need refinement from discovery data
 
 ### Low Match Rate (<80%)
+
 - Constraints may be incorrect or incomplete
 - Do not use for automated generation
 - Report issue for investigation
@@ -187,9 +205,10 @@ If you find constraint mismatches:
 1. **Note the field path**: e.g., `metadata.name`, `spec.port`
 2. **Document the test case**: What value was tested?
 3. **Include API response**: What did the API return?
-4. **Report at**: https://github.com/f5xc-salesdemos/api-specs-enriched/issues
+4. **Report at**: [GitHub Issues](https://github.com/f5xc-salesdemos/api-specs-enriched/issues)
 
 **Issue Template**:
+
 ```markdown
 **Constraint Mismatch**
 
@@ -255,7 +274,7 @@ done
 ## Resources
 
 - **Constraint Metadata Documentation**: [docs/CONSTRAINT_METADATA.md](../../docs/CONSTRAINT_METADATA.md)
-- **F5 XC API Documentation**: https://docs.cloud.f5.com/docs/api
+- **F5 XC API Documentation**: [F5 XC API Documentation](https://docs.cloud.f5.com/docs/api)
 - **OpenAPI Specifications**: [docs/specifications/api/](../../docs/specifications/api/)
 
 ---

--- a/examples/constraints/validate_array_size.sh
+++ b/examples/constraints/validate_array_size.sh
@@ -31,37 +31,37 @@ echo ""
 
 # Function to generate origin servers array
 generate_origins() {
-    local count=$1
-    local origins="[]"
+  local count=$1
+  local origins="[]"
 
-    if [ "$count" -gt 0 ]; then
-        origins="["
-        for i in $(seq 1 $count); do
-            if [ $i -gt 1 ]; then
-                origins="${origins},"
-            fi
-            origins="${origins}{\"public_name\":{\"dns_name\":\"origin${i}.example.com\"}}"
-        done
-        origins="${origins}]"
-    fi
+  if [ "$count" -gt 0 ]; then
+    origins="["
+    for i in $(seq 1 "$count"); do
+      if [ "$i" -gt 1 ]; then
+        origins="${origins},"
+      fi
+      origins="${origins}{\"public_name\":{\"dns_name\":\"origin${i}.example.com\"}}"
+    done
+    origins="${origins}]"
+  fi
 
-    echo "$origins"
+  echo "$origins"
 }
 
 # Function to test array size
 test_array_size() {
-    local size=$1
-    local expected=$2  # "valid" or "invalid"
-    local test_name="test-array-${size}-$$"
+  local size=$1
+  local expected=$2 # "valid" or "invalid"
+  local test_name="test-array-${size}-$$"
 
-    echo "Testing array with ${size} items (expecting: ${expected})"
+  echo "Testing array with ${size} items (expecting: ${expected})"
 
-    origins=$(generate_origins $size)
+  origins=$(generate_origins "$size")
 
-    response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/origin_pools" \
-        -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -d "{
+  response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/origin_pools" \
+    -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{
             \"metadata\": {
                 \"name\": \"${test_name}\",
                 \"namespace\": \"${NAMESPACE}\"
@@ -73,48 +73,48 @@ test_array_size() {
             }
         }" 2>&1)
 
-    http_code=$(echo "$response" | tail -n1)
-    body=$(echo "$response" | head -n-1)
+  http_code=$(echo "$response" | tail -n1)
+  body=$(echo "$response" | head -n-1)
 
-    if [ "$http_code" = "200" ] || [ "$http_code" = "409" ]; then
-        echo "  ✅ Array size accepted by API (HTTP ${http_code})"
-        if [ "$expected" = "invalid" ]; then
-            echo "  ⚠️  WARNING: Expected rejection but API accepted ${size} items!"
-        fi
-
-        # Clean up
-        if [ "$http_code" = "200" ]; then
-            curl -s -X DELETE "${API_BASE}/origin_pools/${test_name}" \
-                -H "Authorization: APIToken ${F5XC_API_TOKEN}" > /dev/null
-            echo "  🧹 Cleaned up test resource"
-        fi
-    elif [ "$http_code" = "400" ]; then
-        echo "  ❌ Array size rejected by API (HTTP 400)"
-        echo "  Error: $(echo "$body" | jq -r '.message // .error // "Unknown error"' 2>/dev/null || echo "$body")"
-        if [ "$expected" = "valid" ]; then
-            echo "  ⚠️  WARNING: Expected acceptance but API rejected ${size} items!"
-        fi
-    else
-        echo "  ⚠️  Unexpected HTTP ${http_code}"
-        echo "  Response: $(echo "$body" | head -c 200)"
+  if [ "$http_code" = "200" ] || [ "$http_code" = "409" ]; then
+    echo "  ✅ Array size accepted by API (HTTP ${http_code})"
+    if [ "$expected" = "invalid" ]; then
+      echo "  ⚠️  WARNING: Expected rejection but API accepted ${size} items!"
     fi
 
-    echo ""
+    # Clean up
+    if [ "$http_code" = "200" ]; then
+      curl -s -X DELETE "${API_BASE}/origin_pools/${test_name}" \
+        -H "Authorization: APIToken ${F5XC_API_TOKEN}" >/dev/null
+      echo "  🧹 Cleaned up test resource"
+    fi
+  elif [ "$http_code" = "400" ]; then
+    echo "  ❌ Array size rejected by API (HTTP 400)"
+    echo "  Error: $(echo "$body" | jq -r '.message // .error // "Unknown error"' 2>/dev/null || echo "$body")"
+    if [ "$expected" = "valid" ]; then
+      echo "  ⚠️  WARNING: Expected acceptance but API rejected ${size} items!"
+    fi
+  else
+    echo "  ⚠️  Unexpected HTTP ${http_code}"
+    echo "  Response: $(echo "$body" | head -c 200)"
+  fi
+
+  echo ""
 }
 
 # Test Cases
 
 echo "1. Valid Array Sizes (should be accepted)"
 echo "------------------------------------------"
-test_array_size 1 "valid"     # Minimum
-test_array_size 2 "valid"     # Typical
-test_array_size 5 "valid"     # Multiple origins
-test_array_size 10 "valid"    # Larger pool
-test_array_size 50 "valid"    # Maximum
+test_array_size 1 "valid"  # Minimum
+test_array_size 2 "valid"  # Typical
+test_array_size 5 "valid"  # Multiple origins
+test_array_size 10 "valid" # Larger pool
+test_array_size 50 "valid" # Maximum
 
 echo "2. Invalid Array Sizes - Below minimum (should be rejected)"
 echo "-----------------------------------------------------------"
-test_array_size 0 "invalid"   # Empty array
+test_array_size 0 "invalid" # Empty array
 
 echo "3. Invalid Array Sizes - Above maximum (should be rejected)"
 echo "-----------------------------------------------------------"

--- a/examples/constraints/validate_dns_label.sh
+++ b/examples/constraints/validate_dns_label.sh
@@ -33,16 +33,16 @@ echo ""
 
 # Function to test a resource name
 test_name() {
-    local name=$1
-    local expected=$2  # "valid" or "invalid"
+  local name=$1
+  local expected=$2 # "valid" or "invalid"
 
-    echo "Testing: '${name}' (expecting: ${expected})"
+  echo "Testing: '${name}' (expecting: ${expected})"
 
-    # Create HTTP load balancer with the test name
-    response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/http_loadbalancers" \
-        -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -d "{
+  # Create HTTP load balancer with the test name
+  response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/http_loadbalancers" \
+    -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{
             \"metadata\": {
                 \"name\": \"${name}\",
                 \"namespace\": \"${NAMESPACE}\"
@@ -50,34 +50,34 @@ test_name() {
             \"spec\": {}
         }" 2>&1)
 
-    http_code=$(echo "$response" | tail -n1)
-    body=$(echo "$response" | head -n-1)
+  http_code=$(echo "$response" | tail -n1)
+  body=$(echo "$response" | head -n-1)
 
-    if [ "$http_code" = "200" ] || [ "$http_code" = "409" ]; then
-        # 200 = created, 409 = already exists (both indicate name format is valid)
-        echo "  ✅ Name format accepted by API (HTTP ${http_code})"
-        if [ "$expected" = "invalid" ]; then
-            echo "  ⚠️  WARNING: Expected rejection but API accepted it!"
-        fi
-
-        # Clean up if we created it
-        if [ "$http_code" = "200" ]; then
-            curl -s -X DELETE "${API_BASE}/http_loadbalancers/${name}" \
-                -H "Authorization: APIToken ${F5XC_API_TOKEN}" > /dev/null
-            echo "  🧹 Cleaned up test resource"
-        fi
-    elif [ "$http_code" = "400" ]; then
-        echo "  ❌ Name format rejected by API (HTTP 400)"
-        echo "  Error: $(echo "$body" | jq -r '.message // .error // "Unknown error"' 2>/dev/null || echo "$body")"
-        if [ "$expected" = "valid" ]; then
-            echo "  ⚠️  WARNING: Expected acceptance but API rejected it!"
-        fi
-    else
-        echo "  ⚠️  Unexpected HTTP ${http_code}"
-        echo "  Response: $body"
+  if [ "$http_code" = "200" ] || [ "$http_code" = "409" ]; then
+    # 200 = created, 409 = already exists (both indicate name format is valid)
+    echo "  ✅ Name format accepted by API (HTTP ${http_code})"
+    if [ "$expected" = "invalid" ]; then
+      echo "  ⚠️  WARNING: Expected rejection but API accepted it!"
     fi
 
-    echo ""
+    # Clean up if we created it
+    if [ "$http_code" = "200" ]; then
+      curl -s -X DELETE "${API_BASE}/http_loadbalancers/${name}" \
+        -H "Authorization: APIToken ${F5XC_API_TOKEN}" >/dev/null
+      echo "  🧹 Cleaned up test resource"
+    fi
+  elif [ "$http_code" = "400" ]; then
+    echo "  ❌ Name format rejected by API (HTTP 400)"
+    echo "  Error: $(echo "$body" | jq -r '.message // .error // "Unknown error"' 2>/dev/null || echo "$body")"
+    if [ "$expected" = "valid" ]; then
+      echo "  ⚠️  WARNING: Expected acceptance but API rejected it!"
+    fi
+  else
+    echo "  ⚠️  Unexpected HTTP ${http_code}"
+    echo "  Response: $body"
+  fi
+
+  echo ""
 }
 
 # Test Cases
@@ -89,7 +89,7 @@ test_name "api-gateway" "valid"
 test_name "lb-prod-01" "valid"
 test_name "web" "valid"
 test_name "a" "valid"
-test_name "api-gateway-production-us-west-2-lb-01" "valid"  # 38 chars
+test_name "api-gateway-production-us-west-2-lb-01" "valid" # 38 chars
 
 echo "2. Invalid DNS Labels - Uppercase (should be rejected)"
 echo "------------------------------------------------------"
@@ -111,8 +111,8 @@ test_name "my@service" "invalid"
 
 echo "5. Invalid DNS Labels - Length violations (should be rejected)"
 echo "--------------------------------------------------------------"
-test_name "" "invalid"  # Too short
-test_name "this-is-a-very-long-name-that-exceeds-the-sixty-three-character-maximum-limit" "invalid"  # Too long (79 chars)
+test_name "" "invalid"                                                                              # Too short
+test_name "this-is-a-very-long-name-that-exceeds-the-sixty-three-character-maximum-limit" "invalid" # Too long (79 chars)
 
 echo "=========================================="
 echo "Test Summary"

--- a/examples/constraints/validate_port_number.sh
+++ b/examples/constraints/validate_port_number.sh
@@ -29,17 +29,17 @@ echo ""
 
 # Function to test a port number
 test_port() {
-    local port=$1
-    local expected=$2  # "valid" or "invalid"
-    local test_name="test-port-${port}-$$"
+  local port=$1
+  local expected=$2 # "valid" or "invalid"
+  local test_name="test-port-${port}-$$"
 
-    echo "Testing port: ${port} (expecting: ${expected})"
+  echo "Testing port: ${port} (expecting: ${expected})"
 
-    # Create origin pool with the test port
-    response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/origin_pools" \
-        -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
-        -H "Content-Type: application/json" \
-        -d "{
+  # Create origin pool with the test port
+  response=$(curl -s -w "\n%{http_code}" -X POST "${API_BASE}/origin_pools" \
+    -H "Authorization: APIToken ${F5XC_API_TOKEN}" \
+    -H "Content-Type: application/json" \
+    -d "{
             \"metadata\": {
                 \"name\": \"${test_name}\",
                 \"namespace\": \"${NAMESPACE}\"
@@ -57,46 +57,46 @@ test_port() {
             }
         }" 2>&1)
 
-    http_code=$(echo "$response" | tail -n1)
-    body=$(echo "$response" | head -n-1)
+  http_code=$(echo "$response" | tail -n1)
+  body=$(echo "$response" | head -n-1)
 
-    if [ "$http_code" = "200" ] || [ "$http_code" = "409" ]; then
-        echo "  ✅ Port accepted by API (HTTP ${http_code})"
-        if [ "$expected" = "invalid" ]; then
-            echo "  ⚠️  WARNING: Expected rejection but API accepted port ${port}!"
-        fi
-
-        # Clean up
-        if [ "$http_code" = "200" ]; then
-            curl -s -X DELETE "${API_BASE}/origin_pools/${test_name}" \
-                -H "Authorization: APIToken ${F5XC_API_TOKEN}" > /dev/null
-            echo "  🧹 Cleaned up test resource"
-        fi
-    elif [ "$http_code" = "400" ]; then
-        echo "  ❌ Port rejected by API (HTTP 400)"
-        echo "  Error: $(echo "$body" | jq -r '.message // .error // "Unknown error"' 2>/dev/null || echo "$body")"
-        if [ "$expected" = "valid" ]; then
-            echo "  ⚠️  WARNING: Expected acceptance but API rejected port ${port}!"
-        fi
-    else
-        echo "  ⚠️  Unexpected HTTP ${http_code}"
-        echo "  Response: $body"
+  if [ "$http_code" = "200" ] || [ "$http_code" = "409" ]; then
+    echo "  ✅ Port accepted by API (HTTP ${http_code})"
+    if [ "$expected" = "invalid" ]; then
+      echo "  ⚠️  WARNING: Expected rejection but API accepted port ${port}!"
     fi
 
-    echo ""
+    # Clean up
+    if [ "$http_code" = "200" ]; then
+      curl -s -X DELETE "${API_BASE}/origin_pools/${test_name}" \
+        -H "Authorization: APIToken ${F5XC_API_TOKEN}" >/dev/null
+      echo "  🧹 Cleaned up test resource"
+    fi
+  elif [ "$http_code" = "400" ]; then
+    echo "  ❌ Port rejected by API (HTTP 400)"
+    echo "  Error: $(echo "$body" | jq -r '.message // .error // "Unknown error"' 2>/dev/null || echo "$body")"
+    if [ "$expected" = "valid" ]; then
+      echo "  ⚠️  WARNING: Expected acceptance but API rejected port ${port}!"
+    fi
+  else
+    echo "  ⚠️  Unexpected HTTP ${http_code}"
+    echo "  Response: $body"
+  fi
+
+  echo ""
 }
 
 # Test Cases
 
 echo "1. Valid Port Numbers (should be accepted)"
 echo "-------------------------------------------"
-test_port 80 "valid"       # HTTP
-test_port 443 "valid"      # HTTPS
-test_port 8080 "valid"     # Alternative HTTP
-test_port 22 "valid"       # SSH
-test_port 1 "valid"        # Minimum
-test_port 65535 "valid"    # Maximum
-test_port 3000 "valid"     # Common app port
+test_port 80 "valid"    # HTTP
+test_port 443 "valid"   # HTTPS
+test_port 8080 "valid"  # Alternative HTTP
+test_port 22 "valid"    # SSH
+test_port 1 "valid"     # Minimum
+test_port 65535 "valid" # Maximum
+test_port 3000 "valid"  # Common app port
 
 echo "2. Invalid Port Numbers - Below minimum (should be rejected)"
 echo "------------------------------------------------------------"

--- a/release/README.md
+++ b/release/README.md
@@ -5,7 +5,7 @@ Enriched OpenAPI 3.0.3 specifications for F5 Distributed Cloud (XC) platform.
 ## Version Information
 
 | Field | Value |
-|-------|-------|
+| ------- | ------- |
 | **Version** | {VERSION} |
 | **Release Date** | {DATE} |
 | **OpenAPI Version** | 3.0.3 |
@@ -64,7 +64,7 @@ swagger-codegen generate \
 The `domains/` directory contains individual API specifications organized by functional area:
 
 | Domain | Description |
-|--------|-------------|
+| -------- | ------------- |
 | `api_security.json` | API security policies and configurations |
 | `applications.json` | Application deployment and management |
 | `cdn.json` | Content delivery network configuration |

--- a/scripts/discovery/report_generator.py
+++ b/scripts/discovery/report_generator.py
@@ -20,11 +20,7 @@ from .schema_inferrer import InferredSchema
 
 # Add utils to path for imports
 sys.path.insert(0, str(Path(__file__).parent.parent / "utils"))
-from extension_constants import (
-    X_F5XC_API_URL,
-    X_F5XC_DISCOVERED_AT,
-    X_F5XC_RESPONSE_TIME_MS,
-)
+from extension_constants import X_F5XC_API_URL, X_F5XC_DISCOVERED_AT, X_F5XC_RESPONSE_TIME_MS
 from path_config import PathConfig
 from report_base import BaseReporter
 from server_variables_markdown import ServerVariablesMarkdownHelper

--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -123,7 +123,7 @@ def generate_catalog_mdx(
             if spec.get("x-f5xc-is-preview"):
                 badge = " (Preview)"
 
-            description_line = short_desc if short_desc else title
+            description_line = short_desc or title
             stats_line = f"{path_count} paths, {schema_count} schemas"
             if complexity:
                 stats_line += f", {complexity}"

--- a/scripts/generate_descriptions.py
+++ b/scripts/generate_descriptions.py
@@ -718,7 +718,7 @@ def parse_opencode_output(output: str, verbose: bool = False) -> dict[str, str] 
                     )
             return None
 
-        return descriptions if descriptions else None
+        return descriptions or None
 
     except json.JSONDecodeError as e:
         print(f"Error parsing OpenCode output as JSON: {e}")

--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -30,11 +30,11 @@ NC='\033[0m' # No Color
 
 # Detect Python interpreter
 if [ -d ".venv" ]; then
-    PYTHON=".venv/bin/python"
-elif command -v python3 &> /dev/null; then
-    PYTHON="python3"
+  PYTHON=".venv/bin/python"
+elif command -v python3 &>/dev/null; then
+  PYTHON="python3"
 else
-    PYTHON="python"
+  PYTHON="python"
 fi
 
 # =============================================================================
@@ -44,8 +44,8 @@ echo -e "${YELLOW}[1/2] Running F5 XC API enrichment pipeline...${NC}"
 echo -e "${YELLOW}Executing: $PYTHON -m scripts.pipeline${NC}"
 
 if ! $PYTHON -m scripts.pipeline; then
-    echo -e "${RED}Pipeline failed! Please fix errors before committing.${NC}"
-    exit 1
+  echo -e "${RED}Pipeline failed! Please fix errors before committing.${NC}"
+  exit 1
 fi
 
 # Stage any changes to enriched specs (output is directly in docs/)
@@ -53,12 +53,12 @@ fi
 ENRICHED_CHANGES=$(git diff --name-only -- 'docs/specifications/api/*.json' 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "$ENRICHED_CHANGES" -gt 0 ]; then
-    echo -e "${YELLOW}Staging $ENRICHED_CHANGES updated enriched spec files...${NC}"
-    # Use --ignore-errors to skip ignored files like openapi.json
-    git add --ignore-errors docs/specifications/api/*.json 2>/dev/null || true
-    echo -e "${GREEN}Enriched specs updated and staged.${NC}"
+  echo -e "${YELLOW}Staging $ENRICHED_CHANGES updated enriched spec files...${NC}"
+  # Use --ignore-errors to skip ignored files like openapi.json
+  git add --ignore-errors docs/specifications/api/*.json 2>/dev/null || true
+  echo -e "${GREEN}Enriched specs updated and staged.${NC}"
 else
-    echo -e "${GREEN}No enriched spec changes detected.${NC}"
+  echo -e "${GREEN}No enriched spec changes detected.${NC}"
 fi
 
 # =============================================================================
@@ -67,11 +67,11 @@ fi
 echo -e "${YELLOW}[2/2] Running Spectral linting on ALL generated specs...${NC}"
 
 # Check if Spectral is installed - REQUIRED, never skip
-if ! command -v spectral &> /dev/null; then
-    echo -e "${RED}ERROR: Spectral CLI is not installed!${NC}"
-    echo -e "${RED}Linting is REQUIRED and cannot be skipped.${NC}"
-    echo -e "${YELLOW}Install with: npm install -g @stoplight/spectral-cli${NC}"
-    exit 1
+if ! command -v spectral &>/dev/null; then
+  echo -e "${RED}ERROR: Spectral CLI is not installed!${NC}"
+  echo -e "${RED}Linting is REQUIRED and cannot be skipped.${NC}"
+  echo -e "${YELLOW}Install with: npm install -g @stoplight/spectral-cli${NC}"
+  exit 1
 fi
 
 echo -e "${YELLOW}Executing: $PYTHON scripts/lint.py --input-dir docs/specifications/api --fail-on-error --fail-on-warning${NC}"
@@ -79,12 +79,12 @@ echo -e "${YELLOW}Note: Validating ALL 25 generated specs (including gitignored 
 
 # Run linting on ALL files in the directory - fail on errors AND warnings to ensure clean specs
 if $PYTHON scripts/lint.py --input-dir docs/specifications/api --fail-on-error --fail-on-warning; then
-    echo -e "${GREEN}Spectral linting passed (all files validated).${NC}"
+  echo -e "${GREEN}Spectral linting passed (all files validated).${NC}"
 else
-    LINT_EXIT_CODE=$?
-    echo -e "${RED}Spectral linting failed with errors!${NC}"
-    echo -e "${RED}Fix linting errors before committing.${NC}"
-    exit $LINT_EXIT_CODE
+  LINT_EXIT_CODE=$?
+  echo -e "${RED}Spectral linting failed with errors!${NC}"
+  echo -e "${RED}Fix linting errors before committing.${NC}"
+  exit $LINT_EXIT_CODE
 fi
 
 echo -e "${GREEN}Pre-commit pipeline complete.${NC}"

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -21,9 +21,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeEl
 from rich.table import Table
 
 from scripts.utils.description_enricher import DescriptionEnricher
-from scripts.utils.domain_categorizer import (
-    categorize_spec as categorize_spec_util,
-)
+from scripts.utils.domain_categorizer import categorize_spec as categorize_spec_util
 from scripts.utils.domain_metadata import (
     calculate_complexity,
     get_domain_icon,

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1120,7 +1120,7 @@ def merge_specs_by_domain(
 
         # Use enriched description if available, otherwise fallback to generic
         enriched_desc = description_enricher.get_description(domain, tier="long")
-        description = enriched_desc if enriched_desc else f"F5 Distributed Cloud {domain_title}"
+        description = enriched_desc or f"F5 Distributed Cloud {domain_title}"
 
         merged_spec = create_base_spec(
             title=domain_title,

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -38,10 +38,10 @@ from .uniqueness_enricher import UniquenessEnricher
 from .validation_enricher import ValidationEnricher
 from .validation_exporter import ValidationExporter
 from .version_calculator import (
-    calculate_next_version,
-    get_version,
-    get_version_from_tags,
-    is_valid_semver,
+                       calculate_next_version,
+                       get_version,
+                       get_version_from_tags,
+                       is_valid_semver,
 )
 
 __all__ = [

--- a/scripts/utils/constraint_enricher.py
+++ b/scripts/utils/constraint_enricher.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""F5 XC API Constraint Enricher
+"""F5 XC API Constraint Enricher.
 
 Purpose: Enrich OpenAPI specifications with x-f5xc-constraints extension
 Based on: Pattern matching, discovery data, and API validation rules
@@ -29,10 +29,10 @@ logger = logging.getLogger(__name__)
 
 
 class PatternMatcher:
-    """Regex-based pattern matcher for field names"""
+    """Regex-based pattern matcher for field names."""
 
-    def __init__(self, patterns: dict[str, list[dict]]):
-        """Initialize pattern matcher with compiled regex patterns
+    def __init__(self, patterns: dict[str, list[dict]]) -> None:
+        """Initialize pattern matcher with compiled regex patterns.
 
         Args:
             patterns: Dict with 'string_patterns', 'array_patterns', 'number_patterns'
@@ -42,7 +42,7 @@ class PatternMatcher:
         self.number_patterns = self._compile_patterns(patterns.get("number_patterns", []))
 
     def _compile_patterns(self, pattern_list: list[dict]) -> list[tuple]:
-        """Compile regex patterns for efficiency
+        """Compile regex patterns for efficiency.
 
         Args:
             pattern_list: List of pattern dictionaries
@@ -61,19 +61,19 @@ class PatternMatcher:
         return compiled
 
     def match_string_pattern(self, field_name: str) -> dict | None:
-        """Match field name against string patterns"""
+        """Match field name against string patterns."""
         return self._match_against_patterns(field_name, self.string_patterns)
 
     def match_array_pattern(self, field_name: str) -> dict | None:
-        """Match field name against array patterns"""
+        """Match field name against array patterns."""
         return self._match_against_patterns(field_name, self.array_patterns)
 
     def match_number_pattern(self, field_name: str) -> dict | None:
-        """Match field name against number patterns"""
+        """Match field name against number patterns."""
         return self._match_against_patterns(field_name, self.number_patterns)
 
     def _match_against_patterns(self, field_name: str, patterns: list[tuple]) -> dict | None:
-        """Match field name against compiled patterns
+        """Match field name against compiled patterns.
 
         Args:
             field_name: Field name to match
@@ -89,11 +89,11 @@ class PatternMatcher:
 
 
 class StringConstraintExtractor:
-    """Extract string-specific constraints"""
+    """Extract string-specific constraints."""
 
     @staticmethod
     def extract(field_name: str, schema: dict, pattern_match: dict | None) -> dict:
-        """Extract string constraints from schema and pattern
+        """Extract string constraints from schema and pattern.
 
         Args:
             field_name: Name of the field
@@ -122,15 +122,15 @@ class StringConstraintExtractor:
                 if key not in constraints:
                     constraints[key] = value
 
-        return constraints if constraints else None
+        return constraints or None
 
 
 class ArrayConstraintExtractor:
-    """Extract array-specific constraints"""
+    """Extract array-specific constraints."""
 
     @staticmethod
     def extract(field_name: str, schema: dict, pattern_match: dict | None) -> dict:
-        """Extract array constraints from schema and pattern
+        """Extract array constraints from schema and pattern.
 
         Args:
             field_name: Name of the field
@@ -157,15 +157,15 @@ class ArrayConstraintExtractor:
                 if key not in constraints:
                     constraints[key] = value
 
-        return constraints if constraints else None
+        return constraints or None
 
 
 class NumericConstraintExtractor:
-    """Extract numeric-specific constraints"""
+    """Extract numeric-specific constraints."""
 
     @staticmethod
     def extract(field_name: str, schema: dict, pattern_match: dict | None) -> dict:
-        """Extract numeric constraints from schema and pattern
+        """Extract numeric constraints from schema and pattern.
 
         Args:
             field_name: Name of the field
@@ -196,15 +196,15 @@ class NumericConstraintExtractor:
                 if key not in constraints:
                     constraints[key] = value
 
-        return constraints if constraints else None
+        return constraints or None
 
 
 class ObjectConstraintExtractor:
-    """Extract object-specific constraints"""
+    """Extract object-specific constraints."""
 
     @staticmethod
     def extract(field_name: str, schema: dict) -> dict:
-        """Extract object constraints from schema
+        """Extract object constraints from schema.
 
         Args:
             field_name: Name of the field
@@ -223,11 +223,11 @@ class ObjectConstraintExtractor:
         if "required" in schema:
             constraints["required"] = schema["required"]
 
-        return constraints if constraints else None
+        return constraints or None
 
 
 class ConstraintReconciler:
-    """Reconcile constraints from multiple sources with priority"""
+    """Reconcile constraints from multiple sources with priority."""
 
     PRIORITY_ORDER = ["existing", "discovery", "inferred"]
 
@@ -238,7 +238,7 @@ class ConstraintReconciler:
         inferred: dict | None,
         confidence_threshold: float = 0.9,
     ) -> dict | None:
-        """Reconcile constraints from multiple sources
+        """Reconcile constraints from multiple sources.
 
         Priority: EXISTING > DISCOVERY > INFERRED
 
@@ -294,10 +294,10 @@ class ConstraintReconciler:
 
 
 class ConstraintEnricher:
-    """Main constraint enrichment orchestrator"""
+    """Main constraint enrichment orchestrator."""
 
-    def __init__(self, config_path: Path):
-        """Initialize constraint enricher
+    def __init__(self, config_path: Path) -> None:
+        """Initialize constraint enricher.
 
         Args:
             config_path: Path to constraint_patterns.yaml
@@ -321,16 +321,16 @@ class ConstraintEnricher:
         }
 
     def _load_config(self) -> dict:
-        """Load constraint patterns configuration"""
+        """Load constraint patterns configuration."""
         try:
             with open(self.config_path) as f:
                 return yaml.safe_load(f)
         except Exception as e:
-            logger.error(f"Failed to load config from {self.config_path}: {e}")
+            logger.exception(f"Failed to load config from {self.config_path}: {e}")
             raise
 
     def enrich_spec(self, spec: dict) -> dict:
-        """Enrich OpenAPI specification with x-f5xc-constraints
+        """Enrich OpenAPI specification with x-f5xc-constraints.
 
         Args:
             spec: OpenAPI specification dictionary
@@ -350,8 +350,8 @@ class ConstraintEnricher:
         )
         return spec
 
-    def _enrich_schema(self, schema_name: str, schema: dict):
-        """Enrich a single schema definition"""
+    def _enrich_schema(self, schema_name: str, schema: dict) -> None:
+        """Enrich a single schema definition."""
         if "properties" not in schema:
             return
 
@@ -359,7 +359,7 @@ class ConstraintEnricher:
             self._enrich_property(prop_name, prop_schema)
 
     def _extract_discovery_constraints(self, schema: dict) -> dict | None:
-        """Extract constraints from x-ves-validation-rules
+        """Extract constraints from x-ves-validation-rules.
 
         Args:
             schema: Property schema with potential x-ves-validation-rules
@@ -477,8 +477,8 @@ class ConstraintEnricher:
 
         return result
 
-    def _enrich_property(self, field_name: str, schema: dict):
-        """Enrich a single property with constraints
+    def _enrich_property(self, field_name: str, schema: dict) -> None:
+        """Enrich a single property with constraints.
 
         Args:
             field_name: Name of the property
@@ -557,7 +557,7 @@ class ConstraintEnricher:
         schema: dict,
         pattern_match: dict | None,
     ) -> dict | None:
-        """Extract string constraints and build x-f5xc-constraints structure"""
+        """Extract string constraints and build x-f5xc-constraints structure."""
         string_constraints = StringConstraintExtractor.extract(field_name, schema, pattern_match)
         if not string_constraints:
             return None
@@ -591,7 +591,7 @@ class ConstraintEnricher:
         schema: dict,
         pattern_match: dict | None,
     ) -> dict | None:
-        """Extract array constraints and build x-f5xc-constraints structure"""
+        """Extract array constraints and build x-f5xc-constraints structure."""
         array_constraints = ArrayConstraintExtractor.extract(field_name, schema, pattern_match)
         if not array_constraints:
             return None
@@ -625,7 +625,7 @@ class ConstraintEnricher:
         schema: dict,
         pattern_match: dict | None,
     ) -> dict | None:
-        """Extract numeric constraints and build x-f5xc-constraints structure"""
+        """Extract numeric constraints and build x-f5xc-constraints structure."""
         numeric_constraints = NumericConstraintExtractor.extract(field_name, schema, pattern_match)
         if not numeric_constraints:
             return None
@@ -654,12 +654,12 @@ class ConstraintEnricher:
         return result
 
     def _extract_object_constraints(self, field_name: str, schema: dict) -> dict | None:
-        """Extract object constraints and build x-f5xc-constraints structure"""
+        """Extract object constraints and build x-f5xc-constraints structure."""
         object_constraints = ObjectConstraintExtractor.extract(field_name, schema)
         if not object_constraints:
             return None
 
-        result = {
+        return {
             "type": "object",
             "category": "general",
             "object": object_constraints,
@@ -670,14 +670,13 @@ class ConstraintEnricher:
             },
         }
 
-        return result
 
     def _merge_discovery_constraints(
         self,
         schema: dict,
         discovery_data: dict | None,
     ) -> dict | None:
-        """Merge constraints from discovery data
+        """Merge constraints from discovery data.
 
         Args:
             schema: Property schema
@@ -723,7 +722,7 @@ class ConstraintEnricher:
         return None
 
     def _map_string_discovery_rules(self, ves_rules: dict) -> dict:
-        """Map x-ves-validation-rules to string constraints"""
+        """Map x-ves-validation-rules to string constraints."""
         mapping = self.config.get("discovery_mapping", {}).get("string_rules", [])
         constraints = {}
 
@@ -741,7 +740,7 @@ class ConstraintEnricher:
         return constraints
 
     def _map_array_discovery_rules(self, ves_rules: dict) -> dict:
-        """Map x-ves-validation-rules to array constraints"""
+        """Map x-ves-validation-rules to array constraints."""
         mapping = self.config.get("discovery_mapping", {}).get("array_rules", [])
         constraints = {}
 
@@ -759,7 +758,7 @@ class ConstraintEnricher:
         return constraints
 
     def _map_numeric_discovery_rules(self, ves_rules: dict) -> dict:
-        """Map x-ves-validation-rules to numeric constraints"""
+        """Map x-ves-validation-rules to numeric constraints."""
         mapping = self.config.get("discovery_mapping", {}).get("number_rules", [])
         constraints = {}
 
@@ -782,7 +781,7 @@ class ConstraintEnricher:
         return constraints
 
     def get_stats(self) -> dict:
-        """Get enrichment statistics
+        """Get enrichment statistics.
 
         Returns:
             Statistics dictionary

--- a/scripts/utils/description_structure.py
+++ b/scripts/utils/description_structure.py
@@ -281,7 +281,7 @@ class DescriptionStructureTransformer:
         else:
             result = description
 
-        return result.strip(), rules if rules else None
+        return result.strip(), rules or None
 
     def _extract_required_marker(
         self,

--- a/scripts/utils/memory_profiler.py
+++ b/scripts/utils/memory_profiler.py
@@ -139,7 +139,7 @@ class MemoryProfiler:
                 "generation_1": counts[1] if len(counts) > 1 else 0,
                 "generation_2": counts[2] if len(counts) > 2 else 0,
             },
-            "detailed_stats": stats if stats else [],
+            "detailed_stats": stats or [],
         }
 
     def save_report(self, output_path: Path) -> None:

--- a/scripts/utils/minimum_configuration_enricher.py
+++ b/scripts/utils/minimum_configuration_enricher.py
@@ -361,7 +361,10 @@ class MinimumConfigurationEnricher:
         """
         # Infer resource type from schema name
         resource_name = (
-            schema_name.split("Create")[0].split("Update")[0].split("Get")[0].split("Delete")[0]
+            schema_name.split("Create", maxsplit=1)[0]
+            .split("Update", maxsplit=1)[0]
+            .split("Get", maxsplit=1)[0]
+            .split("Delete", maxsplit=1)[0]
         )
         resource_name = _CAMELCASE_TO_SNAKE_PATTERN.sub("_", resource_name).lower()
 

--- a/scripts/utils/operation_metadata_enricher.py
+++ b/scripts/utils/operation_metadata_enricher.py
@@ -261,7 +261,7 @@ class OperationMetadataEnricher:
                 "prerequisites": prerequisites,
                 "postconditions": postconditions,
             },
-            "side_effects": side_effects if side_effects else {},
+            "side_effects": side_effects or {},
             "danger_level": danger_level,
             "confirmation_required": danger_level == "high",
             "common_errors": common_errors,
@@ -503,7 +503,7 @@ class OperationMetadataEnricher:
             impact["resource_usage"] = "high"
 
         # Check for list operations
-        elif method == "GET" and "{" not in path.split("/")[-1]:
+        elif method == "GET" and "{" not in path.rsplit("/", maxsplit=1)[-1]:
             impact["latency"] = "moderate"
             impact["resource_usage"] = "moderate"
 

--- a/scripts/utils/uniqueness_enricher.py
+++ b/scripts/utils/uniqueness_enricher.py
@@ -231,9 +231,8 @@ class UniquenessEnricher:
         resource_type = s2.lower().strip("_")
 
         # Remove duplicate underscores
-        resource_type = re.sub("_+", "_", resource_type)
+        return re.sub("_+", "_", resource_type)
 
-        return resource_type
 
     def _derive_uniqueness_from_namespace_scope(self, namespace_scope: str) -> dict:
         """Map namespace scope to uniqueness constraints.

--- a/tests/test_constraint_enricher.py
+++ b/tests/test_constraint_enricher.py
@@ -518,7 +518,7 @@ class TestConstraintEnricher:
             },
         }
 
-        enriched = enricher.enrich_spec(spec)
+        enricher.enrich_spec(spec)
         stats = enricher.get_stats()
 
         assert stats["properties_analyzed"] == 4
@@ -549,7 +549,7 @@ class TestEdgeCases:
             "openapi": "3.0.0",
             "info": {"title": "Test", "version": "1.0.0"},
         }
-        result = enricher.enrich_spec(spec)
+        enricher.enrich_spec(spec)
         stats = enricher.get_stats()
         assert stats["properties_analyzed"] == 0
 
@@ -564,7 +564,7 @@ class TestEdgeCases:
                 },
             },
         }
-        result = enricher.enrich_spec(spec)
+        enricher.enrich_spec(spec)
         stats = enricher.get_stats()
         assert stats["properties_analyzed"] == 0
 
@@ -598,7 +598,7 @@ class TestPatternCoverage:
     """Test coverage of various patterns"""
 
     @pytest.mark.parametrize(
-        "field_name,expected_category",
+        ("field_name", "expected_category"),
         [
             ("username", "identity"),
             ("email", "communication"),

--- a/tests/test_discovery_enricher_operations.py
+++ b/tests/test_discovery_enricher_operations.py
@@ -12,11 +12,7 @@ Tests the new operation-level enrichment functionality added in Issue #314:
 
 import pytest
 
-from scripts.utils.discovery_enricher import (
-    DiscoveryData,
-    DiscoveryEnricher,
-    EnrichmentStats,
-)
+from scripts.utils.discovery_enricher import DiscoveryData, DiscoveryEnricher, EnrichmentStats
 from scripts.utils.extension_constants import (
     X_F5XC_DISCOVERED_ERROR_CATALOG,
     X_F5XC_DISCOVERED_RATE_LIMITS,

--- a/tests/test_domain_categorizer.py
+++ b/tests/test_domain_categorizer.py
@@ -10,11 +10,7 @@ import re
 
 import pytest
 
-from scripts.utils.domain_categorizer import (
-    DomainCategorizer,
-    categorize_spec,
-    get_domain_patterns,
-)
+from scripts.utils.domain_categorizer import DomainCategorizer, categorize_spec, get_domain_patterns
 
 
 class TestDomainCategorizerSingleton:

--- a/tests/test_external_docs_enricher.py
+++ b/tests/test_external_docs_enricher.py
@@ -9,10 +9,7 @@ providing links to F5's official documentation.
 import pytest
 
 from scripts.utils.extension_constants import X_F5XC_CLI_DOMAIN
-from scripts.utils.external_docs_enricher import (
-    ExternalDocsEnricher,
-    ExternalDocsStats,
-)
+from scripts.utils.external_docs_enricher import ExternalDocsEnricher, ExternalDocsStats
 
 
 class TestExternalDocsStats:

--- a/tests/test_minimum_configuration_enricher.py
+++ b/tests/test_minimum_configuration_enricher.py
@@ -8,10 +8,7 @@ for AI-assisted resource creation.
 
 import pytest
 
-from scripts.utils.extension_constants import (
-    X_F5XC_CLI_DOMAIN,
-    X_F5XC_MINIMUM_CONFIGURATION,
-)
+from scripts.utils.extension_constants import X_F5XC_CLI_DOMAIN, X_F5XC_MINIMUM_CONFIGURATION
 from scripts.utils.minimum_configuration_enricher import (
     MinimumConfigurationEnricher,
     MinimumConfigurationStats,

--- a/tests/test_namespace_scope_enricher.py
+++ b/tests/test_namespace_scope_enricher.py
@@ -9,10 +9,7 @@ indicating which namespaces each resource type can be created in.
 import pytest
 
 from scripts.utils.extension_constants import X_F5XC_CLI_DOMAIN, X_F5XC_NAMESPACE_SCOPE
-from scripts.utils.namespace_scope_enricher import (
-    NamespaceScopeEnricher,
-    NamespaceScopeStats,
-)
+from scripts.utils.namespace_scope_enricher import NamespaceScopeEnricher, NamespaceScopeStats
 
 
 class TestNamespaceScopeStats:

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -7,11 +7,7 @@ import time
 
 import pytest
 
-from scripts.discovery.rate_limiter import (
-    RateLimitConfig,
-    RateLimiter,
-    RateLimiterStats,
-)
+from scripts.discovery.rate_limiter import RateLimitConfig, RateLimiter, RateLimiterStats
 
 
 class TestRateLimitConfig:

--- a/tests/test_uniqueness_enricher.py
+++ b/tests/test_uniqueness_enricher.py
@@ -21,9 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
-from scripts.utils.uniqueness_enricher import (
-    UniquenessEnricher,
-)
+from scripts.utils.uniqueness_enricher import UniquenessEnricher
 
 # =============================================================================
 # Test Fixtures
@@ -301,7 +299,7 @@ class TestEdgeCases:
         spec = {
             "info": {"title": "Test", "x-f5xc-namespace-scope": "any"},
         }
-        result = enricher.enrich_spec(spec)
+        enricher.enrich_spec(spec)
         assert enricher.stats.schemas_enriched == 0
 
     def test_schema_without_components(self, enricher):
@@ -309,7 +307,7 @@ class TestEdgeCases:
         spec = {
             "info": {"title": "Test", "x-f5xc-namespace-scope": "any"},
         }
-        result = enricher.enrich_spec(spec)
+        enricher.enrich_spec(spec)
         assert enricher.stats.schemas_enriched == 0
 
 


### PR DESCRIPTION
## Summary

- Fix markdown lint errors (MD032 blanks-around-lists, MD022 blanks-around-headings) in documentation files
- Fix Python lint errors: ruff formatting, isort import ordering across pipeline scripts and tests
- Fix shell script lint errors: shfmt formatting and shellcheck warnings in constraint validation scripts and pre-commit hook
- Fix natural language lint issues in README files

Closes #27
Closes #28
Closes #32
Closes #33

## Test plan

- [ ] CI `Lint Code Base` check passes
- [ ] CI `Check linked issues` check passes
- [ ] No functional changes — all fixes are formatting and lint compliance only