### PR TITLE
chore: skip enrichment pipeline when no inputs staged

### DIFF
--- a/scripts/hooks/pre-commit-pipeline.sh
+++ b/scripts/hooks/pre-commit-pipeline.sh
@@ -38,6 +38,24 @@ else
 fi
 
 # =============================================================================
+# STEP 0: Skip when no pipeline inputs are staged.
+# =============================================================================
+# The enrichment pipeline is ~13 min and deterministic in its inputs.
+# If nothing staged in this commit can affect the pipeline output
+# (scripts/**, config/**, specs/original/**, requirements*.txt,
+# pyproject.toml, sync-and-enrich.yml), the previous run's output is
+# still valid and re-running is pure waste. Override with
+# FORCE_PIPELINE=1 when you need a full regeneration anyway.
+if [ "${FORCE_PIPELINE:-0}" != "1" ]; then
+  STAGED_INPUTS=$(git diff --cached --name-only | grep -E '^(scripts/|config/|specs/original/|requirements(-dev)?\.txt$|pyproject\.toml$|\.github/workflows/sync-and-enrich\.yml$)' | head -1 || true)
+  if [ -z "$STAGED_INPUTS" ]; then
+    echo -e "${GREEN}No pipeline inputs staged — skipping enrichment + lint.${NC}"
+    echo -e "${GREEN}(Set FORCE_PIPELINE=1 to force a full run.)${NC}"
+    exit 0
+  fi
+fi
+
+# =============================================================================
 # STEP 1: Run Enrichment Pipeline
 # =============================================================================
 echo -e "${YELLOW}[1/2] Running F5 XC API enrichment pipeline...${NC}"

--- a/tests/shell/test_pre_commit_pipeline.py
+++ b/tests/shell/test_pre_commit_pipeline.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Tests for scripts/hooks/pre-commit-pipeline.sh.
+
+Specifically, the STEP 0 input-fingerprint skip that short-circuits the
+~13 min enrichment pipeline when no pipeline-input files are staged.
+The full pipeline run is NOT exercised here — we only verify the skip
+decision against a throwaway git repo.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+_HOOK_RELATIVE = "scripts/hooks/pre-commit-pipeline.sh"
+_PROJECT_HOOK = Path(__file__).resolve().parents[2] / _HOOK_RELATIVE
+
+
+def _run_cmd(cmd: list[str], cwd: Path) -> None:
+    subprocess.run(cmd, cwd=cwd, check=True, capture_output=True)
+
+
+def _setup_repo(tmp_path: Path, hook_copy: Path) -> Path:
+    """Create a throwaway repo that mimics the project layout the hook sees."""
+    _run_cmd(["git", "init", "-q", "-b", "main"], tmp_path)
+    _run_cmd(["git", "config", "user.email", "t@t.t"], tmp_path)
+    _run_cmd(["git", "config", "user.name", "t"], tmp_path)
+
+    # Mirror the minimum shape the hook fingerprint inspects, and commit
+    # the hook itself as part of the base state so `git add .` in a test
+    # doesn't re-stage it as a pipeline-input change.
+    (tmp_path / "scripts").mkdir()
+    (tmp_path / "config").mkdir()
+    (tmp_path / "specs" / "original").mkdir(parents=True)
+    (tmp_path / ".github" / "workflows").mkdir(parents=True)
+    (tmp_path / "README.md").write_text("readme\n")
+    (tmp_path / "requirements.txt").write_text("pytest\n")
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='x'\n")
+
+    hook_target = tmp_path / _HOOK_RELATIVE
+    hook_target.parent.mkdir(parents=True, exist_ok=True)
+    hook_target.write_text(hook_copy.read_text())
+    hook_target.chmod(hook_target.stat().st_mode | stat.S_IEXEC)
+
+    _run_cmd(["git", "add", "."], tmp_path)
+    _run_cmd(["git", "commit", "-q", "-m", "init"], tmp_path)
+    return tmp_path
+
+
+def _invoke(cwd: Path, *, force: bool = False) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ}
+    if force:
+        env["FORCE_PIPELINE"] = "1"
+    # We point PYTHON at `true` so that if the hook DOES fall through to
+    # STEP 1 (pipeline run) it exits 0 without doing anything. Our assertions
+    # then key on stdout to distinguish skip vs. fall-through.
+    env["PATH"] = f"{cwd}/_fakebin:{env.get('PATH', '')}"
+    fakebin = cwd / "_fakebin"
+    fakebin.mkdir(exist_ok=True)
+    python_stub = fakebin / "python3"
+    python_stub.write_text(
+        '#!/usr/bin/env bash\necho "[fake python] args: $*" >&2\nexit 0\n'.replace("'", '"')
+    )
+    python_stub.chmod(python_stub.stat().st_mode | stat.S_IEXEC)
+    spectral_stub = fakebin / "spectral"
+    spectral_stub.write_text("#!/usr/bin/env bash\nexit 0\n")
+    spectral_stub.chmod(spectral_stub.stat().st_mode | stat.S_IEXEC)
+
+    return subprocess.run(
+        ["bash", _HOOK_RELATIVE],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+        timeout=30,
+    )
+
+
+class TestSkipPath:
+    """STEP 0 short-circuits when no pipeline inputs are staged."""
+
+    def test_readme_only_commit_skips_pipeline(self, tmp_path: Path) -> None:
+        hook_src = _project_hook()
+        repo = _setup_repo(tmp_path, hook_src)
+
+        (repo / "README.md").write_text("edited\n")
+        _run_cmd(["git", "add", "README.md"], repo)
+
+        result = _invoke(repo)
+        assert result.returncode == 0, result.stderr
+        assert "skipping enrichment + lint" in result.stdout
+        assert "[fake python]" not in result.stderr
+
+    def test_test_file_only_skips_pipeline(self, tmp_path: Path) -> None:
+        hook_src = _project_hook()
+        repo = _setup_repo(tmp_path, hook_src)
+
+        (repo / "tests").mkdir()
+        (repo / "tests" / "test_x.py").write_text("def test_ok():\n    assert True\n")
+        _run_cmd(["git", "add", "."], repo)
+
+        result = _invoke(repo)
+        assert result.returncode == 0, result.stderr
+        assert "skipping enrichment + lint" in result.stdout
+
+
+class TestRunPath:
+    """STEP 0 falls through when a pipeline-input file is staged."""
+
+    def test_config_change_triggers_pipeline(self, tmp_path: Path) -> None:
+        hook_src = _project_hook()
+        repo = _setup_repo(tmp_path, hook_src)
+
+        (repo / "config" / "thing.yaml").write_text("key: value\n")
+        _run_cmd(["git", "add", "config/thing.yaml"], repo)
+
+        result = _invoke(repo)
+        # The fake python stub exits 0, so the hook continues past STEP 1.
+        assert "Running F5 XC API enrichment pipeline" in result.stdout
+        assert "skipping enrichment + lint" not in result.stdout
+
+    def test_scripts_change_triggers_pipeline(self, tmp_path: Path) -> None:
+        hook_src = _project_hook()
+        repo = _setup_repo(tmp_path, hook_src)
+
+        (repo / "scripts" / "enrich.py").write_text("print('hi')\n")
+        _run_cmd(["git", "add", "scripts/enrich.py"], repo)
+
+        result = _invoke(repo)
+        assert "Running F5 XC API enrichment pipeline" in result.stdout
+
+    def test_workflow_change_triggers_pipeline(self, tmp_path: Path) -> None:
+        hook_src = _project_hook()
+        repo = _setup_repo(tmp_path, hook_src)
+
+        (repo / ".github" / "workflows" / "sync-and-enrich.yml").write_text("name: x\n")
+        _run_cmd(["git", "add", ".github/workflows/sync-and-enrich.yml"], repo)
+
+        result = _invoke(repo)
+        assert "Running F5 XC API enrichment pipeline" in result.stdout
+
+
+class TestForceOverride:
+    """FORCE_PIPELINE=1 runs the pipeline even when no inputs are staged."""
+
+    def test_force_overrides_skip(self, tmp_path: Path) -> None:
+        hook_src = _project_hook()
+        repo = _setup_repo(tmp_path, hook_src)
+
+        (repo / "README.md").write_text("edited\n")
+        _run_cmd(["git", "add", "README.md"], repo)
+
+        result = _invoke(repo, force=True)
+        assert "Running F5 XC API enrichment pipeline" in result.stdout
+        assert "skipping enrichment + lint" not in result.stdout
+
+
+def _project_hook() -> Path:
+    """Path to the repo's own copy of the hook."""
+    return _PROJECT_HOOK


### PR DESCRIPTION
## Summary

- Adds STEP 0 input-fingerprint skip to `scripts/hooks/pre-commit-pipeline.sh`.
- When `git diff --cached --name-only` has no paths under `scripts/`, `config/`, `specs/original/`, `requirements*.txt`, `pyproject.toml`, or `.github/workflows/sync-and-enrich.yml`, the hook exits `0` immediately — the previous run's enriched output is still valid.
- `FORCE_PIPELINE=1` overrides the skip when a full regen is wanted regardless.
- Eliminates the `core.hooksPath=/dev/null` workaround github-ops has been applying this session for ~90% of PRs that don't regenerate specs.

Closes #167

## Changes

| File | Δ |
| --- | --- |
| `scripts/hooks/pre-commit-pipeline.sh` | +18 lines (STEP 0 skip) |
| `tests/shell/test_pre_commit_pipeline.py` | +164 lines (new, 6 tests) |

Net: 2 files, 182 insertions.

## Test plan

- [ ] `Check linked issues` CI check passes (issue #167 linked via `Closes`)
- [ ] `Lint Code Base` CI check passes
- [ ] `tests/shell/test_pre_commit_pipeline.py` passes in CI (6 tests, 0.07s locally)
- [ ] Pipeline CI runs on this PR (expected — `scripts/` is a pipeline input, so the current unconditional behaviour runs; benefit kicks in post-merge for subsequent non-input-touching PRs)
- [ ] Post-merge: a subsequent PR touching only (e.g.) README confirms the skip path

## Notes

- Phase-4 followup per `HANDOFF.md` §2 (post-PR-#149 roadmap).
- Test suite uses a fake `python3` shim on `PATH` so the real 13-min pipeline is **never** exercised in the test — keeps the suite fast and hermetic.