### PR TITLE
fix(tests): isolate test_verify_governance from CI sync-branch env

### DIFF
--- a/tests/test_verify_governance.py
+++ b/tests/test_verify_governance.py
@@ -30,6 +30,19 @@ def _run(cmd: list[str], cwd: Path) -> None:
     subprocess.run(cmd, cwd=cwd, check=True, capture_output=True)
 
 
+@pytest.fixture(autouse=True)
+def _clear_sync_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Isolate tests from CI's GITHUB_HEAD_REF.
+
+    `scripts.verify_governance.main` short-circuits when the env var
+    matches the sync-branch prefix. CI on the docs-control sync PR
+    sets GITHUB_HEAD_REF=governance/sync-managed-files, which would
+    make every `main()` test here return 0 regardless of the scenario
+    under test.
+    """
+    monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)
+
+
 @pytest.fixture
 def repo(tmp_path: Path) -> Path:
     """A minimal git repo with one commit on main and a branch with two changes.


### PR DESCRIPTION
## Summary

PR #204 added a `GITHUB_HEAD_REF` short-circuit to `scripts.verify_governance.main` so docs-control sync PRs don't self-block. The test fixtures inherit CI's env, so when this suite runs on a sync-branch PR, every `main()` test returns 0 regardless of its scenario — masking real regressions.

Observed in PR #202 CI: `Run pytest suite` failed with
- `test_exit_one_when_violation` (expected rc=1, got 0)
- `test_exit_two_on_missing_manifest` (expected rc=2, got 0)

## Fix

Add autouse fixture `_clear_sync_env` that `monkeypatch.delenv("GITHUB_HEAD_REF", raising=False)` for every test in the module. Tests now pass regardless of the CI branch name.

Closes #206

## Test plan

- [x] Local: `GITHUB_HEAD_REF=governance/sync-managed-files pytest -o addopts= tests/test_verify_governance.py -q` → 8 passed
- [x] ruff check + format clean
- [ ] CI: pytest suite green