### PR TITLE
fix(ci): exempt docs-control sync branches from verify_governance

### DIFF
--- a/scripts/verify_governance.py
+++ b/scripts/verify_governance.py
@@ -26,11 +26,24 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 DEFAULT_GOVERNANCE_JSON = Path(".claude/governance.json")
+
+# Branches created by the docs-control sync-managed-files workflow carry
+# the very files this check would otherwise reject. Exempt them by prefix;
+# the sync is the authorized upstream channel, so blocking it would self-
+# block every consumer every time docs-control updates a managed file.
+SYNC_BRANCH_PREFIXES = ("governance/sync-managed-files",)
+
+
+def _is_governance_sync_branch() -> bool:
+    """Return True when running on a PR from the managed-files sync bot."""
+    head_ref = os.environ.get("GITHUB_HEAD_REF", "")
+    return any(head_ref.startswith(prefix) for prefix in SYNC_BRANCH_PREFIXES)
 
 
 class GovernanceViolationError(RuntimeError):
@@ -99,6 +112,11 @@ def main(argv: list[str] | None = None) -> int:
         help="Path to governance.json (default: .claude/governance.json)",
     )
     args = parser.parse_args(argv)
+
+    if _is_governance_sync_branch():
+        head_ref = os.environ.get("GITHUB_HEAD_REF", "")
+        print(f"ok: skipping governance check on sync branch {head_ref}")
+        return 0
 
     try:
         violations = verify(args.base, args.head, args.governance_json)


### PR DESCRIPTION
## Summary

Exempts the authorized `governance/sync-managed-files` branches (created by docs-control's sync workflow) from verify_governance's protected-files check. Without this, every docs-control sync PR self-blocks on the very files it's authorized to propagate.

## Impact

Unblocks currently-stuck PR #202 (biome.json 2.4.12 sync from f5xc-salesdemos/docs-control#396).

## Test plan

- [x] Local: `GITHUB_HEAD_REF=governance/sync-managed-files python -m scripts.verify_governance --base HEAD --head HEAD` → "ok: skipping governance check on sync branch ..."
- [x] Local: no env var, normal path → unchanged behavior
- [x] Local: ruff check + format clean
- [ ] CI: all checks green

Closes #203