### PR TITLE
docs: refresh HANDOFF.md to capture followup round

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,11 @@
 <!-- markdownlint-disable MD013 MD033 MD058 MD060 -->
 
-# HANDOFF — end of phased-roadmap session (2026-04-21)
+# HANDOFF — end of phased roadmap + followup round (2026-04-21)
 
 > **Purpose:** clean resume state for the next session. The four-phase
-> roadmap that started with PR #149 landed in full this session.
+> roadmap that started with PR #149 landed in full, plus a four-PR
+> followup round resolving the QoL followups that accumulated during
+> it. Main is clean.
 
 ## 0. Resume-here status
 
@@ -13,81 +15,166 @@
 | PR #156 — TDD backfill for `json_writer` + `schema_fixer` | Merged `c450951` | Closed #155 |
 | PR #158 — pytest CI gate + fix 16 latent drift failures | Merged `6a18f98` | Closed #157 |
 | PR #162 — exponential-backoff merge-poll script | Merged `2366495` | Closed #161 |
-| Phase 4 — governance guard (this PR) | ▶ in review | Issue TBD (filed by github-ops) |
+| PR #165 — governance guard + first HANDOFF refresh | Merged `be3e0b5` | Closed #164 |
+| PR #168 — pre-commit idempotency skip | Merged `50c6d2a` | Closed #167 |
+| PR #171 — biome via `biomejs/setup-biome@latest` | Merged `4be419c` | Closed #154, #169 |
+| PR #174 — seed `specs/original/` in tests.yml CI | Merged `90a3026` | Closed #172 |
+| PR #176 — full fixture coverage (10→55 resources, 8→20 patterns) | Merged `1c95108` | Closed #175 |
 
-Main HEAD at session end: `2366495` (plus Phase 4 once merged).
+Main HEAD at session end: `1c95108`.
 
-## 1. What shipped
+Full-suite pytest posture: **1901 passed + 1 xfailed** (structural namespace path-extraction limit). Up from zero tests in CI at session start.
 
-### 1.1 Workflow reliability
+## 1. What shipped (roadmap + followups, in merge order)
 
-- `scripts/release/wait-for-merge.sh` replaces the prior hardcoded
-  30×10 s inline merge-poll with a 60 s warm-up + exponential backoff
-  up to 15 min. Diagnostic JSON to stderr on timeout. Unit-tested via
-  `tests/shell/test_wait_for_merge.py` with a fake-`gh` PATH stub.
-- Pre-clean block in `sync-and-enrich.yml` now detects and clears
-  stale release PRs/branches before starting a new release run.
+### 1.1 Phase 0 — workflow self-heal (PR #149)
 
-### 1.2 Test infrastructure
+Adds a pre-clean block to `.github/workflows/sync-and-enrich.yml:541-554`:
+detects and closes any stale open release PR (with `--delete-branch`)
+or force-deletes the stale branch before creating a fresh one. All `gh`
+calls are guarded with `|| true` so cleanup cannot fail the job. Uses
+`$GITHUB_RUN_ID` (not `${{ github.run_id }}`) in the shell body to
+stay on the safe side of workflow-injection patterns. Exercised in
+production this session — PR #150 (the previous stuck release PR) was
+auto-cleaned by a subsequent scheduled run.
 
-- `make test` target added; new `.github/workflows/tests.yml` runs
-  pytest on every PR.
-- Phase 4 adds a `verify_governance` gate step: any PR touching files
-  in `.claude/governance.json` protected_files fails the `tests /
-  pytest` check with a clear error.
-- 104+ new tests added across `tests/utils/test_json_writer.py`,
-  `tests/utils/test_schema_fixer.py`, `tests/test_enricher_integration.py`
-  (constraint-isolation regression), `tests/shell/test_wait_for_merge.py`,
-  `tests/test_verify_governance.py`. Full suite: 1777+ passed + 3 xfailed
-  (counts shift with config growth).
-- 16 pre-existing drift failures surfaced by the new CI gate were
-  fixed in-line (PR #158): signature drifts in `test_zip_security.py`,
-  domain-mapping drift in `test_external_docs_enricher.py` + `test_minimum_configuration_enricher.py`,
-  snake_case + wording drift in `test_uniqueness_enricher.py`, config
-  growth (10 → 55 resources, 8 → 20 patterns) in
-  `test_enricher_integration.py` (two count-guards marked xfail —
-  see §4).
+### 1.2 Phase 1 — TDD backfill (PR #156)
 
-### 1.3 Config + CI governance state (§5 of the prior HANDOFF, all carried over)
+New tests:
 
-- Canonical `.checkov.yaml` + `trivy.yaml` land via docs-control sync
-  (PR #148 previous session). No re-drift this session.
-- Super-Linter + walker-proof TRIVY upstream in docs-control#380.
-- Super-Linter's bundled Biome 2.4.10 vs. our pipeline 2.4.12 skew
-  still exists — tracked in local #154 + upstream docs-control#383.
-  Has not bitten any non-release PR this session (BIOME_FORMAT passed
-  every time). It will re-surface on the next release PR unless
-  docs-control#383 lands first.
+- `tests/utils/test_json_writer.py` — 23 tests on `_is_publishing_path`,
+  `_is_maxsize_only`, `_format_with_biome` gating/exception paths,
+  `write_json_file` end-to-end.
+- `tests/utils/test_schema_fixer.py` — 42 tests including the
+  `inject_max_items` isolation-from-`x-f5xc-constraints` invariant
+  (Codex P1 regression guard).
+- `tests/test_enricher_integration.py::TestConstraintEnricherSchemaFixerIsolation`
+  — 2 tests running the real `ConstraintEnricher` →
+  `SchemaFixer.inject_max_items` sequence against
+  `config/constraint_patterns.yaml`.
 
-## 2. Open issues / followups
+Coverage: 100 % lines on `json_writer.py`, 96 % on `schema_fixer.py`.
 
-- **local #154 + docs-control#383** — biome version skew (needs
-  upstream).
-- **Enrichment pre-commit hook non-idempotency** — every commit
-  triggers the ~12 min pipeline which regenerates 39 spec JSONs with
-  fresh timestamps, forcing a `core.hooksPath=/dev/null` workaround
-  on every commit via github-ops. No tracking issue filed this session;
-  worth creating one (candidate title: `chore: make pre-commit
-  enrichment hook idempotent`).
-- **Super-Linter mypy config drift** — `PYTHON_MYPY_CONFIG_FILE` points
-  at `.mypy.ini` which doesn't exist, so the `tests.*` override in
-  `pyproject.toml` is bypassed in CI. Worked around in-file for Phase 1
-  (`# type: ignore[index]` on 3 lines). Structural fix needs
-  docs-control coordination — file as a followup.
-- **`test_all_explicit_resources_count` + `test_all_patterns_count`
-  xfail** — fixtures pin 10 / 8, config has 55 / 20. Expanding
-  fixtures is mechanical-but-tedious work; leaves an automated
-  forcing function so they flip green when the fixtures catch up.
-- **Phase-3 deferred guards** — stale-tag-without-branch abort
-  (pre-check `git ls-remote origin refs/tags/v${VERSION}` before
-  pushing) and concurrent-run tag race guard. Neither has bitten us
-  in the wild; both documented in Phase 3 tracker #161 (now closed —
-  would need a new tracker).
-- **CI should seed `specs/original/`** so
-  `tests/test_all_endpoints_enrichment.py` (and any future spec-dependent
-  tests) actually run. Currently that module skips cleanly with
-  `allow_module_level=True`. Good enough for Phase-2 unblock; worth
-  a follow-up.
+### 1.3 Phase 2 — pytest CI gate + drift cleanup (PR #158)
+
+Adds `Makefile:test` target and `.github/workflows/tests.yml` that
+runs pytest on every PR. The new gate surfaced 16 pre-existing
+drifts, all fixed in the same PR:
+
+- `test_zip_security.py` (6) — `extract_zip(..., config)` and
+  `validate_zip_member_size(..., limits)` signature drift.
+- `test_external_docs_enricher.py` + `test_minimum_configuration_enricher.py`
+  (2) — `app_firewall` regrouped under the `virtual` domain.
+- `test_uniqueness_enricher.py` (3) — snake_case drift
+  (`HTTPLoadBalancer` → `http_load_balancer`, `AWSVPCSite` →
+  `awsvpc_site`); "platform" scope wording switched to
+  "globally unique across all F5 XC tenants".
+- `test_enricher_integration.py` (5) — `waf_policy` wording; two
+  pattern-matcher entries graduated to explicit resources;
+  count-guards `test_all_*_count` originally marked xfail for the
+  config-growth delta (later expanded in PR #176).
+- `tests/test_all_endpoints_enrichment.py` — `allow_module_level=True`
+  on the module-scope `pytest.skip` so the module cleanly skips in
+  CI when `specs/original/` is absent (later seeded by PR #174).
+
+### 1.4 Phase 3 — exponential-backoff merge-poll (PR #162)
+
+Replaces the hardcoded `30×10 s = 300 s` inline poll (which timed out
+on every Super-Linter run > 5 min, orphaning release PRs) with:
+
+- `scripts/release/wait-for-merge.sh` — 60 s warm-up + exponential
+  backoff up to 15 min total. Emits diagnostic JSON to stderr on
+  failure. Unit-tested via `tests/shell/test_wait_for_merge.py` (6
+  tests against a fake-`gh` PATH stub).
+
+Deferred guards (stale-tag-without-branch abort, concurrent-run tag
+race) never bitten in the wild — see §2.
+
+### 1.5 Phase 4 — governance guard + first HANDOFF (PR #165)
+
+- `scripts/verify_governance.py` — pure-stdlib CLI. Reads
+  `.claude/governance.json`, runs `git diff --name-only <base>..<head>`,
+  exits 1 if any changed file is in `protected_files`.
+- `tests/test_verify_governance.py` — 8 tests on a throwaway repo.
+- `.github/workflows/tests.yml` — new `Verify no governed files
+  touched` step running only on `pull_request` events.
+
+### 1.6 Followup — pre-commit idempotency (PR #168)
+
+Adds a STEP-0 input-fingerprint skip to
+`scripts/hooks/pre-commit-pipeline.sh`. When `git diff --cached
+--name-only` returns no paths under `scripts/`, `config/`,
+`specs/original/`, `requirements*.txt`, `pyproject.toml`, or
+`sync-and-enrich.yml`, the hook exits 0 immediately — the previous
+run's enriched output is still valid. `FORCE_PIPELINE=1` overrides.
+Coverage: `tests/shell/test_pre_commit_pipeline.py` (6 tests). This
+ended the `core.hooksPath=/dev/null` workaround github-ops was
+applying on every commit — confirmed in PR #174's commit log
+("No pipeline inputs staged — skipping enrichment + lint.").
+
+### 1.7 Followup — biome alignment (PR #171)
+
+Mirrors docs-control#385: swap the `npm install -g
+@biomejs/biome@${BIOME_VERSION}` pin for a `biomejs/setup-biome@SHA`
+step with `version: latest` (same action SHA docs-control uses).
+Drops `env.BIOME_VERSION`. The runtime-resolved version is captured
+into `steps.biome.outputs.version` and used as the enriched-output
+cache key suffix. The pipeline's Biome and docs-control's Super-Linter
+Biome now resolve to the same binary on every run.
+
+### 1.8 Followup — seed specs/original/ (PR #174)
+
+Adds a `Seed specs/original/` step to `tests.yml` before pytest.
+Runs `python -m scripts.download` with ambient `GITHUB_TOKEN` for
+rate-limit headroom (api-specs is public). The 18 previously-skipped
+tests in `tests/test_all_endpoints_enrichment.py` now execute on
+every PR — counted and confirmed in CI logs (main baseline 1779 →
+post-#174 1797).
+
+### 1.9 Followup — fixture coverage expansion (PR #176)
+
+`EXPLICIT_RESOURCES_FULL_PIPELINE`, `EXPLICIT_RESOURCES_PRESERVATION`,
+and `PATTERN_MATCHERS` in `tests/test_enricher_integration.py` now
+match the full `config/operation_descriptions.yaml`:
+
+- 10 → **55** explicit resources
+- 8 → **20** pattern matchers
+
+Both count-guard tests (`test_all_explicit_resources_count`,
+`test_all_patterns_count`) lost their xfail decorators — they now
+enforce bidirectional fixture↔config parity. Only `namespace`
+remains xfail (strict=True) because the enricher's
+`_extract_resource_type` legitimately skips `namespaces` as a
+structural path segment. Full-suite: 1797 → **1901** (+104).
+
+## 2. Still-open followups (intentional)
+
+- **`docs-control#383`** — upstream biome-skew tracker. Our local
+  #154 is closed (PR #171 aligned us architecturally via
+  `biomejs/setup-biome@latest`). A comment has been posted on #383
+  asking docs-control maintainers to close it now that #385 landed.
+  Not blocking; cosmetic upstream cleanup.
+
+- **Phase-3 deferred guards.** `sync-and-enrich.yml`'s release step
+  still lacks:
+  - Stale-tag-without-branch abort (pre-check
+    `git ls-remote origin refs/tags/v${VERSION}` before pushing).
+  - Concurrent-run tag race guard. Workflow concurrency
+    `cancel-in-progress: true` mitigates but doesn't guard clock-skew
+    windows.
+  Neither has bitten us in the wild. Merge-poll timeout (the one that
+  did bite) is closed by PR #162. A future session can pick these up
+  as a narrow defensive PR.
+
+- **Codespell-governed path shapes.** PR #176 worked around codespell
+  flagging the naive `{name}-plus-s` plurals of `policy`, `proxy`, and
+  `discovery` as typos (codespell wants the true English plural
+  forms). Workaround: use singular path segments in the fixture
+  (`/alert_policy` instead of appending an `s`) — `_extract_resource_type`
+  returns non-`s`-ending parts as-is, so the singular paths still
+  extract correctly. `.codespellrc` is governed — a more idiomatic
+  `{name} → {name}ies` pluralization in our test paths would be an
+  upstream ask against docs-control.
 
 ## 3. Ground rules that persist
 
@@ -100,18 +187,24 @@ Main HEAD at session end: `2366495` (plus Phase 4 once merged).
   `f5xc-salesdemos/docs-control` instead.
 - **No `--no-verify`, no `--admin`, no `[skip ci]`, no force-push**
   without explicit authorization.
-- **Pre-commit runs the full enrichment pipeline (~12 min)** on every
-  commit. See the hook-idempotency followup above.
+- **Pre-commit idempotency now works**: commits that don't touch
+  pipeline-input paths skip the 13-min enrichment. When editing
+  `scripts/`, `config/`, `specs/original/`, `requirements*.txt`,
+  `pyproject.toml`, or `sync-and-enrich.yml`, the full pipeline
+  still runs — budget ~15 min wall-clock.
+- **CI now runs pytest on every PR** (1901 tests + 1 xfailed) plus
+  the governance-drift guard. Super-Linter's Biome is aligned with
+  our pipeline's Biome via `biomejs/setup-biome@latest`.
 
 ## 4. Useful links
 
-- Closed issues this session: #142, #155, #157, #161 (and whatever
-  Phase 4's tracker lands as).
-- Open issues this session: #154 (local biome skew), docs-control#383
-  (upstream biome skew).
-- Roadmap file: `/home/vscode/.claude/plans/you-need-to-do-glimmering-beaver.md`
-- Pre-clean block: `.github/workflows/sync-and-enrich.yml:541-554`
-- Merge-poll script: `scripts/release/wait-for-merge.sh`
-- Governance guard: `scripts/verify_governance.py` +
-  `tests/test_verify_governance.py` + new CI step in
-  `.github/workflows/tests.yml`.
+- Closed this session: #142, #154, #155, #157, #161, #164, #167,
+  #169, #172, #175.
+- Still open: docs-control#383 (upstream cosmetic).
+- Roadmap file:
+  `/home/vscode/.claude/plans/you-need-to-do-glimmering-beaver.md`
+  (historical — the roadmap landed in full).
+- Workflow artefacts: `.github/workflows/sync-and-enrich.yml:541-554`
+  (pre-clean), `scripts/release/wait-for-merge.sh` (merge-poll),
+  `scripts/verify_governance.py` (governance guard),
+  `scripts/hooks/pre-commit-pipeline.sh` (idempotent hook).


### PR DESCRIPTION
## Summary

Rewrites `HANDOFF.md` end-to-end so the session resume state matches the current main HEAD (`1c95108`). The prior refresh (PR #165) was taken at `be3e0b5` and predates four followup PRs.

Covers:

- **§0 status table** — 9 merged PRs including #168, #171, #174, #176.
- **§1 what-shipped** — one subsection per PR (§1.1..§1.9), in merge order.
- **§2 still-open followups** — docs-control#383 (cosmetic), Phase-3 deferred guards (stale-tag-without-branch, concurrent-run tag race), codespell path-shape governance.
- **§3 ground rules** — persistent constraints, including the new "pre-commit idempotency now works" note.
- **§4 useful links** — reference artefacts + what remains open.

Closes #177

## Notes

- Final bookkeeping PR of the session — Markdown-only edit.
- No pipeline run, no code execution, no test changes.
- PR #168's idempotency skip engaged on this commit (confirmed: "No pipeline inputs staged — skipping enrichment + lint." path fired in ~6ms).
- Auto-merge NOT enabled.

## Test plan

- [x] Local `codespell HANDOFF.md` clean
- [x] Local `markdownlint HANDOFF.md` silent
- [x] Local `pre-commit run --files HANDOFF.md` (SKIP=super-linter) all green
- [ ] CI `Check linked issues` passes (links issue #177)
- [ ] CI `Lint Code Base` (super-linter MARKDOWN) passes