### PR TITLE
chore: seed specs/original/ before pytest in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,5 +46,14 @@ jobs:
           git fetch origin "$BASE_REF" --depth=50
           python -m scripts.verify_governance --base "origin/$BASE_REF" --head HEAD
 
+      - name: Seed specs/original/ from upstream releases
+        # Pulls the latest f5xc-salesdemos/api-specs release into
+        # specs/original/ so spec-dependent test modules (currently
+        # only tests/test_all_endpoints_enrichment.py) execute instead
+        # of skipping at import time.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python -m scripts.download
+
       - name: Run pytest
         run: python -m pytest


### PR DESCRIPTION
## Summary

Adds a `Seed specs/original/ from upstream releases` step to
`.github/workflows/tests.yml` between the governed-files guard and
`Run pytest`. The step runs `python -m scripts.download`, which
pulls the public `f5xc-salesdemos/api-specs` release asset into
`specs/original/`.

Today `tests/test_all_endpoints_enrichment.py` requires
`specs/original/` on disk at import time. The Phase 2 fix
(`allow_module_level=True` skip) means CI silently skips the whole
module — 18 real enrichment-regression tests never run. This PR
flips them on.

Closes #172.

## Test plan

- [x] `actionlint` clean on the new step
- [x] `zizmor` clean (GitHub Actions security hook passes locally;
      no pinning/secret issues — uses `${{ secrets.GITHUB_TOKEN }}`
      with no extra scopes)
- [x] `yamllint` silent
- [x] Locally, with `specs/original/` populated, the 18 tests in
      `tests/test_all_endpoints_enrichment.py` pass in ~0.29s
- [ ] CI: `Run pytest suite` job now runs the 18 additional tests
- [ ] CI: first run includes `scripts.download` time (~520 files);
      expect pytest job total to jump 10-30s vs baseline

## Notes

- Uses ambient `GITHUB_TOKEN` purely for rate-limit headroom;
  `api-specs` is a public repo so no custom scopes required.
- Phase 4 followup per `HANDOFF.md` §2.