### PR TITLE
fix: add Spectral config symlink and biome format post-processing

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -179,8 +179,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install Spectral CLI
-        run: npm install -g @stoplight/spectral-cli
+      - name: Install Spectral CLI and Biome
+        run: npm install -g @stoplight/spectral-cli @biomejs/biome
 
       - name: Check for Discovery Data
         id: check-discovery

--- a/.spectral.yaml
+++ b/.spectral.yaml
@@ -1,0 +1,1 @@
+config/spectral.yaml

--- a/scripts/merge_specs.py
+++ b/scripts/merge_specs.py
@@ -99,11 +99,27 @@ def load_spec(spec_path: Path) -> dict[str, Any]:
 
 
 def save_spec(spec: dict[str, Any], output_path: Path, indent: int = 2) -> None:
-    """Save an OpenAPI specification to JSON file."""
+    """Save an OpenAPI specification to JSON file.
+
+    Writes JSON with the specified indent, then runs biome format
+    if available to ensure consistent formatting.
+    """
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w") as f:
         json.dump(spec, f, indent=indent, ensure_ascii=False)
         f.write("\n")
+
+    # Apply biome formatting if available (ensures consistent JSON style)
+    import subprocess  # noqa: PLC0415
+
+    try:
+        subprocess.run(
+            ["biome", "format", "--write", str(output_path)],
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pass  # biome not installed, skip formatting
 
 
 def categorize_spec(filename: str) -> str:

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -215,11 +215,27 @@ def load_spec(spec_path: Path) -> dict[str, Any]:
 
 
 def save_spec(spec: dict[str, Any], output_path: Path, indent: int = 2) -> None:
-    """Save an OpenAPI specification to JSON file."""
+    """Save an OpenAPI specification to JSON file.
+
+    Writes JSON with the specified indent, then runs biome format
+    if available to ensure consistent formatting.
+    """
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w") as f:
         json.dump(spec, f, indent=indent, ensure_ascii=False)
         f.write("\n")
+
+    # Apply biome formatting if available (ensures consistent JSON style)
+    import subprocess  # noqa: PLC0415
+
+    try:
+        subprocess.run(
+            ["biome", "format", "--write", str(output_path)],
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError:
+        pass  # biome not installed, skip formatting
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add `.spectral.yaml` symlink at repo root so super-linter discovers our custom Spectral ruleset (disables `oas3-schema` and `path-params` false positives for F5 XC non-standard patterns)
- Add biome format post-processing in `save_spec()` for `pipeline.py` and `merge_specs.py` to ensure generated JSON matches biome formatting standards
- Install biome alongside Spectral in the `sync-and-enrich` CI workflow

Closes #29, Closes #34

## Test plan

- [ ] CI `Lint Code Base` check passes (super-linter finds `.spectral.yaml` and uses custom rules)
- [ ] CI `Check linked issues` check passes
- [ ] Generated JSON specs are formatted consistently by biome post-processing