### PR TITLE
fix: resolve PYTHON_RUFF and EDITORCONFIG lint errors

### DIFF
--- a/scripts/download.py
+++ b/scripts/download.py
@@ -25,7 +25,7 @@ Usage:
 
 Environment:
     GITHUB_TOKEN: Optional authentication token for higher rate limits
-                  (5000/hr vs 60/hr unauthenticated)
+                    (5000/hr vs 60/hr unauthenticated)
 """
 
 import argparse
@@ -406,17 +406,17 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  # Check for updates without downloading
-  python -m scripts.download --check-only
+    # Check for updates without downloading
+    python -m scripts.download --check-only
 
-  # Download latest release (uses cache)
-  python -m scripts.download
+    # Download latest release (uses cache)
+    python -m scripts.download
 
-  # Force download (bypass cache)
-  python -m scripts.download --force
+    # Force download (bypass cache)
+    python -m scripts.download --force
 
 Environment Variables:
-  GITHUB_TOKEN    Optional GitHub token for authentication (5000/hr vs 60/hr)
+    GITHUB_TOKEN    Optional GitHub token for authentication (5000/hr vs 60/hr)
         """,
     )
     parser.add_argument(

--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -4,9 +4,9 @@
 """Generate Scalar API viewer pages and Starlight MDX wrappers.
 
 Reads docs/specifications/api/index.json and generates:
-  - docs/specifications/api/viewer/{domain}.html  (standalone Scalar viewers)
-  - docs/api-reference/{domain}.mdx               (Starlight iframe wrappers)
-  - docs/api-reference/index.mdx                  (catalog landing page)
+    - docs/specifications/api/viewer/{domain}.html  (standalone Scalar viewers)
+    - docs/api-reference/{domain}.mdx               (Starlight iframe wrappers)
+    - docs/api-reference/index.mdx                  (catalog landing page)
 
 Usage:
     python -m scripts.generate_api_viewer
@@ -34,25 +34,25 @@ def generate_viewer_html(domain: str, title: str) -> str:
     return f"""<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>{title} - API Reference</title>
-  <style>
-    body {{ margin: 0; padding: 0; }}
-  </style>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title} - API Reference</title>
+    <style>
+        body {{ margin: 0; padding: 0; }}
+    </style>
 </head>
 <body>
-  <div id="app"></div>
-  <script src="{SCALAR_CDN_URL}"></script>
-  <script>
-    Scalar.createApiReference('#app', {{
-      url: '../{domain}.json',
-      theme: 'kepler',
-      darkMode: true,
-      defaultOpenAllTags: false,
-      hideDownloadButton: false,
-    }});
-  </script>
+    <div id="app"></div>
+    <script src="{SCALAR_CDN_URL}"></script>
+    <script>
+        Scalar.createApiReference('#app', {{
+            url: '../{domain}.json',
+            theme: 'kepler',
+            darkMode: true,
+            defaultOpenAllTags: false,
+            hideDownloadButton: false,
+        }});
+    </script>
 </body>
 </html>
 """
@@ -73,9 +73,9 @@ import {{ LinkCard }} from '@astrojs/starlight/components';
 import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
-  <LinkCard title="Back to API Catalog" href="/api-reference/" />
-  <LinkCard title="Full Screen" href="{viewer_path}" />
-  <LinkCard title="Download Spec" href="{spec_path}" />
+    <LinkCard title="Back to API Catalog" href="/api-reference/" />
+    <LinkCard title="Full Screen" href="{viewer_path}" />
+    <LinkCard title="Download Spec" href="{spec_path}" />
 </div>
 
 <ScalarViewer specUrl="{spec_path}" title="{title}" />
@@ -144,7 +144,7 @@ title: API Reference
 description: Interactive API documentation for F5 Distributed Cloud services
 tableOfContents: false
 sidebar:
-  order: 0
+    order: 0
 ---
 
 import {{ CardGrid, LinkCard }} from '@astrojs/starlight/components';

--- a/scripts/generate_descriptions.py
+++ b/scripts/generate_descriptions.py
@@ -405,62 +405,62 @@ STRICT RULES - Violations cause INSTANT REJECTION:
 
 1. BANNED TERMS BY CATEGORY (all fail implicit context test):
 
-  REDUNDANT (context implies these - zero semantic value):
-  ✗ "API", "REST API", "endpoint", "specifications", "spec"
-  Why: Repository name includes "api" - readers already know this is API documentation
+    REDUNDANT (context implies these - zero semantic value):
+    ✗ "API", "REST API", "endpoint", "specifications", "spec"
+    Why: Repository name includes "api" - readers already know this is API documentation
 
-  BRAND NAMES (context implies these - zero semantic value):
-  ✗ "F5", "F5 XC", "XC", "Distributed Cloud", "Volterra"
-  Why: Repository name includes "f5xc" - readers already know this is F5 XC content
+    BRAND NAMES (context implies these - zero semantic value):
+    ✗ "F5", "F5 XC", "XC", "Distributed Cloud", "Volterra"
+    Why: Repository name includes "f5xc" - readers already know this is F5 XC content
 
-  FILLER WORDS (use simpler alternatives):
-  ✗ "utilize" → use "use"
-  ✗ "leverage" → use "use"
-  ✗ "facilitate" → use "enable"
-  ✗ "in order to" → use "to"
+    FILLER WORDS (use simpler alternatives):
+    ✗ "utilize" → use "use"
+    ✗ "leverage" → use "use"
+    ✗ "facilitate" → use "enable"
+    ✗ "in order to" → use "to"
 
-  VAGUE DESCRIPTORS (be specific or omit):
-  ✗ "various", "multiple", "several", "etc.", "and more", "diverse"
+    VAGUE DESCRIPTORS (be specific or omit):
+    ✗ "various", "multiple", "several", "etc.", "and more", "diverse"
 
-  MARKETING HYPE (state facts, not opinions):
-  ✗ "seamless", "robust", "powerful", "cutting-edge", "innovative"
-  ✗ "enterprise-grade", "world-class", "best-in-class", "superior"
+    MARKETING HYPE (state facts, not opinions):
+    ✗ "seamless", "robust", "powerful", "cutting-edge", "innovative"
+    ✗ "enterprise-grade", "world-class", "best-in-class", "superior"
 
-  SELF-REFERENCE (domain name in description is redundant):
-  ✗ "{domain_variants}" (the domain name itself)
+    SELF-REFERENCE (domain name in description is redundant):
+    ✗ "{domain_variants}" (the domain name itself)
 
 2. ACTIVE VOICE REQUIRED (passive voice = instant rejection):
-  ✗ "Data is returned" → ✓ "Returns data"
-  ✗ "Connections are managed" → ✓ "Manages connections"
-  ✗ "Security is handled" → ✓ "Handles security"
+    ✗ "Data is returned" → ✓ "Returns data"
+    ✗ "Connections are managed" → ✓ "Manages connections"
+    ✗ "Security is handled" → ✓ "Handles security"
 
 3. NOUN-FIRST, VALUE-ADD DESCRIPTIONS (CRITICAL - DRY COMPLIANCE):
-  Since this is a CRUD API, users already know they can configure/manage/deploy.
-  DO NOT waste characters on implied operations. Instead, describe:
-  - WHAT resources/concepts exist in this domain
-  - WHAT technical capabilities are available
-  - WHAT specific features differentiate this domain
+    Since this is a CRUD API, users already know they can configure/manage/deploy.
+    DO NOT waste characters on implied operations. Instead, describe:
+    - WHAT resources/concepts exist in this domain
+    - WHAT technical capabilities are available
+    - WHAT specific features differentiate this domain
 
-  ✗ BANNED STARTERS (redundant in API context):
+    ✗ BANNED STARTERS (redundant in API context):
     "Configure...", "Manage...", "Create...", "Deploy...", "Monitor...",
     "Access...", "Define...", "Set up...", "Enable...", "Control...", "Handle..."
 
-  ✗ ALSO BANNED: "This", "The", "A", "An", "Provides", "Enables", "Offers"
+    ✗ ALSO BANNED: "This", "The", "A", "An", "Provides", "Enables", "Offers"
 
-  ✓ GOOD PATTERNS (noun-first, information-dense):
+    ✓ GOOD PATTERNS (noun-first, information-dense):
     "HTTP, TCP, UDP load balancing with origin pool health checks."
     "Authoritative zones, record types, and DNS-based failover."
     "Request inspection, attack signatures, and bot mitigation."
 
-  The first word should be a NOUN or NOUN-PHRASE describing domain concepts.
+    The first word should be a NOUN or NOUN-PHRASE describing domain concepts.
 
 4. PROGRESSIVE INFORMATION (no repetition across tiers):
-  - SHORT: Primary capability only (the core "what")
-  - MEDIUM: Add secondary features + benefit (the "what else" + "why")
-  - LONG: Add mechanics, options, usage context (the "how" + "when")
+    - SHORT: Primary capability only (the core "what")
+    - MEDIUM: Add secondary features + benefit (the "what else" + "why")
+    - LONG: Add mechanics, options, usage context (the "how" + "when")
 
-  CRITICAL: If a concept appears in SHORT, it MUST NOT appear in MEDIUM or LONG.
-  Each tier reveals NEW information only.
+    CRITICAL: If a concept appears in SHORT, it MUST NOT appear in MEDIUM or LONG.
+    Each tier reveals NEW information only.
 
 ═══════════════════════════════════════════════════════════════════════════════
 COMPRESSION TECHNIQUES - Apply these to stay under limits:
@@ -472,39 +472,39 @@ COMPRESSION TECHNIQUES - Apply these to stay under limits:
 
 NEGATIVE EXAMPLES (from actual failures - DO NOT repeat these patterns):
 ❌ "Configure content delivery and caching policies for global distribution" (71 chars)
-  → Noun-first rewrite: "Content delivery and edge caching." (35 chars) ✓
+    → Noun-first rewrite: "Content delivery and edge caching." (35 chars) ✓
 
 ❌ "Manage zones, records, and load balancing for domain resolution" (63 chars)
-  → Noun-first rewrite: "DNS zones, record types, and load balancing." (45 chars) ✓
+    → Noun-first rewrite: "DNS zones, record types, and load balancing." (45 chars) ✓
 
 ═══════════════════════════════════════════════════════════════════════════════
 CHARACTER LIMITS - WRITE TO FIT, NEVER TRUNCATE:
 
 ⚠️ CRITICAL: Write descriptions that NATURALLY fit within limits.
-  NEVER write long text and truncate it. No "..." endings. No partial sentences.
-  If your draft is too long, REWRITE it shorter - do not cut it off.
+    NEVER write long text and truncate it. No "..." endings. No partial sentences.
+    If your draft is too long, REWRITE it shorter - do not cut it off.
 
 SHORT (TARGET: 35-50 chars, HARD MAX: {MAX_SHORT}):
-  • Format: [Noun/Concept phrase ending with period]
-  • Start with WHAT exists, not what users DO
-  • Remove ALL unnecessary words
-  • If over 50 chars, REMOVE WORDS (don't truncate!)
-  • Examples:
+    • Format: [Noun/Concept phrase ending with period]
+    • Start with WHAT exists, not what users DO
+    • Remove ALL unnecessary words
+    • If over 50 chars, REMOVE WORDS (don't truncate!)
+    • Examples:
     ✓ "HTTP load balancers and traffic distribution." (46 chars)
     ✓ "WAF rules, rate limits, and bot protection." (44 chars)
     ✓ "Edge nodes, clusters, and cloud sites." (39 chars)
     ✗ TOO LONG (71 chars): "Configure content delivery and caching..."
 
 MEDIUM (TARGET: 100-130 chars, HARD MAX: {MAX_MEDIUM}):
-  • Two short noun-first sentences
-  • If over 130 chars, REWRITE with fewer words (don't truncate!)
-  • Example (82 chars): "Routing rules, health checks, and failover. Traffic distribution controls."
-  • AVOID long phrases like "with support for BIND and AXFR transfer protocols"
+    • Two short noun-first sentences
+    • If over 130 chars, REWRITE with fewer words (don't truncate!)
+    • Example (82 chars): "Routing rules, health checks, and failover. Traffic distribution controls."
+    • AVOID long phrases like "with support for BIND and AXFR transfer protocols"
 
 LONG (TARGET: 350-450 chars, HARD MAX: {MAX_LONG}):
-  • 3-4 sentences, stay under 450 to be safe
-  • If over 450 chars, SIMPLIFY sentences (don't truncate!)
-  • Remove verbose qualifiers ("authoritative", "global", "comprehensive")
+    • 3-4 sentences, stay under 450 to be safe
+    • If over 450 chars, SIMPLIFY sentences (don't truncate!)
+    • Remove verbose qualifiers ("authoritative", "global", "comprehensive")
 
 ═══════════════════════════════════════════════════════════════════════════════
 SUCCESSFUL EXAMPLE - Follow this structure and style:
@@ -517,7 +517,7 @@ Respond with JSON only: {{"short": "...", "medium": "...", "long": "..."}}
 BEFORE RESPONDING - MANDATORY VERIFICATION CHECKLIST:
 
 ⚠️ NEVER TRUNCATE - If any tier exceeds its target, REWRITE IT SHORTER.
-  Truncated text with "..." is REJECTED. Incomplete sentences are REJECTED.
+    Truncated text with "..." is REJECTED. Incomplete sentences are REJECTED.
 
 CHARACTER LIMITS:
 □ SHORT ≤50 chars (if over, REWRITE - never cut off!)
@@ -544,10 +544,10 @@ COMPLETE THOUGHT REQUIREMENT (CRITICAL - instant rejection for violations):
 □ NEVER end a sentence with: and, or, with, for, to, the, a, an
 □ If your draft exceeds the limit, REWRITE it shorter as a complete thought
 □ Examples:
-  ✓ "Load balancers and health checks." (complete thought)
-  ✗ "Load balancers and" (cut-off mid-phrase)
-  ✗ "Load balancers with" (incomplete thought)
-  ✗ "Load balancers" (missing period)
+    ✓ "Load balancers and health checks." (complete thought)
+    ✗ "Load balancers and" (cut-off mid-phrase)
+    ✗ "Load balancers with" (incomplete thought)
+    ✗ "Load balancers" (missing period)
 
 Do not use any tools. Generate based on context provided."""
 
@@ -1896,25 +1896,25 @@ Mental test: "Does this word add semantic value beyond what context implies?"
 FIX INSTRUCTIONS:
 
 1. For DOMAIN NAME violations:
-  - Replace "{domain.replace("_", " ")}" with one of: {synonyms_str}
-  - The description DESCRIBES the domain, it should NOT MENTION it
+    - Replace "{domain.replace("_", " ")}" with one of: {synonyms_str}
+    - The description DESCRIBES the domain, it should NOT MENTION it
 
 2. For CHARACTER LIMIT violations:
-  - SHORT must be ≤{MAX_SHORT} chars (aim for 35-50)
-  - MEDIUM must be ≤{MAX_MEDIUM} chars (aim for 100-130)
-  - LONG must be ≤{MAX_LONG} chars (aim for 350-450)
-  - Remove words/phrases, don't truncate with "..."
+    - SHORT must be ≤{MAX_SHORT} chars (aim for 35-50)
+    - MEDIUM must be ≤{MAX_MEDIUM} chars (aim for 100-130)
+    - LONG must be ≤{MAX_LONG} chars (aim for 350-450)
+    - Remove words/phrases, don't truncate with "..."
 
 3. For REPETITION/OVERLAP violations:
-  - Each tier must use DIFFERENT vocabulary
-  - Replace overlapping words with synonyms
-  - Progress: WHAT (short) → HOW+SCOPE (medium) → WHERE+WHEN+METRICS (long)
+    - Each tier must use DIFFERENT vocabulary
+    - Replace overlapping words with synonyms
+    - Progress: WHAT (short) → HOW+SCOPE (medium) → WHERE+WHEN+METRICS (long)
 
 4. For STYLE violations (DRY-COMPLIANT):
-  - Start EVERY tier with NOUN/CONCEPT (not action verbs)
-  - BANNED: Configure, Create, Manage, Define, Deploy, Monitor, Access
-  - Also banned: This, The, A, An, Provides, Enables
-  - Example: "HTTP load balancing..." NOT "Configure load balancing..."
+    - Start EVERY tier with NOUN/CONCEPT (not action verbs)
+    - BANNED: Configure, Create, Manage, Define, Deploy, Monitor, Access
+    - Also banned: This, The, A, An, Provides, Enables
+    - Example: "HTTP load balancing..." NOT "Configure load balancing..."
 
 ═══════════════════════════════════════════════════════════════════════════════
 OUTPUT:

--- a/scripts/utils/__init__.py
+++ b/scripts/utils/__init__.py
@@ -38,10 +38,10 @@ from .uniqueness_enricher import UniquenessEnricher
 from .validation_enricher import ValidationEnricher
 from .validation_exporter import ValidationExporter
 from .version_calculator import (
-                       calculate_next_version,
-                       get_version,
-                       get_version_from_tags,
-                       is_valid_semver,
+    calculate_next_version,
+    get_version,
+    get_version_from_tags,
+    is_valid_semver,
 )
 
 __all__ = [

--- a/scripts/utils/branding.py
+++ b/scripts/utils/branding.py
@@ -8,8 +8,8 @@ and industry-standard terminology (XCKS/XCCS) for Kubernetes offerings.
 Fully automated - no manual intervention required.
 
 Branding Strategy:
-  - XCKS (XC Kubernetes Service) = AppStack/VoltStack (comparable to AWS EKS, Azure AKS, GCP GKE)
-  - XCCS (XC Container Services) = Virtual Kubernetes (comparable to AWS ECS, Azure Container Services)
+    - XCKS (XC Kubernetes Service) = AppStack/VoltStack (comparable to AWS EKS, Azure AKS, GCP GKE)
+    - XCCS (XC Container Services) = Virtual Kubernetes (comparable to AWS ECS, Azure Container Services)
 
 Version: v3.0.0 - Uses x-f5xc-* namespace constants
 """

--- a/scripts/utils/constraint_enricher.py
+++ b/scripts/utils/constraint_enricher.py
@@ -20,6 +20,7 @@ import logging
 import re
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import ClassVar
 
 import yaml
 
@@ -57,7 +58,7 @@ class PatternMatcher:
                 compiled_regex = re.compile(pattern, re.IGNORECASE)
                 compiled.append((compiled_regex, pattern_dict))
             except re.error as e:
-                logger.warning(f"Invalid regex pattern '{pattern}': {e}")
+                logger.warning("Invalid regex pattern '%s': %s", pattern, e)
         return compiled
 
     def match_string_pattern(self, field_name: str) -> dict | None:
@@ -92,7 +93,7 @@ class StringConstraintExtractor:
     """Extract string-specific constraints."""
 
     @staticmethod
-    def extract(field_name: str, schema: dict, pattern_match: dict | None) -> dict:
+    def extract(_field_name: str, schema: dict, pattern_match: dict | None) -> dict:
         """Extract string constraints from schema and pattern.
 
         Args:
@@ -129,7 +130,7 @@ class ArrayConstraintExtractor:
     """Extract array-specific constraints."""
 
     @staticmethod
-    def extract(field_name: str, schema: dict, pattern_match: dict | None) -> dict:
+    def extract(_field_name: str, schema: dict, pattern_match: dict | None) -> dict:
         """Extract array constraints from schema and pattern.
 
         Args:
@@ -164,7 +165,7 @@ class NumericConstraintExtractor:
     """Extract numeric-specific constraints."""
 
     @staticmethod
-    def extract(field_name: str, schema: dict, pattern_match: dict | None) -> dict:
+    def extract(_field_name: str, schema: dict, pattern_match: dict | None) -> dict:
         """Extract numeric constraints from schema and pattern.
 
         Args:
@@ -203,11 +204,11 @@ class ObjectConstraintExtractor:
     """Extract object-specific constraints."""
 
     @staticmethod
-    def extract(field_name: str, schema: dict) -> dict:
+    def extract(_field_name: str, schema: dict) -> dict:
         """Extract object constraints from schema.
 
         Args:
-            field_name: Name of the field
+            _field_name: Name of the field
             schema: OpenAPI schema for the field
 
         Returns:
@@ -229,7 +230,7 @@ class ObjectConstraintExtractor:
 class ConstraintReconciler:
     """Reconcile constraints from multiple sources with priority."""
 
-    PRIORITY_ORDER = ["existing", "discovery", "inferred"]
+    PRIORITY_ORDER: ClassVar[list[str]] = ["existing", "discovery", "inferred"]
 
     @staticmethod
     def reconcile(
@@ -323,10 +324,10 @@ class ConstraintEnricher:
     def _load_config(self) -> dict:
         """Load constraint patterns configuration."""
         try:
-            with open(self.config_path) as f:
+            with Path(self.config_path).open() as f:
                 return yaml.safe_load(f)
-        except Exception as e:
-            logger.exception(f"Failed to load config from {self.config_path}: {e}")
+        except Exception:
+            logger.exception("Failed to load config from %s", self.config_path)
             raise
 
     def enrich_spec(self, spec: dict) -> dict:
@@ -346,11 +347,12 @@ class ConstraintEnricher:
                 self._enrich_schema(schema_name, schema)
 
         logger.info(
-            f"Constraint enrichment complete. Added {self.stats['constraints_added']} constraints",
+            "Constraint enrichment complete. Added %d constraints",
+            self.stats["constraints_added"],
         )
         return spec
 
-    def _enrich_schema(self, schema_name: str, schema: dict) -> None:
+    def _enrich_schema(self, _schema_name: str, schema: dict) -> None:
         """Enrich a single schema definition."""
         if "properties" not in schema:
             return
@@ -815,7 +817,7 @@ if __name__ == "__main__":
     # Load a test spec
     test_spec_path = Path("specs/enriched/dns.json")
     if test_spec_path.exists():
-        with open(test_spec_path) as f:
+        with test_spec_path.open() as f:
             spec = json.load(f)
 
         # Run enricher
@@ -828,7 +830,7 @@ if __name__ == "__main__":
 
         # Save enriched spec
         output_path = Path("specs/enriched/dns_with_constraints.json")
-        with open(output_path, "w") as f:
+        with output_path.open("w") as f:
             json.dump(enriched_spec, f, indent=2)
         print(f"Enriched spec saved to {output_path}")
     else:

--- a/scripts/utils/uniqueness_enricher.py
+++ b/scripts/utils/uniqueness_enricher.py
@@ -115,11 +115,11 @@ class UniquenessEnricher:
 
         1. Read namespace scope from spec.info["x-f5xc-namespace-scope"]
         2. For each schema in components.schemas:
-          - Skip if already has x-f5xc-uniqueness (idempotent)
-          - Convert schema name to resource type (HTTPLoadBalancer → http_loadbalancer)
-          - Check resource_overrides, else use namespace_scope_mapping
-          - Build uniqueness extension with scope, within, fields, metadata
-          - Add to schema
+            - Skip if already has x-f5xc-uniqueness (idempotent)
+            - Convert schema name to resource type (HTTPLoadBalancer → http_loadbalancer)
+            - Check resource_overrides, else use namespace_scope_mapping
+            - Build uniqueness extension with scope, within, fields, metadata
+            - Add to schema
 
         Args:
             spec: OpenAPI specification dictionary

--- a/scripts/validate_curl_examples.py
+++ b/scripts/validate_curl_examples.py
@@ -107,22 +107,22 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Environment Variables:
-  F5XC_API_URL         API base URL (required for non-dry-run)
-  F5XC_API_TOKEN       API authentication token (required for non-dry-run)
-  F5XC_TEST_NAMESPACE  Override test namespace (default: "default")
+    F5XC_API_URL         API base URL (required for non-dry-run)
+    F5XC_API_TOKEN       API authentication token (required for non-dry-run)
+    F5XC_TEST_NAMESPACE  Override test namespace (default: "default")
 
 Examples:
-  # Full CRUD validation
-  %(prog)s
+    # Full CRUD validation
+    %(prog)s
 
-  # Dry-run mode
-  %(prog)s --dry-run
+    # Dry-run mode
+    %(prog)s --dry-run
 
-  # Test specific resource
-  %(prog)s --resource http_loadbalancer
+    # Test specific resource
+    %(prog)s --resource http_loadbalancer
 
-  # Cleanup orphaned test resources
-  %(prog)s --cleanup-only
+    # Cleanup orphaned test resources
+    %(prog)s --cleanup-only
         """,
     )
     parser.add_argument(

--- a/tests/test_constraint_enricher.py
+++ b/tests/test_constraint_enricher.py
@@ -40,7 +40,7 @@ from scripts.utils.constraint_enricher import (
 def test_config():
     """Load test constraint patterns configuration"""
     config_path = Path(__file__).parent.parent / "config" / "constraint_patterns.yaml"
-    with open(config_path) as f:
+    with config_path.open() as f:
         return yaml.safe_load(f)
 
 

--- a/tests/test_curl_validator.py
+++ b/tests/test_curl_validator.py
@@ -364,7 +364,7 @@ class TestCurlExampleValidatorInit:
         config_path.write_text(
             """
 validation:
-  test_prefix: "my-custom-prefix"
+    test_prefix: "my-custom-prefix"
 """,
         )
         validator = CurlExampleValidator(
@@ -425,7 +425,7 @@ class TestTestNameGeneration:
         config_path.write_text(
             """
 validation:
-  test_prefix: "my-prefix"
+    test_prefix: "my-prefix"
 """,
         )
         validator = CurlExampleValidator(
@@ -473,9 +473,9 @@ class TestApiPathConstruction:
         config_path.write_text(
             """
 api_paths:
-  custom_resource:
-    collection: "/api/custom/namespaces/{namespace}/resources"
-    resource: "/api/custom/namespaces/{namespace}/resources/{name}"
+    custom_resource:
+        collection: "/api/custom/namespaces/{namespace}/resources"
+        resource: "/api/custom/namespaces/{namespace}/resources/{name}"
 """,
         )
         validator = CurlExampleValidator(
@@ -556,14 +556,14 @@ class TestLoadMinimumConfigs:
         (config_dir / "minimum_configs.yaml").write_text(
             """
 resources:
-  http_loadbalancer:
-    description: "HTTP Load Balancer"
-    example_json: |
-      {"metadata": {"name": "example"}, "spec": {}}
-  origin_pool:
-    description: "Origin Pool"
-    example_json: |
-      {"metadata": {"name": "example"}, "spec": {"port": 443}}
+    http_loadbalancer:
+        description: "HTTP Load Balancer"
+        example_json: |
+            {"metadata": {"name": "example"}, "spec": {}}
+    origin_pool:
+        description: "Origin Pool"
+        example_json: |
+            {"metadata": {"name": "example"}, "spec": {"port": 443}}
 """,
         )
 
@@ -827,7 +827,7 @@ class TestResourceFiltering:
         config_path.write_text(
             """
 validation:
-  resources: ["http_loadbalancer"]
+    resources: ["http_loadbalancer"]
 """,
         )
         validator = CurlExampleValidator(
@@ -879,11 +879,11 @@ class TestExpectedStatusCodes:
         config_path.write_text(
             """
 expected_status:
-  create: [201]
-  read: [200, 304]
-  update: [200, 204]
-  delete: [200, 202]
-  verify_delete: [404, 410]
+    create: [201]
+    read: [200, 304]
+    update: [200, 204]
+    delete: [200, 202]
+    verify_delete: [404, 410]
 """,
         )
         validator = CurlExampleValidator(
@@ -1530,7 +1530,7 @@ class TestSkipOperations:
         config_path.write_text(
             """
 validation:
-  skip_operations: ["create"]
+    skip_operations: ["create"]
 """,
         )
         validator = CurlExampleValidator(
@@ -1561,7 +1561,7 @@ validation:
         config_path.write_text(
             """
 validation:
-  skip_operations: ["update"]
+    skip_operations: ["update"]
 """,
         )
         validator = CurlExampleValidator(
@@ -1773,7 +1773,7 @@ class TestEdgeCases:
         config_path.write_text(
             """
 validation:
-  timeout: 60
+    timeout: 60
 """,
         )
         validator = CurlExampleValidator(
@@ -1849,9 +1849,9 @@ class TestConfigMerge:
 custom_setting: "my-custom-value"
 # Nested validation config with test_prefix
 validation:
-  test_prefix: "custom-prefix"
-  skip_operations:
-    - verify_delete
+    test_prefix: "custom-prefix"
+    skip_operations:
+        - verify_delete
 """,
         )
         validator = CurlExampleValidator(
@@ -1892,9 +1892,9 @@ class TestLoadMinimumConfigsFile:
         config_file.write_text(
             """
 resources:
-  http_loadbalancer:
-    example_json: '{"metadata": {"name": "test"}}'
-    description: "Test LB"
+    http_loadbalancer:
+        example_json: '{"metadata": {"name": "test"}}'
+        description: "Test LB"
 """,
         )
 

--- a/tests/test_discover.py
+++ b/tests/test_discover.py
@@ -37,9 +37,9 @@ class TestConfigurationLoading:
         config_file = tmp_path / "discovery.yaml"
         config_file.write_text("""
 discovery:
-  api_url: "https://test.example.com"
-  rate_limit:
-    requests_per_second: 10
+    api_url: "https://test.example.com"
+    rate_limit:
+        requests_per_second: 10
 """)
 
         result = load_config(config_file)
@@ -944,19 +944,19 @@ class TestConfigurationLoadingFromYaml:
         config_file = tmp_path / "config.yaml"
         config_file.write_text("""
 discovery:
-  api_url: "https://test.example.com"
-  rate_limit:
-    requests_per_second: 20
-  exploration:
-    namespaces:
-      - custom
-      - testing
-    methods:
-      - GET
-      - POST
-  output:
-    base_dir: "custom/path"
-    format: "yaml"
+    api_url: "https://test.example.com"
+    rate_limit:
+        requests_per_second: 20
+    exploration:
+        namespaces:
+            - custom
+            - testing
+        methods:
+            - GET
+            - POST
+    output:
+        base_dir: "custom/path"
+        format: "yaml"
 """)
 
         config = load_config(config_file)
@@ -974,9 +974,9 @@ discovery:
         config_file = tmp_path / "config.yaml"
         config_file.write_text("""
 discovery:
-  api_url: "https://nested.example.com"
-  rate_limit:
-    requests_per_second: 15
+    api_url: "https://nested.example.com"
+    rate_limit:
+        requests_per_second: 15
 """)
 
         config = load_config(config_file)

--- a/tests/test_resource_examples_enricher.py
+++ b/tests/test_resource_examples_enricher.py
@@ -217,11 +217,11 @@ class TestExampleValidator:
         validator = ExampleValidator(sample_schemas)
         yaml_content = """
 metadata:
-  name: my-lb
-  namespace: default
+    name: my-lb
+    namespace: default
 spec:
-  domains:
-    - example.com
+    domains:
+        - example.com
 """
         is_valid, errors = validator.validate_example(yaml_content, "http_loadbalancer")
         # Should be valid (or skip validation if jsonschema not available)
@@ -232,8 +232,8 @@ spec:
         validator = ExampleValidator(sample_schemas)
         yaml_content = """
 invalid: yaml:
-  - missing proper structure
-  this is not valid: [
+    - missing proper structure
+    this is not valid: [
 """
         is_valid, errors = validator.validate_example(yaml_content, "http_loadbalancer")
         assert is_valid is False

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -47,9 +47,9 @@ class TestConfigurationLoading:
         config_file = tmp_path / "config.yaml"
         config_file.write_text("""
 api:
-  timeout: 60
+    timeout: 60
 scope:
-  sample_size: 10
+    sample_size: 10
 new_key: new_value
 """)
 


### PR DESCRIPTION
## Summary

- Fix 14 PYTHON_RUFF errors across `scripts/utils/constraint_enricher.py` and `tests/test_constraint_enricher.py` (G004 logging f-strings, ARG unused args, PTH123 Path.open, RUF012 ClassVar, TRY401 verbose log)
- Fix 71 EDITORCONFIG errors (4-space indent in multiline strings) across 11 Python files in `scripts/` and `tests/`
- All ruff and editorconfig checks now pass locally

Closes #30, Closes #35

## Test plan

- [ ] CI `Lint Code Base` check passes (PYTHON_RUFF and EDITORCONFIG linters)
- [ ] CI `Check linked issues` check passes
- [ ] No regressions in other linters