### PR TITLE
chore: align biome install with docs-control (setup-biome@latest)

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -29,10 +29,12 @@ concurrency:
 
 env:
   PYTHON_VERSION: '3.13'
-  # Pinned Biome version — also used as a cache-key suffix so that a
-  # Biome upgrade busts the enriched-output cache (and forces the
-  # generator to re-emit JSON formatted by the new Biome release).
-  BIOME_VERSION: '2.4.12'
+  # Biome is installed via biomejs/setup-biome@version:latest, mirroring
+  # docs-control's super-linter.yml (docs-control#385). The version
+  # resolved at install time is captured into steps.biome.outputs.version
+  # and used as a cache-key suffix so that a Biome upgrade busts the
+  # enriched-output cache and forces the generator to re-emit JSON
+  # formatted by the new Biome release.
 
 jobs:
   check-updates:
@@ -164,13 +166,25 @@ jobs:
           } | sha256sum | cut -d' ' -f1)
           echo "hash=$HASH" >> "$GITHUB_OUTPUT"
 
+      - name: Setup Biome
+        uses: biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51  # v2.7.1 — matches docs-control super-linter.yml
+        with:
+          version: latest
+
+      - name: Capture Biome version
+        id: biome
+        run: |
+          version=$(biome --version | awk '{print $2}')
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "Biome ${version} installed (matches docs-control's setup-biome pin)"
+
       - name: Restore enriched output cache
         if: github.event_name != 'workflow_dispatch'
         id: enriched-cache
         uses: actions/cache/restore@v5
         with:
           path: docs/specifications/api
-          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}-biome-${{ env.BIOME_VERSION }}
+          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}-biome-${{ steps.biome.outputs.version }}
 
       - name: Install Java (for LanguageTool)
         if: steps.enriched-cache.outputs.cache-hit != 'true'
@@ -183,8 +197,8 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install Spectral CLI and Biome
-        run: npm install -g @stoplight/spectral-cli "@biomejs/biome@${BIOME_VERSION}"
+      - name: Install Spectral CLI
+        run: npm install -g @stoplight/spectral-cli
 
       - name: Check for Discovery Data
         id: check-discovery
@@ -225,7 +239,7 @@ jobs:
         uses: actions/cache/save@v5
         with:
           path: docs/specifications/api
-          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}-biome-${{ env.BIOME_VERSION }}
+          key: enriched-${{ steps.specs-fingerprint.outputs.hash }}-${{ steps.pipeline-fingerprint.outputs.hash }}-biome-${{ steps.biome.outputs.version }}
 
       - name: Generate API viewer pages
         run: python -m scripts.generate_api_viewer


### PR DESCRIPTION
## Summary

Mirrors docs-control's Super-Linter Biome install approach (docs-control#385) in our `sync-and-enrich.yml`:

- Install Biome via `biomejs/setup-biome@4c91541eaada48f67d7dbd7833600ce162b68f51` (v2.7.1 — the same SHA docs-control uses) with `version: latest`.
- Capture resolved Biome version at runtime into `steps.biome.outputs.version` and use it as the enriched-output cache-key suffix on both restore and save.
- Remove `env.BIOME_VERSION: '2.4.12'` hardcoded pin.
- Drop `@biomejs/biome` from the `npm install` line (spectral-cli only now).

Architecturally eliminates the version-skew risk between the pipeline's Biome (what formats generator output) and Super-Linter's Biome (what `biome ci` validates). When docs-control bumps the action SHA via Dependabot, we pick up the new Biome on the next workflow run and the cache invalidates via the new version key.

Tracking issue: #169
Local follow-up tracker: Closes #154

## Test plan

- [x] `actionlint` clean locally on the modified workflow.
- [x] `zizmor` clean locally (surfaced via the `GitHub Actions security` pre-commit hook — Passed).
- [x] Pre-commit hooks Passed on `.github/workflows/sync-and-enrich.yml` (GOVERNANCE, repo-specific, large-files, YAML lint, actionlint, spelling, EditorConfig, zizmor, infra-security, secrets).
- [ ] CI green on this PR (sync-and-enrich WILL run the full ~13 min here because this PR touches a pipeline-input path — the idempotency skip from #168 does not apply to pipeline-input changes).
- [ ] After merge: cache key rotates cleanly on the first post-merge pipeline run (new `enriched-…-biome-<resolved-version>` key replaces the old `…-biome-2.4.12` key).
- [ ] After merge: a manual `workflow_dispatch` on `sync-and-enrich` exercises the new setup-biome path end-to-end.

## Related

- Closes #154 (local follow-up tracker)
- Tracked by: #169
- Upstream origin: f5xc-salesdemos/docs-control#385 (landed), f5xc-salesdemos/docs-control#383 (follow-up discussion)