### PR TITLE
test: unit coverage for json_writer + schema_fixer

### DIFF
--- a/tests/test_enricher_integration.py
+++ b/tests/test_enricher_integration.py
@@ -1137,8 +1137,11 @@ class TestConstraintEnricherSchemaFixerIsolation:
         spec = constraint_enricher.enrich_spec(spec)
         spec = SchemaFixer().inject_max_items(spec)
 
-        tags = spec["components"]["schemas"]["Resource"]["properties"]["tags"]
-        unknown = spec["components"]["schemas"]["Resource"]["properties"]["unknown_list"]
+        # mypy: ConstraintEnricher.enrich_spec returns bare `dict`, which
+        # poisons the deep-key chain below under Super-Linter's default
+        # (no-config) mypy run. Narrow the two leaves we need.
+        tags = spec["components"]["schemas"]["Resource"]["properties"]["tags"]  # type: ignore[index]
+        unknown = spec["components"]["schemas"]["Resource"]["properties"]["unknown_list"]  # type: ignore[index]
 
         # tags received a pattern-inferred constraint (100) and the
         # Checkov-compliance schema bound (65535). They must be
@@ -1179,7 +1182,7 @@ class TestConstraintEnricherSchemaFixerIsolation:
         spec = SchemaFixer().inject_max_items(spec)
         spec = constraint_enricher.enrich_spec(spec)
 
-        tags = spec["components"]["schemas"]["Resource"]["properties"]["tags"]
+        tags = spec["components"]["schemas"]["Resource"]["properties"]["tags"]  # type: ignore[index]
         # EXISTING priority wins over INFERRED in ConstraintReconciler, so
         # the 65535 now shadows the pattern-inferred 100. Assert the
         # poisoned state to document the failure mode.

--- a/tests/test_enricher_integration.py
+++ b/tests/test_enricher_integration.py
@@ -9,12 +9,15 @@ descriptions flow through the pipeline correctly.
 Issue: #408 - OperationMetadataEnricher overwrites DRY-compliant purpose descriptions
 """
 
+from pathlib import Path
 from typing import ClassVar
 
 import pytest
 
+from scripts.utils.constraint_enricher import ConstraintEnricher
 from scripts.utils.operation_description_enricher import OperationDescriptionEnricher
 from scripts.utils.operation_metadata_enricher import OperationMetadataEnricher
+from scripts.utils.schema_fixer import SchemaFixer
 
 
 def _get_resource_id(item):
@@ -1083,6 +1086,105 @@ class TestEdgeCases:
         # Comprehensive metadata should be added (overwrites entire object but preserves purpose)
         assert "danger_level" in metadata
         assert "required_fields" in metadata
+
+
+class TestConstraintEnricherSchemaFixerIsolation:
+    """End-to-end regression: inject_max_items must run AFTER ConstraintEnricher.
+
+    Codex P1 (HANDOFF.md §1.1) was the symmetric failure: running
+    ``SchemaFixer.inject_max_items`` BEFORE ``ConstraintEnricher``
+    caused the synthetic 65535 schema-level ``maxItems`` to leak into
+    ``x-f5xc-constraints.maxItems``, shadowing the pattern-inferred
+    bounds (100 for ``tags``, 50 for ``origins``, etc.). The
+    production ordering is locked in ``scripts/enrich.py::save_spec``
+    and ``scripts/pipeline.py::save_spec`` — this test exercises the
+    full sequence against real ``config/constraint_patterns.yaml``
+    and asserts the isolation invariant.
+    """
+
+    @pytest.fixture
+    def constraint_enricher(self) -> ConstraintEnricher:
+        config_path = Path(__file__).parent.parent / "config" / "constraint_patterns.yaml"
+        return ConstraintEnricher(config_path=config_path)
+
+    def test_tags_preserves_pattern_inferred_max_items(
+        self,
+        constraint_enricher: ConstraintEnricher,
+    ) -> None:
+        """A ``tags`` array gets x-f5xc-constraints.maxItems=100 (pattern-inferred)
+        and schema.maxItems=65535 (Checkov compliance), with no crossover.
+        """
+        spec = {
+            "components": {
+                "schemas": {
+                    "Resource": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                            "unknown_list": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                            },
+                        },
+                    },
+                },
+            },
+        }
+
+        spec = constraint_enricher.enrich_spec(spec)
+        spec = SchemaFixer().inject_max_items(spec)
+
+        tags = spec["components"]["schemas"]["Resource"]["properties"]["tags"]
+        unknown = spec["components"]["schemas"]["Resource"]["properties"]["unknown_list"]
+
+        # tags received a pattern-inferred constraint (100) and the
+        # Checkov-compliance schema bound (65535). They must be
+        # independent values — no leakage in either direction.
+        assert tags["maxItems"] == 65535
+        assert tags["x-f5xc-constraints"]["maxItems"] == 100
+
+        # unknown_list matches no constraint pattern, so no
+        # x-f5xc-constraints is added, but the schema bound is still
+        # stamped so Checkov CKV_OPENAPI_21 passes.
+        assert unknown["maxItems"] == 65535
+        assert "x-f5xc-constraints" not in unknown or (
+            "maxItems" not in unknown.get("x-f5xc-constraints", {})
+        )
+
+    def test_ordering_is_not_commutative(
+        self,
+        constraint_enricher: ConstraintEnricher,
+    ) -> None:
+        """Reverse ordering is the bug: running inject_max_items first
+        poisons x-f5xc-constraints with 65535. This documents the
+        failure mode so future refactors cannot regress silently.
+        """
+        spec = {
+            "components": {
+                "schemas": {
+                    "Resource": {
+                        "type": "object",
+                        "properties": {
+                            "tags": {"type": "array", "items": {"type": "string"}},
+                        },
+                    },
+                },
+            },
+        }
+
+        # WRONG order
+        spec = SchemaFixer().inject_max_items(spec)
+        spec = constraint_enricher.enrich_spec(spec)
+
+        tags = spec["components"]["schemas"]["Resource"]["properties"]["tags"]
+        # EXISTING priority wins over INFERRED in ConstraintReconciler, so
+        # the 65535 now shadows the pattern-inferred 100. Assert the
+        # poisoned state to document the failure mode.
+        assert tags["maxItems"] == 65535
+        assert tags["x-f5xc-constraints"]["maxItems"] == 65535
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_json_writer.py
+++ b/tests/utils/test_json_writer.py
@@ -1,0 +1,294 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for scripts/utils/json_writer.py.
+
+Covers the Biome-gated JSON writer that landed via PR #138. The writer
+is load-bearing in release CI: it is the single sanctioned producer of
+generator output under ``docs/specifications/api/`` and
+``docs/api-reference/``, and must match what Super-Linter's
+BIOME_FORMAT check would produce. Writes to other destinations must
+succeed even when Biome is absent — this suite locks down both halves.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+from scripts.utils import json_writer
+from scripts.utils.json_writer import (
+    BiomeFormatError,
+    BiomeNotFoundError,
+    _format_with_biome,
+    _is_maxsize_only,
+    _is_publishing_path,
+    write_json_file,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestIsPublishingPath:
+    """_is_publishing_path gates Biome formatting on resolved path."""
+
+    def test_matches_docs_specifications_api(self, tmp_path: Path) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "foo.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        assert _is_publishing_path(target) is True
+
+    def test_matches_docs_api_reference(self, tmp_path: Path) -> None:
+        target = tmp_path / "docs" / "api-reference" / "foo.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        assert _is_publishing_path(target) is True
+
+    def test_rejects_tmp_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "foo.json"
+        target.write_text("{}")
+        assert _is_publishing_path(target) is False
+
+    def test_rejects_reports_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "reports" / "foo.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        assert _is_publishing_path(target) is False
+
+    def test_rejects_docs_toplevel(self, tmp_path: Path) -> None:
+        target = tmp_path / "docs" / "index.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        assert _is_publishing_path(target) is False
+
+    def test_accepts_nested_subdirs_of_publishing_root(self, tmp_path: Path) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "viewer" / "x.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        assert _is_publishing_path(target) is True
+
+
+def _fake_completed(stdout: str, stderr: str, returncode: int) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(
+        args=["biome", "format", "--write", "path"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+class TestIsMaxsizeOnly:
+    """Truth table over (size_warning, no_files_processed, no_other_diff)."""
+
+    @pytest.mark.parametrize(
+        ("stdout", "stderr", "expected"),
+        [
+            # All three conditions met → True
+            (
+                "",
+                "file exceeds the configured maximum size\nNo files were processed",
+                True,
+            ),
+            # size_warning missing → False
+            ("", "No files were processed", False),
+            # no_files_processed missing → False
+            ("", "exceeds the configured maximum size", False),
+            # "Formatter would have printed" means real diff → False
+            (
+                "Formatter would have printed the following content:\n{}",
+                "exceeds the configured maximum size\nNo files were processed",
+                False,
+            ),
+            # No relevant stderr → False
+            ("", "something else", False),
+        ],
+    )
+    def test_matrix(self, stdout: str, stderr: str, expected: bool) -> None:
+        result = _fake_completed(stdout, stderr, returncode=1)
+        assert _is_maxsize_only(result) is expected
+
+
+class TestFormatWithBiome:
+    """_format_with_biome gates on path, env var, PATH availability, and exit."""
+
+    def test_skips_non_publishing_path(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.json"
+        target.write_text("{}")
+        with patch.object(subprocess, "run") as mock_run:
+            _format_with_biome(target)
+        mock_run.assert_not_called()
+
+    def test_skips_when_env_opt_out_set(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "x.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        monkeypatch.setenv("API_SPECS_SKIP_BIOME", "1")
+        with patch.object(subprocess, "run") as mock_run:
+            _format_with_biome(target)
+        mock_run.assert_not_called()
+
+    def test_raises_biome_not_found_when_missing_on_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "x.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        monkeypatch.delenv("API_SPECS_SKIP_BIOME", raising=False)
+        with (
+            patch.object(json_writer.shutil, "which", return_value=None),
+            pytest.raises(BiomeNotFoundError, match="biome not found on PATH"),
+        ):
+            _format_with_biome(target)
+
+    def test_passes_through_on_biome_success(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "x.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        monkeypatch.delenv("API_SPECS_SKIP_BIOME", raising=False)
+        with (
+            patch.object(json_writer.shutil, "which", return_value="/usr/bin/biome"),
+            patch.object(
+                subprocess,
+                "run",
+                return_value=_fake_completed(stdout="", stderr="", returncode=0),
+            ) as mock_run,
+        ):
+            _format_with_biome(target)
+        mock_run.assert_called_once()
+        assert mock_run.call_args.args[0] == ["biome", "format", "--write", str(target)]
+
+    def test_raises_biome_format_error_on_real_diff(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "x.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        monkeypatch.delenv("API_SPECS_SKIP_BIOME", raising=False)
+        diff_stdout = "Formatter would have printed the following content:\n{}"
+        with (
+            patch.object(json_writer.shutil, "which", return_value="/usr/bin/biome"),
+            patch.object(
+                subprocess,
+                "run",
+                return_value=_fake_completed(stdout=diff_stdout, stderr="", returncode=1),
+            ),
+            pytest.raises(BiomeFormatError, match="biome format failed"),
+        ):
+            _format_with_biome(target)
+
+    def test_swallows_maxsize_only_non_zero_exit(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "huge.json"
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text("{}")
+        monkeypatch.delenv("API_SPECS_SKIP_BIOME", raising=False)
+        stderr = "file exceeds the configured maximum size\nNo files were processed"
+        with (
+            patch.object(json_writer.shutil, "which", return_value="/usr/bin/biome"),
+            patch.object(
+                subprocess,
+                "run",
+                return_value=_fake_completed(stdout="", stderr=stderr, returncode=1),
+            ),
+        ):
+            # Must NOT raise
+            _format_with_biome(target)
+
+        captured = capsys.readouterr()
+        assert "files.maxSize" in captured.err
+
+
+class TestWriteJsonFile:
+    """End-to-end tests for write_json_file."""
+
+    def test_writes_json_with_trailing_newline_outside_publishing_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        target = tmp_path / "out.json"
+        data: dict[str, Any] = {"a": 1, "b": [2, 3]}
+        with patch.object(subprocess, "run") as mock_run:
+            write_json_file(data, target)
+        assert target.read_text(encoding="utf-8") == json.dumps(data, indent=2) + "\n"
+        mock_run.assert_not_called()
+
+    def test_creates_parent_directories(self, tmp_path: Path) -> None:
+        target = tmp_path / "nested" / "deep" / "out.json"
+        write_json_file({"x": 1}, target)
+        assert target.exists()
+        assert target.parent.is_dir()
+
+    def test_respects_indent_and_sort_keys(self, tmp_path: Path) -> None:
+        target = tmp_path / "out.json"
+        write_json_file({"b": 2, "a": 1}, target, indent=4, sort_keys=True)
+        content = target.read_text(encoding="utf-8")
+        # sort_keys=True → "a" comes before "b"
+        assert content.index('"a"') < content.index('"b"')
+        # indent=4 → four-space indent visible
+        assert '    "a": 1' in content
+
+    def test_invokes_biome_when_destination_is_publishing(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "x.json"
+        monkeypatch.delenv("API_SPECS_SKIP_BIOME", raising=False)
+        with (
+            patch.object(json_writer.shutil, "which", return_value="/usr/bin/biome"),
+            patch.object(
+                subprocess,
+                "run",
+                return_value=_fake_completed(stdout="", stderr="", returncode=0),
+            ) as mock_run,
+        ):
+            write_json_file({"k": "v"}, target)
+        mock_run.assert_called_once()
+        args_list = mock_run.call_args.args[0]
+        assert args_list[:3] == ["biome", "format", "--write"]
+        assert args_list[3] == str(target)
+
+    def test_publishing_path_without_biome_raises(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "api-reference" / "x.json"
+        monkeypatch.delenv("API_SPECS_SKIP_BIOME", raising=False)
+        with (
+            patch.object(json_writer.shutil, "which", return_value=None),
+            pytest.raises(BiomeNotFoundError),
+        ):
+            write_json_file({}, target)
+
+    def test_publishing_path_with_skip_env_writes_plainly(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        target = tmp_path / "docs" / "specifications" / "api" / "x.json"
+        monkeypatch.setenv("API_SPECS_SKIP_BIOME", "1")
+        with patch.object(subprocess, "run") as mock_run:
+            write_json_file({"ok": True}, target)
+        assert target.exists()
+        mock_run.assert_not_called()

--- a/tests/utils/test_schema_fixer.py
+++ b/tests/utils/test_schema_fixer.py
@@ -1,0 +1,267 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for scripts/utils/schema_fixer.py.
+
+Covers the two-phase fixer that landed via PR #138. The critical
+invariant: ``inject_max_items`` must run AFTER ``ConstraintEnricher``
+so the synthetic 65535 bound does not leak into
+``x-f5xc-constraints.maxItems``. A direct regression of Codex P1.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+import yaml
+
+from scripts.utils.schema_fixer import SchemaFixer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestNeedsMaxItems:
+    """Guards on which array schemas are eligible for maxItems injection."""
+
+    @pytest.fixture
+    def fixer(self) -> SchemaFixer:
+        return SchemaFixer()
+
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            ({"type": "array"}, True),
+            ({"type": "array", "items": {"type": "string"}}, True),
+            ({"type": "array", "maxItems": 10}, False),
+            ({"type": "array", "$ref": "#/components/schemas/X"}, False),
+            ({"type": "array", "allOf": []}, False),
+            ({"type": "array", "oneOf": []}, False),
+            ({"type": "array", "anyOf": []}, False),
+            ({"type": "string"}, False),
+            ({"type": "object"}, False),
+            ({"type": "integer"}, False),
+            ({}, False),
+        ],
+        ids=[
+            "plain_array",
+            "array_with_items",
+            "array_with_maxitems",
+            "array_with_ref",
+            "array_with_allof",
+            "array_with_oneof",
+            "array_with_anyof",
+            "string",
+            "object",
+            "integer",
+            "empty",
+        ],
+    )
+    def test_matrix(
+        self,
+        fixer: SchemaFixer,
+        schema: dict[str, Any],
+        expected: bool,
+    ) -> None:
+        assert fixer._needs_max_items(schema) is expected
+
+
+class TestNeedsTypeFix:
+    """Guards on which schemas are eligible for the format-without-type fix."""
+
+    @pytest.fixture
+    def fixer(self) -> SchemaFixer:
+        return SchemaFixer()
+
+    @pytest.mark.parametrize(
+        ("schema", "expected"),
+        [
+            ({"format": "date-time"}, True),
+            ({"format": "int32"}, True),
+            ({"format": "date-time", "type": "string"}, False),
+            ({"format": "date-time", "$ref": "#/components/schemas/X"}, False),
+            ({"format": "date-time", "allOf": []}, False),
+            ({"format": "date-time", "oneOf": []}, False),
+            ({"format": "date-time", "anyOf": []}, False),
+            ({"type": "string"}, False),
+            ({}, False),
+        ],
+        ids=[
+            "format_string",
+            "format_int",
+            "format_plus_type",
+            "format_plus_ref",
+            "format_plus_allof",
+            "format_plus_oneof",
+            "format_plus_anyof",
+            "type_without_format",
+            "empty",
+        ],
+    )
+    def test_matrix(
+        self,
+        fixer: SchemaFixer,
+        schema: dict[str, Any],
+        expected: bool,
+    ) -> None:
+        assert fixer._needs_type_fix(schema) is expected
+
+
+class TestInjectMaxItems:
+    """inject_max_items stamps 65535 on unbounded arrays, never clobbers."""
+
+    def test_stamps_on_unbounded_array(self) -> None:
+        spec = {"components": {"schemas": {"L": {"type": "array"}}}}
+        result = SchemaFixer().inject_max_items(spec)
+        assert result["components"]["schemas"]["L"]["maxItems"] == 65535
+
+    def test_does_not_overwrite_existing_max_items(self) -> None:
+        spec = {"components": {"schemas": {"L": {"type": "array", "maxItems": 42}}}}
+        result = SchemaFixer().inject_max_items(spec)
+        assert result["components"]["schemas"]["L"]["maxItems"] == 42
+
+    def test_stats_count_injections(self) -> None:
+        spec = {
+            "components": {
+                "schemas": {
+                    "A": {"type": "array"},
+                    "B": {"type": "array"},
+                    "C": {"type": "array", "maxItems": 5},  # untouched
+                    "D": {"type": "string"},  # not an array
+                },
+            },
+        }
+        fixer = SchemaFixer()
+        fixer.inject_max_items(spec)
+        assert fixer.get_stats()["max_items_added"] == 2
+
+    def test_does_not_touch_non_array_schemas(self) -> None:
+        spec = {"components": {"schemas": {"S": {"type": "string"}}}}
+        result = SchemaFixer().inject_max_items(spec)
+        assert "maxItems" not in result["components"]["schemas"]["S"]
+
+    def test_isolation_invariant_does_not_leak_into_xf5xc_constraints(self) -> None:
+        """Codex P1 regression guard.
+
+        When an array already has pattern-inferred ``x-f5xc-constraints.maxItems``,
+        ``inject_max_items`` must stamp the schema-level bound on the array but
+        MUST NOT touch the ``x-f5xc-constraints`` subtree.
+        """
+        spec = {
+            "components": {
+                "schemas": {
+                    "tags": {
+                        "type": "array",
+                        "x-f5xc-constraints": {"maxItems": 512},
+                    },
+                },
+            },
+        }
+        result = SchemaFixer().inject_max_items(spec)
+        tags = result["components"]["schemas"]["tags"]
+        assert tags["maxItems"] == 65535
+        assert tags["x-f5xc-constraints"]["maxItems"] == 512
+
+
+class TestFixSpec:
+    """fix_spec applies the format-without-type fix only."""
+
+    def test_adds_type_when_format_present(self) -> None:
+        spec = {"components": {"schemas": {"T": {"format": "date-time"}}}}
+        result = SchemaFixer().fix_spec(spec)
+        assert result["components"]["schemas"]["T"]["type"] == "string"
+
+    @pytest.mark.parametrize(
+        ("format_value", "expected_type"),
+        [
+            ("date-time", "string"),
+            ("uuid", "string"),
+            ("int32", "integer"),
+            ("int64", "integer"),
+            ("float", "number"),
+            ("double", "number"),
+            ("ipv4", "string"),
+        ],
+    )
+    def test_format_type_mapping(self, format_value: str, expected_type: str) -> None:
+        spec = {"components": {"schemas": {"T": {"format": format_value}}}}
+        result = SchemaFixer().fix_spec(spec)
+        assert result["components"]["schemas"]["T"]["type"] == expected_type
+
+    def test_unknown_format_falls_back_to_string(self) -> None:
+        spec = {"components": {"schemas": {"T": {"format": "quuxly"}}}}
+        result = SchemaFixer().fix_spec(spec)
+        assert result["components"]["schemas"]["T"]["type"] == "string"
+
+    def test_fix_spec_does_not_inject_max_items(self) -> None:
+        """fix_spec is the early-phase pass; maxItems must come from inject_max_items."""
+        spec = {"components": {"schemas": {"L": {"type": "array"}}}}
+        result = SchemaFixer().fix_spec(spec)
+        assert "maxItems" not in result["components"]["schemas"]["L"]
+
+
+def _write_config(tmp_path: Path, schema_fixes: dict[str, Any]) -> Path:
+    config = {"schema_fixes": schema_fixes}
+    path = tmp_path / "enrichment.yaml"
+    with path.open("w") as f:
+        yaml.safe_dump(config, f)
+    return path
+
+
+class TestConfigLoading:
+    """SchemaFixer respects enrichment.yaml schema_fixes block."""
+
+    def test_disabling_max_items_makes_inject_noop(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, {"fix_missing_max_items": False})
+        spec = {"components": {"schemas": {"L": {"type": "array"}}}}
+        result = SchemaFixer(config_path=config).inject_max_items(spec)
+        assert "maxItems" not in result["components"]["schemas"]["L"]
+
+    def test_custom_default_max_items_respected(self, tmp_path: Path) -> None:
+        config = _write_config(tmp_path, {"default_max_items": 1024})
+        spec = {"components": {"schemas": {"L": {"type": "array"}}}}
+        result = SchemaFixer(config_path=config).inject_max_items(spec)
+        assert result["components"]["schemas"]["L"]["maxItems"] == 1024
+
+    def test_custom_format_type_mapping_overrides_default(self, tmp_path: Path) -> None:
+        # Override "date-time" → "integer" (unrealistic, but tests the hook).
+        config = _write_config(
+            tmp_path,
+            {"format_type_mapping": {"date-time": "integer"}},
+        )
+        spec = {"components": {"schemas": {"T": {"format": "date-time"}}}}
+        result = SchemaFixer(config_path=config).fix_spec(spec)
+        assert result["components"]["schemas"]["T"]["type"] == "integer"
+
+    def test_missing_config_file_uses_defaults(self, tmp_path: Path) -> None:
+        missing = tmp_path / "does-not-exist.yaml"
+        fixer = SchemaFixer(config_path=missing)
+        assert fixer._default_max_items == SchemaFixer.DEFAULT_ARRAY_MAX_ITEMS
+        assert fixer._fix_missing_max_items is True
+        assert fixer._fix_format_without_type is True
+
+
+class TestGetStats:
+    """get_stats reports the expected shape after each phase."""
+
+    def test_stats_after_fix_spec(self) -> None:
+        spec = {"components": {"schemas": {"T": {"format": "date-time"}}}}
+        fixer = SchemaFixer()
+        fixer.fix_spec(spec)
+        stats = fixer.get_stats()
+        assert stats["fixes_applied"] == 1
+        assert stats["max_items_added"] == 0
+
+    def test_stats_after_inject_max_items(self) -> None:
+        spec = {"components": {"schemas": {"L": {"type": "array"}}}}
+        fixer = SchemaFixer()
+        fixer.inject_max_items(spec)
+        stats = fixer.get_stats()
+        assert stats["max_items_added"] == 1
+        assert stats["fixes_applied"] == 0
+
+    def test_stats_exposes_config_values(self) -> None:
+        stats = SchemaFixer().get_stats()
+        assert stats["fix_missing_max_items"] is True
+        assert stats["fix_format_without_type"] is True
+        assert stats["default_max_items"] == SchemaFixer.DEFAULT_ARRAY_MAX_ITEMS


### PR DESCRIPTION
## Summary

Backfill pytest coverage for two utilities that landed in PR #138 with zero direct tests:

- `scripts/utils/json_writer.py` — **100 %** line coverage (plan target: ≥ 95 %)
- `scripts/utils/schema_fixer.py` — **96 %** line coverage (plan target: ≥ 95 %)

The Biome path-gating in `json_writer` and the late-phase `maxItems` injection in `schema_fixer` are load-bearing in release CI (see HANDOFF.md §1.1 Codex P1/P2). Previously untested.

Closes #155

## Changes

- **`tests/utils/test_json_writer.py`** (new, 23 tests) — `_is_publishing_path`, `_is_maxsize_only` truth table, `_format_with_biome` gating and exception paths, `write_json_file` end-to-end in both publishing and non-publishing destinations.
- **`tests/utils/test_schema_fixer.py`** (new, 42 tests) — `_needs_max_items` and `_needs_type_fix` truth tables, `inject_max_items` behaviour and isolation-from-`x-f5xc-constraints` invariant (Codex P1 regression guard), `fix_spec` format-type mapping, YAML config overrides, `get_stats` shape.
- **`tests/test_enricher_integration.py`** (extended, +2 tests) — `TestConstraintEnricherSchemaFixerIsolation` runs the real `ConstraintEnricher` → `SchemaFixer.inject_max_items` sequence against `config/constraint_patterns.yaml`; asserts `tags` gets pattern-inferred `maxItems=100` in `x-f5xc-constraints` and the Checkov bound `maxItems=65535` at schema level, with no crossover; documents the reverse-ordering failure mode so refactors cannot regress silently.

## Test plan

- [x] `python3 -m pytest` — 67 new tests pass in 0.32 s
- [x] `python3 -m ruff check <3 files>` — all checks pass
- [x] `python3 -m ruff format --check <3 files>` — all formatted
- [x] Local coverage: 100 % / 96 % on the two target modules
- [ ] CI — `Check linked issues` passes
- [ ] CI — `Lint Code Base` passes (Python-only changes; no JSON spec modifications; CHECKOV/TRIVY/BIOME sub-linters should skip)

## Roadmap

Phase 1 of the post-PR-#149 phased TDD roadmap.

- **Phase 0** — PR #149 merge (landed as `e07a4d9`)
- **Phase 1** — unit coverage for `json_writer` + `schema_fixer` (**this PR**)
- **Phases 2–4** — pytest CI gate, workflow hardening, governance invariants (forthcoming)

## Notes

- No source under `scripts/` is modified — tests only.
- No JSON spec files in `docs/specifications/api/` are modified.
- No workflow or managed files are modified.