### PR TITLE
fix(ci): raise release auto-merge timeout to 30 min

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -601,11 +601,14 @@ jobs:
             gh pr merge "$BRANCH" --squash --auto --delete-branch
 
             # Wait for PR to merge with exponential backoff (60 s warm-up + up
-            # to 15 min total). Replaces a prior hardcoded 30×10 s loop that
-            # timed out whenever Super-Linter ran longer than 5 min, leaving
-            # the release PR orphaned. Exits non-zero on CLOSED-without-merge
-            # or on timeout; emits diagnostic JSON to stderr on failure.
-            bash scripts/release/wait-for-merge.sh "$BRANCH"
+            # to 30 min total). The 30-min ceiling accommodates the enforcing
+            # Contract-diff gate which runs the full enrichment pipeline
+            # (~21 min) as the long-pole check. Replaces a prior hardcoded
+            # 30×10 s loop that timed out whenever Super-Linter ran longer
+            # than 5 min, leaving the release PR orphaned. Exits non-zero on
+            # CLOSED-without-merge or on timeout; emits diagnostic JSON to
+            # stderr on failure.
+            WAIT_FOR_MERGE_MAX_TOTAL=1800 bash scripts/release/wait-for-merge.sh "$BRANCH"
 
             # Switch back to main and pull the merge commit
             git checkout main


### PR DESCRIPTION
## Summary

The enforcing Contract-diff gate (PR #199, merged 2026-04-23) runs the full enrichment pipeline as the long-pole check on release PRs, taking ~21 minutes. `scripts/release/wait-for-merge.sh` defaults to a 15-min (900s) ceiling — every sync-and-enrich run times out before the release PR merges, skipping the tag + release creation steps.

Evidence: runs 24815889684 and 24816937771 both timed out at 900s with the Contract-diff gate still in progress.

## Fix

Pass `WAIT_FOR_MERGE_MAX_TOTAL=1800` (30 min) when invoking `wait-for-merge.sh` in `.github/workflows/sync-and-enrich.yml`. 30 min is the 21-min gate runtime plus 9-min headroom for Super-Linter, pytest, and transient delays.

No changes to the script itself — just bumps the per-workflow override.

Closes #208

## Test plan

- [ ] CI: all required checks pass
- [ ] After merge: trigger sync-and-enrich.yml manually; verify release PR auto-merges and tag is created