### PR TITLE
fix: exponential-backoff merge-poll for release auto-merge

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -586,25 +586,12 @@ jobs:
             # Enable auto-merge (squash) — merges when required checks pass
             gh pr merge "$BRANCH" --squash --auto --delete-branch
 
-            # Wait for PR to merge (poll up to 5 minutes)
-            for i in $(seq 1 30); do
-              STATE=$(gh pr view "$BRANCH" --json state --jq '.state')
-              if [ "$STATE" = "MERGED" ]; then
-                echo "PR merged successfully"
-                break
-              fi
-              if [ "$STATE" = "CLOSED" ]; then
-                echo "::error::PR was closed without merging"
-                exit 1
-              fi
-              echo "Waiting for PR merge... (attempt $i/30)"
-              sleep 10
-            done
-
-            if [ "$STATE" != "MERGED" ]; then
-              echo "::error::PR did not merge within timeout"
-              exit 1
-            fi
+            # Wait for PR to merge with exponential backoff (60 s warm-up + up
+            # to 15 min total). Replaces a prior hardcoded 30×10 s loop that
+            # timed out whenever Super-Linter ran longer than 5 min, leaving
+            # the release PR orphaned. Exits non-zero on CLOSED-without-merge
+            # or on timeout; emits diagnostic JSON to stderr on failure.
+            bash scripts/release/wait-for-merge.sh "$BRANCH"
 
             # Switch back to main and pull the merge commit
             git checkout main

--- a/scripts/release/wait-for-merge.sh
+++ b/scripts/release/wait-for-merge.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Poll a release PR until it reaches a terminal state, with exponential backoff.
+#
+# Arguments:
+#   $1  Branch (head ref) of the PR to watch. Required.
+#
+# Environment overrides (all optional, seconds):
+#   WAIT_FOR_MERGE_WARMUP     Initial sleep before first poll.                 default 60
+#   WAIT_FOR_MERGE_MAX_TOTAL  Hard ceiling on total wall-clock wait.           default 900
+#   WAIT_FOR_MERGE_BASE       Base backoff unit.                               default 20
+#   WAIT_FOR_MERGE_CAP        Max sleep between polls after exponential ramp. default 120
+#   WAIT_FOR_MERGE_GH         Override `gh` command (tests inject a fake).     default "gh"
+#
+# Exit codes:
+#   0  PR reached MERGED state.
+#   1  PR reached CLOSED (without merge), or total wait exceeded
+#      WAIT_FOR_MERGE_MAX_TOTAL without a terminal state.
+#
+# Motivation: the prior inline 30×10s=300s poll timed out whenever
+# Super-Linter (~5 min warm-up + ~5 min first-run-on-PR) on the release PR
+# took longer than the window, leaving the release PR orphaned and
+# requiring the self-heal pre-clean block on the NEXT scheduled run to
+# recover. Warming up for 60s, then backing off exponentially up to a
+# 15-min ceiling, covers typical Super-Linter runs without burning
+# API-call budget at a fixed 10s cadence.
+
+set -euo pipefail
+
+BRANCH="${1:?usage: wait-for-merge.sh <BRANCH>}"
+
+WARMUP="${WAIT_FOR_MERGE_WARMUP:-60}"
+MAX_TOTAL="${WAIT_FOR_MERGE_MAX_TOTAL:-900}"
+BASE="${WAIT_FOR_MERGE_BASE:-20}"
+CAP="${WAIT_FOR_MERGE_CAP:-120}"
+GH_CMD="${WAIT_FOR_MERGE_GH:-gh}"
+
+poll_state() {
+  "$GH_CMD" pr view "$BRANCH" --json state --jq '.state' 2>/dev/null
+}
+
+fail_with_diagnostics() {
+  local reason="$1"
+  echo "::error::${reason}" >&2
+  # Best-effort diagnostic capture — don't let failure inside this
+  # block mask the original exit status.
+  "$GH_CMD" pr view "$BRANCH" \
+    --json state,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup \
+    >&2 2>/dev/null || true
+  return 1
+}
+
+elapsed=0
+
+echo "Waiting ${WARMUP}s before first poll..."
+sleep "$WARMUP"
+elapsed=$((elapsed + WARMUP))
+
+attempt=1
+sleep_for="$BASE"
+
+while [ "$elapsed" -lt "$MAX_TOTAL" ]; do
+  state="$(poll_state || true)"
+  case "$state" in
+  MERGED)
+    echo "PR merged successfully after ${elapsed}s"
+    exit 0
+    ;;
+  CLOSED)
+    fail_with_diagnostics "PR was closed without merging after ${elapsed}s"
+    exit 1
+    ;;
+  OPEN | "")
+    echo "Attempt ${attempt}: state=${state:-unknown}, elapsed=${elapsed}s, sleeping ${sleep_for}s"
+    ;;
+  *)
+    echo "Attempt ${attempt}: unexpected state '${state}', sleeping ${sleep_for}s"
+    ;;
+  esac
+
+  sleep "$sleep_for"
+  elapsed=$((elapsed + sleep_for))
+  attempt=$((attempt + 1))
+
+  # Exponential ramp capped at $CAP.
+  sleep_for=$((sleep_for * 2))
+  if [ "$sleep_for" -gt "$CAP" ]; then
+    sleep_for="$CAP"
+  fi
+done
+
+fail_with_diagnostics "PR did not merge within ${MAX_TOTAL}s (${attempt} attempts)"
+exit 1

--- a/tests/shell/__init__.py
+++ b/tests/shell/__init__.py
@@ -1,0 +1,3 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Shell-harness tests for scripts/release/*.sh."""

--- a/tests/shell/test_wait_for_merge.py
+++ b/tests/shell/test_wait_for_merge.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for scripts/release/wait-for-merge.sh.
+
+Covers the exponential-backoff merge-poll helper that replaces the prior
+hardcoded 30x10s inline loop in `.github/workflows/sync-and-enrich.yml`.
+The old loop timed out whenever Super-Linter on the release PR took longer
+than 5 min, leaving the release orphaned. Verifying via a pytest/subprocess
+harness keeps the contract testable without shipping a new lint toolchain.
+
+The fake `gh` binary used here is a tiny shell script that reads a state
+file (or a sequence file that flips after N calls) and echoes the payload
+the real `gh pr view --json state --jq '.state'` would return.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "release" / "wait-for-merge.sh"
+
+
+def _write_fake_gh(tmp_path: Path, states: list[str]) -> Path:
+    """Create a fake `gh` binary that returns each state in sequence.
+
+    After the last state is emitted, the fake repeats the last value
+    forever — matches reality (a PR stays in its final state).
+    """
+    counter = tmp_path / "fake_gh_counter"
+    counter.write_text("0")
+
+    states_file = tmp_path / "fake_gh_states"
+    states_file.write_text("\n".join(states) + "\n")
+
+    fake_gh = tmp_path / "fake_gh.sh"
+    fake_gh.write_text(
+        f"""#!/usr/bin/env bash
+# Tiny fake gh — only implements `gh pr view ... --json state --jq '.state'`
+# and `gh pr view ... --json state,mergeStateStatus,...` diagnostic form.
+set -e
+
+COUNTER_FILE={counter.as_posix()!r}
+STATES_FILE={states_file.as_posix()!r}
+
+# Diagnostic form used by fail_with_diagnostics — return a tiny JSON blob
+# so stderr capture is deterministic.
+if printf '%s\\n' "$@" | grep -q mergeStateStatus; then
+  echo '{{"state":"UNKNOWN","mergeStateStatus":"UNKNOWN"}}'
+  exit 0
+fi
+
+i=$(cat "$COUNTER_FILE")
+total=$(wc -l <"$STATES_FILE" | tr -d ' ')
+if [ "$i" -ge "$total" ]; then
+  i=$((total - 1))
+fi
+sed -n "$((i + 1))p" "$STATES_FILE"
+echo $((i + 1)) >"$COUNTER_FILE"
+"""
+    )
+    fake_gh.chmod(fake_gh.stat().st_mode | stat.S_IEXEC)
+    return fake_gh
+
+
+def _run(
+    fake_gh: Path,
+    *,
+    branch: str = "release/v0.0.1",
+    warmup: int = 0,
+    base: int = 0,
+    cap: int = 0,
+    max_total: int = 2,
+) -> subprocess.CompletedProcess[str]:
+    env = {
+        **os.environ,
+        "WAIT_FOR_MERGE_GH": str(fake_gh),
+        "WAIT_FOR_MERGE_WARMUP": str(warmup),
+        "WAIT_FOR_MERGE_BASE": str(base),
+        "WAIT_FOR_MERGE_CAP": str(cap),
+        "WAIT_FOR_MERGE_MAX_TOTAL": str(max_total),
+    }
+    return subprocess.run(
+        ["bash", str(_SCRIPT), branch],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=30,
+    )
+
+
+class TestHappyPath:
+    """PR reaches MERGED — exit 0, logs state."""
+
+    def test_merged_on_first_poll(self, tmp_path: Path) -> None:
+        fake = _write_fake_gh(tmp_path, ["MERGED"])
+        result = _run(fake, max_total=5)
+        assert result.returncode == 0, result.stderr
+        assert "PR merged successfully" in result.stdout
+
+    def test_merged_after_backoff(self, tmp_path: Path) -> None:
+        fake = _write_fake_gh(tmp_path, ["OPEN", "OPEN", "OPEN", "MERGED"])
+        result = _run(fake, max_total=10)
+        assert result.returncode == 0, result.stderr
+        assert "PR merged successfully" in result.stdout
+        # At least 3 "Attempt N:" log lines (the OPEN poll attempts).
+        assert result.stdout.count("Attempt ") >= 3
+
+    def test_unknown_state_is_non_terminal(self, tmp_path: Path) -> None:
+        fake = _write_fake_gh(tmp_path, ["WEIRD", "WEIRD", "MERGED"])
+        result = _run(fake, max_total=10)
+        assert result.returncode == 0, result.stderr
+        assert "unexpected state 'WEIRD'" in result.stdout
+
+
+class TestFailurePath:
+    """CLOSED and timeout both exit 1 with diagnostics on stderr."""
+
+    def test_closed_exits_nonzero(self, tmp_path: Path) -> None:
+        fake = _write_fake_gh(tmp_path, ["CLOSED"])
+        result = _run(fake, max_total=5)
+        assert result.returncode == 1
+        assert "PR was closed without merging" in result.stderr
+
+    def test_timeout_exits_nonzero(self, tmp_path: Path) -> None:
+        # Never-flipping OPEN state + base=1 + max_total=2 → ~2s wall clock
+        # before the loop gives up. Diagnostic fail message on stderr.
+        fake = _write_fake_gh(tmp_path, ["OPEN"])
+        result = _run(fake, base=1, cap=1, max_total=2)
+        assert result.returncode == 1
+        assert "did not merge within" in result.stderr
+
+
+class TestContract:
+    """Guards on the CLI contract."""
+
+    def test_requires_branch_argument(self, tmp_path: Path) -> None:
+        fake = _write_fake_gh(tmp_path, ["MERGED"])
+        result = subprocess.run(
+            ["bash", str(_SCRIPT)],
+            capture_output=True,
+            text=True,
+            env={**os.environ, "WAIT_FOR_MERGE_GH": str(fake)},
+            check=False,
+            timeout=5,
+        )
+        assert result.returncode != 0
+        assert "usage" in result.stderr.lower() or "BRANCH" in result.stderr


### PR DESCRIPTION
## Summary

The `Commit and tag release` step in `.github/workflows/sync-and-enrich.yml` had a hardcoded `30 × 10s = 300s` poll loop waiting for the release PR to auto-merge. On 2026-04-21 this timed out in production (Super-Linter on release PR #150 exceeded 5 min), orphaning the release PR and failing the release workflow with `::error::PR did not merge within timeout`.

This PR:

- Extracts the merge-poll into `scripts/release/wait-for-merge.sh` (single-purpose, PATH-stubbable).
- Replaces the 300 s fixed wait with a **60 s warm-up + exponential backoff up to 900 s (15 min)** capped at 120 s per step.
- Emits diagnostic `gh pr view --json state,mergeStateStatus,mergeable,reviewDecision,statusCheckRollup` to stderr on `CLOSED`-without-merge or final timeout, so failing runs surface root cause.
- Adds `tests/shell/test_wait_for_merge.py` — pytest harness using a fake `gh` via the `WAIT_FOR_MERGE_GH` env override. 6 tests cover merged-immediately, merged-after-backoff, unknown-state-non-terminal, CLOSED-exits-1, timeout-exits-1, and the contract that refuses without a branch arg.

Closes #161.

## Out of scope (Phase-3 followups)

- Stale-tag-without-branch abort (`git ls-remote origin refs/tags/v${VERSION}` pre-check before tagging).
- Concurrent-run tag race guard (cancel-in-progress already mitigates; clock-skew edge-case remains).

`gh release create` idempotency is already on main (sync-and-enrich.yml lines 697-701) — no change needed.

## Roadmap

Phase 3 of the post-PR-#149 phased roadmap.

- Phase 0 — #149 (merged)
- Phase 1 — #156 (merged)
- Phase 2 — #158 (merged)
- Phase 3 — **this PR**

## Test plan

- [x] `pytest tests/shell/` — 6 tests pass against a fake `gh` stub
- [x] `shellcheck scripts/release/wait-for-merge.sh` — clean
- [x] `shfmt -d scripts/release/wait-for-merge.sh` — clean
- [x] `actionlint .github/workflows/sync-and-enrich.yml` — clean
- [x] `ruff check tests/shell/` — clean
- [x] `ruff format --check tests/shell/` — clean
- [ ] `check / Check linked issues` passes (Closes #161)
- [ ] `Validate PR` passes
- [ ] `lint / Shell Unit Tests` passes
- [ ] `lint / Lint Code Base` passes
- [ ] `Run pytest suite` passes