### PR TITLE
fix: add frontmatter to catalog.md for Starlight schema

### DIFF
--- a/docs/extensions/catalog.md
+++ b/docs/extensions/catalog.md
@@ -1,3 +1,8 @@
+---
+title: "Enrichment Extension Catalog"
+description: "Source of truth for every x-* extension in the enriched OpenAPI specifications"
+---
+
 # Enrichment Extension Catalog
 
 Source of truth for every `x-*` extension that appears in


### PR DESCRIPTION
Add YAML frontmatter with `title` field to `docs/extensions/catalog.md` so it passes Starlight's `docsSchema()` validation.

Refs f5xc-salesdemos/xcsh#223