### PR TITLE
feat(#252): add schema_components and api_paths to x-f5xc-primary-resources

### DIFF
--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -471,8 +471,31 @@ index_level:
     type: array
     items: object
     purpose: Primary resource metadata for the domain
-    consumers: [mcp, cli, ide]
+    consumers: [mcp, cli, ide, terraform, vscode]
     migrated_from: "primary_resources"
+    item_fields:
+      name: {type: string, purpose: "Resource identifier (e.g. http_loadbalancer)"}
+      description: {type: string, purpose: "Long description"}
+      description_short: {type: string, purpose: "Short label (max 60 chars)"}
+      tier: {type: string, purpose: "Required subscription tier"}
+      icon: {type: string, purpose: "Emoji icon"}
+      category: {type: string, purpose: "Resource category"}
+      supports_logs: {type: boolean, purpose: "Whether resource emits logs"}
+      supports_metrics: {type: boolean, purpose: "Whether resource emits metrics"}
+      dependencies: {type: object, purpose: "required/optional dependency lists"}
+      relationship_hints: {type: array, items: string, purpose: "Human-readable relationship descriptions"}
+      schema_components:
+        type: array
+        items: string
+        purpose: "Dotted operationId component names (e.g. views.http_loadbalancer). Empty array for conceptual resources."
+        consumers: [mcp, cli, ide, terraform, vscode]
+        example: ["views.http_loadbalancer"]
+      api_paths:
+        type: array
+        items: string
+        purpose: "Primary CRUD path patterns with {namespace} placeholder. Empty array for conceptual resources."
+        consumers: [mcp, cli, ide, terraform, vscode]
+        example: ["/api/config/namespaces/{namespace}/http_loadbalancers"]
 
   x-f5xc-description-short:
     type: string

--- a/config/resource_metadata.yaml
+++ b/config/resource_metadata.yaml
@@ -112,6 +112,9 @@ resources:
         - healthcheck
     relationship_hints:
       - "healthcheck: Monitor origin server health"
+    # In service_mesh - actual API is in virtual domain
+    schema_components: []
+    api_paths: []
 
   healthcheck:
     description: "Health monitoring configuration for origin server availability"
@@ -169,6 +172,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual resource - no direct API CRUD; detection is configured via http_loadbalancer settings
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # dns domain
@@ -261,6 +267,9 @@ resources:
       optional: []
     relationship_hints:
       - "site: Sites to include in mesh connectivity"
+    # In network/sites - actual API is in service_mesh domain
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # cloud_infrastructure domain
@@ -279,6 +288,9 @@ resources:
       optional: []
     relationship_hints:
       - "cloud_credentials: AWS authentication for deployment"
+    # In cloud_infrastructure - actual API is in sites domain
+    schema_components: []
+    api_paths: []
 
   azure_vnet_site:
     description: "Azure VNet site deployment with edge node provisioning"
@@ -294,6 +306,9 @@ resources:
       optional: []
     relationship_hints:
       - "cloud_credentials: Azure authentication for deployment"
+    # In cloud_infrastructure - actual API is in sites domain
+    schema_components: []
+    api_paths: []
 
   gcp_vpc_site:
     description: "Google Cloud VPC site deployment with edge node provisioning"
@@ -309,6 +324,9 @@ resources:
       optional: []
     relationship_hints:
       - "cloud_credentials: GCP authentication for deployment"
+    # In cloud_infrastructure - actual API is in sites domain
+    schema_components: []
+    api_paths: []
 
   cloud_credentials:
     description: "Cloud provider authentication credentials for site deployment"
@@ -386,6 +404,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - CDN origins configured within cdn_loadbalancer
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # network domain
@@ -481,6 +502,10 @@ resources:
         - api_rate_limit
     relationship_hints:
       - "api_rate_limit: Rate limiting for this endpoint"
+    schema_components: ['api_group_element']
+    api_paths:
+      - "/api/web/namespaces/{namespace}/api_group_elements"
+      - "/api/web/namespaces/{namespace}/api_group_elements/{name}"
 
   api_rate_limit:
     description: "API rate limiting configuration for traffic control"
@@ -494,6 +519,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - rate limiting configured via rate_limiter_policy
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # network_security domain
@@ -565,6 +593,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['trusted_ca_list']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/trusted_ca_lists"
+      - "/api/config/namespaces/{metadata.namespace}/trusted_ca_lists/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/trusted_ca_lists"
+      - "/api/config/namespaces/{namespace}/trusted_ca_lists/{name}"
 
   certificate_chain:
     description: "Certificate chain for complete trust verification"
@@ -609,6 +643,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['policer']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/policers"
+      - "/api/config/namespaces/{metadata.namespace}/policers/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/policers"
+      - "/api/config/namespaces/{namespace}/policers/{name}"
 
   rate_limit_threshold:
     description: "Rate limit threshold configuration for traffic control"
@@ -622,6 +662,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['protocol_policer']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/protocol_policers"
+      - "/api/config/namespaces/{metadata.namespace}/protocol_policers/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/protocol_policers"
+      - "/api/config/namespaces/{namespace}/protocol_policers/{name}"
 
   # ===========================================================================
   # container_services domain
@@ -668,6 +714,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - use k8s_pod_security_policy in managed_kubernetes
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # managed_kubernetes domain
@@ -686,6 +735,9 @@ resources:
         - k8s_cluster_role
     relationship_hints:
       - "k8s_cluster_role: RBAC roles for cluster access"
+    # Conceptual - managed via sites and k8s_cluster resources
+    schema_components: []
+    api_paths: []
 
   k8s_cluster_role:
     description: "Kubernetes cluster RBAC role configuration"
@@ -741,6 +793,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - service discovery via app_type and app_setting
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # observability domain
@@ -757,6 +812,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # In observability - actual CRUD API is in statistics domain
+    schema_components: []
+    api_paths: []
 
   metrics_receiver:
     description: "Metrics receiver for centralized metrics collection"
@@ -770,6 +828,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - metrics collection via observability subscription
+    schema_components: []
+    api_paths: []
 
   alert_policy:
     description: "Alert policy for monitoring and notification"
@@ -783,6 +844,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # In observability - actual CRUD API is in statistics domain
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # authentication domain
@@ -799,6 +863,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - authentication configured via OIDC/OAuth providers
+    schema_components: []
+    api_paths: []
 
   token:
     description: "API token for programmatic access"
@@ -812,6 +879,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual in authentication - token CRUD is in users domain
+    schema_components: []
+    api_paths: []
 
   api_credential:
     description: "API credential for service authentication"
@@ -843,6 +913,9 @@ resources:
         - user_role
     relationship_hints:
       - "user_role: Role assignment for user permissions"
+    # Conceptual - user management via tenant_and_identity domain
+    schema_components: []
+    api_paths: []
 
   user_role:
     description: "User role for permission management"
@@ -856,6 +929,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - roles managed via tenant_and_identity role APIs
+    schema_components: []
+    api_paths: []
 
   namespace_role:
     description: "Namespace-scoped role for fine-grained permissions"
@@ -869,6 +945,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - namespace roles via tenant_and_identity
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # blindfold domain
@@ -885,6 +964,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - secrets managed via secret_policy
+    schema_components: []
+    api_paths: []
 
   secret_policy:
     description: "Secret management policy configuration"
@@ -911,6 +993,10 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['secret_management']
+    api_paths:
+      - "/api/secret_management/get_public_key"
+      - "/api/secret_management/namespaces/{namespace}/secret_policys/{name}/get_policy_document"
 
   # ===========================================================================
   # ddos domain
@@ -929,6 +1015,31 @@ resources:
         - ddos_mitigation_rule
     relationship_hints:
       - "ddos_mitigation_rule: Custom mitigation rules"
+    schema_components: ['infraprotect']
+    api_paths:
+      - "/api/data/namespaces/{namespace}/infraprotect/bgp_peer_status"
+      - "/api/data/namespaces/{namespace}/infraprotect/transit_usage"
+      - "/api/infraprotect/namespaces/system/infraprotect/access"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/alert/{alert_id}"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/alert/{alert_id}/to_event"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/alerts"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/event/{event_id}"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/event/{event_id}/alerts"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/event/{event_id}/attachments"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/event/{event_id}/detail/{event_detail_id}"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/event/{event_id}/details"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/event/{event_id}/mitigation_annotations"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/events"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/events_summary"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/mitigation/{mitigation_id}"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/mitigation/{mitigation_id}/annotations"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/mitigation/{mitigation_id}/countermeasures"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/mitigation/{mitigation_id}/ips"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/mitigations"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/networks"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/report/{report_id}"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect/reports"
+      - "/api/infraprotect/namespaces/{namespace}/suggest-values"
 
   ddos_mitigation_rule:
     description: "DDoS mitigation rule for attack response"
@@ -942,6 +1053,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['infraprotect_firewall_rule']
+    api_paths:
+      - "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_firewall_rules"
+      - "/api/infraprotect/namespaces/{metadata.namespace}/infraprotect_firewall_rules/{metadata.name}"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rules"
+      - "/api/infraprotect/namespaces/{namespace}/infraprotect_firewall_rules/{name}"
 
   # ===========================================================================
   # shape domain
@@ -958,6 +1075,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - Shape WAF via protected_application config
+    schema_components: []
+    api_paths: []
 
   shape_recognizer:
     description: "Shape recognizer for traffic pattern analysis"
@@ -971,6 +1091,22 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['shape.recognize']
+    api_paths:
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/channel"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/conversion"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/enjoy"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/friction_aggregation"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/friction_histogram"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/health"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/lift"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/rescue"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/dashboard/top_reason_code"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/provision"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/state"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/subscribe"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/unsubscribe"
+      - "/api/shape/recognize/namespaces/system/recognize/addon/validate/src_tag_injection"
 
   # ===========================================================================
   # threat_campaign domain
@@ -987,6 +1123,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['app_security']
+    api_paths:
+      - "/api/waf/threat_campaign/{id}"
 
   # ===========================================================================
   # support domain
@@ -1003,6 +1142,20 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['customer_support']
+    api_paths:
+      - "/api/web/namespaces/system/child_tenant/support_tickets"
+      - "/api/web/namespaces/system/customer_support/tax_exempt_request"
+      - "/api/web/namespaces/system/customer_support/{name}/comment/{comment_id}/attachment/{attachment_id}"
+      - "/api/web/namespaces/{metadata.namespace}/customer_supports"
+      - "/api/web/namespaces/{namespace}/admin/customer_supports"
+      - "/api/web/namespaces/{namespace}/customer_support/{name}/close"
+      - "/api/web/namespaces/{namespace}/customer_support/{name}/comment"
+      - "/api/web/namespaces/{namespace}/customer_support/{name}/escalate"
+      - "/api/web/namespaces/{namespace}/customer_support/{name}/priority"
+      - "/api/web/namespaces/{namespace}/customer_support/{name}/reopen"
+      - "/api/web/namespaces/{namespace}/customer_supports"
+      - "/api/web/namespaces/{namespace}/customer_supports/{name}"
 
   alert:
     description: "System alert for operational notifications"
@@ -1016,6 +1169,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # In support - alerts are read-only data, use alert_policy for config
+    schema_components: []
+    api_paths: []
 
   audit_log:
     description: "Audit log for compliance and security tracking"
@@ -1029,6 +1185,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Read-only - audit logs accessed via data API endpoints
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # system domain
@@ -1089,6 +1248,9 @@ resources:
         - saved_query
     relationship_hints:
       - "saved_query: Queries displayed on dashboard"
+    # Conceptual - dashboards via console UI, no direct CRUD API
+    schema_components: []
+    api_paths: []
 
   saved_query:
     description: "Saved query for metrics and log analysis"
@@ -1102,6 +1264,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - saved queries via console UI, no direct CRUD API
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # billing_and_usage / billing domains
@@ -1118,6 +1283,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['pbac.addon_subscription']
+    api_paths:
+      - "/api/web/namespaces/{metadata.namespace}/addon_subscriptions"
+      - "/api/web/namespaces/{metadata.namespace}/addon_subscriptions/{metadata.name}"
+      - "/api/web/namespaces/{namespace}/addon_subscriptions"
+      - "/api/web/namespaces/{namespace}/addon_subscriptions/{name}"
 
   quota:
     description: "Resource quota for usage limits"
@@ -1144,6 +1315,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['usage']
+    api_paths:
+      - "/api/web/namespaces/{namespace}/current_usage"
+      - "/api/web/namespaces/{namespace}/hourly_usage_details"
+      - "/api/web/namespaces/{namespace}/monthly_usage"
+      - "/api/web/namespaces/{namespace}/usage_details"
 
   invoice:
     description: "Invoice for billing records"
@@ -1186,6 +1363,10 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['ui.static_component']
+    api_paths:
+      - "/api/web/namespaces/{namespace}/static_components"
+      - "/api/web/namespaces/{namespace}/static_components/{name}"
 
   static_asset:
     description: "Static asset for UI resources"
@@ -1199,6 +1380,10 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['ui.static_component']
+    api_paths:
+      - "/api/web/namespaces/{namespace}/static_components"
+      - "/api/web/namespaces/{namespace}/static_components/{name}"
 
   global_setting:
     description: "Global setting for system-wide configuration"
@@ -1241,6 +1426,21 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['user.setting']
+    api_paths:
+      - "/api/web/namespaces/system/user/admin_notifications"
+      - "/api/web/namespaces/system/user/admin_notifications/unset"
+      - "/api/web/namespaces/system/user/combined_notifications"
+      - "/api/web/namespaces/system/user/notifications"
+      - "/api/web/namespaces/system/user/notifications/unset"
+      - "/api/web/namespaces/system/user/otp/admin_reset"
+      - "/api/web/namespaces/system/user/sessions"
+      - "/api/web/namespaces/system/user/settings"
+      - "/api/web/namespaces/system/user/settings/idm/disable"
+      - "/api/web/namespaces/system/user/settings/idm/enable"
+      - "/api/web/namespaces/system/user/settings/image"
+      - "/api/web/namespaces/system/user/settings/request_initial_access"
+      - "/api/web/namespaces/system/user/settings/view_preference"
 
   session:
     description: "User session for authentication state"
@@ -1254,6 +1454,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Read-only - sessions accessed via user.setting endpoints
+    schema_components: []
+    api_paths: []
 
   otp_policy:
     description: "OTP policy for multi-factor authentication"
@@ -1267,6 +1470,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - OTP settings via tenant configuration
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # marketplace domain
@@ -1283,6 +1489,13 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['pbac.addon_service']
+    api_paths:
+      - "/api/web/custom/namespaces/shared/addon_services/{name}"
+      - "/api/web/namespaces/system/addon_services/{addon_service}/activation-status"
+      - "/api/web/namespaces/system/addon_services/{addon_service}/all-activation-status"
+      - "/api/web/namespaces/{namespace}/addon_services"
+      - "/api/web/namespaces/{namespace}/addon_services/{name}"
 
   # ===========================================================================
   # bigip domain
@@ -1299,6 +1512,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - BIG-IP pools managed via views.bigip_http_proxy
+    schema_components: []
+    api_paths: []
 
   bigip_device:
     description: "BIG-IP device registration and management"
@@ -1312,6 +1528,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - BIG-IP devices managed via views.bigip_virtual_server
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # nginx_one domain
@@ -1330,6 +1549,10 @@ resources:
         - nginx_upstream
     relationship_hints:
       - "nginx_upstream: Backend server configuration"
+    schema_components: ['nginx.one.nginx_csg']
+    api_paths:
+      - "/api/config/namespaces/{namespace}/nginx_csgs"
+      - "/api/config/namespaces/{namespace}/nginx_csgs/{name}"
 
   nginx_upstream:
     description: "NGINX upstream for backend server pools"
@@ -1343,6 +1566,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - upstreams configured within nginx_service_discovery
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # ai_services domain
@@ -1359,6 +1585,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - AI policy settings via console, no direct CRUD API
+    schema_components: []
+    api_paths: []
 
   ai_gateway:
     description: "AI gateway for LLM API management"
@@ -1374,6 +1603,9 @@ resources:
         - ai_policy
     relationship_hints:
       - "ai_policy: Policy for AI traffic control"
+    # Conceptual - AI gateway settings via console, no direct CRUD API
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # object_storage domain
@@ -1392,6 +1624,17 @@ resources:
         - bucket
     relationship_hints:
       - "bucket: Storage buckets in this store"
+    schema_components: ['stored_object']
+    api_paths:
+      - "/api/object_store/namespaces/{namespace}/stored_objects/mobile-app-shield"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/mobile-app-shield/{name}/{version}"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/mobile-integrator"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/mobile-integrator/{name}/{version}"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/mobile-sdk-self-serve"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/mobile-sdk-self-serve/{name}/{version}"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/{object_type}"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/{object_type}/{name}"
+      - "/api/object_store/namespaces/{namespace}/stored_objects/{object_type}/{name}/{version}"
 
   bucket:
     description: "Storage bucket for object storage"
@@ -1407,6 +1650,9 @@ resources:
       optional: []
     relationship_hints:
       - "object_store: Parent object store"
+    # Conceptual - buckets are object_type within stored_object paths
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # bot_and_threat_defense domain
@@ -1423,6 +1669,10 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['shape_bot_defense_instance']
+    api_paths:
+      - "/api/config/namespaces/{namespace}/shape_bot_defense_instances"
+      - "/api/config/namespaces/{namespace}/shape_bot_defense_instances/{name}"
 
   threat_category:
     description: "Threat category for classification"
@@ -1436,6 +1686,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['tpm_category']
+    api_paths:
+      - "/api/tpm/namespaces/{metadata.namespace}/tpm_categorys"
+      - "/api/tpm/namespaces/{metadata.namespace}/tpm_categorys/{metadata.name}"
+      - "/api/tpm/namespaces/{namespace}/tpm_categorys"
+      - "/api/tpm/namespaces/{namespace}/tpm_categorys/{name}"
 
   # ===========================================================================
   # ce_management domain
@@ -1452,6 +1708,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - site settings distributed across fleet and registration
+    schema_components: []
+    api_paths: []
 
   fleet_config:
     description: "Fleet configuration for multi-site management"
@@ -1465,6 +1724,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['fleet']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/fleets"
+      - "/api/config/namespaces/{metadata.namespace}/fleets/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/fleets"
+      - "/api/config/namespaces/{namespace}/fleets/{name}"
 
   registration_token:
     description: "Registration token for site onboarding"
@@ -1478,6 +1743,20 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['registration']
+    api_paths:
+      - "/api/register/namespaces/system/get-image-download-url"
+      - "/api/register/namespaces/system/get-registrations-by-token"
+      - "/api/register/namespaces/system/suggest-values"
+      - "/api/register/namespaces/{metadata.namespace}/registrations"
+      - "/api/register/namespaces/{metadata.namespace}/registrations/{metadata.name}"
+      - "/api/register/namespaces/{namespace}/listregistrationsbystate"
+      - "/api/register/namespaces/{namespace}/registration/{name}/approve"
+      - "/api/register/namespaces/{namespace}/registrations"
+      - "/api/register/namespaces/{namespace}/registrations/{name}"
+      - "/api/register/namespaces/{namespace}/registrations_by_site/{site_name}"
+      - "/api/register/registerBootstrap"
+      - "/api/register/requestConfig"
 
   # ===========================================================================
   # data_and_privacy_security domain
@@ -1507,6 +1786,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['data_type']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/data_types"
+      - "/api/config/namespaces/{metadata.namespace}/data_types/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/data_types"
+      - "/api/config/namespaces/{namespace}/data_types/{name}"
 
   # ===========================================================================
   # secops_and_incident_response domain
@@ -1523,6 +1808,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['malicious_user_mitigation']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations"
+      - "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/malicious_user_mitigations"
+      - "/api/config/namespaces/{namespace}/malicious_user_mitigations/{name}"
 
   malicious_user_rule:
     description: "Malicious user rule for threat mitigation"
@@ -1536,6 +1827,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['malicious_user_mitigation']
+    api_paths:
+      - "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations"
+      - "/api/config/namespaces/{metadata.namespace}/malicious_user_mitigations/{metadata.name}"
+      - "/api/config/namespaces/{namespace}/malicious_user_mitigations"
+      - "/api/config/namespaces/{namespace}/malicious_user_mitigations/{name}"
 
   # ===========================================================================
   # vpm_and_node_management domain
@@ -1552,6 +1849,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - node config via fleet and site management
+    schema_components: []
+    api_paths: []
 
   vpm_config:
     description: "VPM configuration for virtual platform management"
@@ -1565,6 +1865,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - VPM config via site management APIs
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # client_side_defense domain
@@ -1610,6 +1913,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - telemetry via flow subscription and graph services
+    schema_components: []
+    api_paths: []
 
   insight_query:
     description: "Insight query for analytics"
@@ -1623,6 +1929,9 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    # Conceptual - insights via graph.service and data endpoints
+    schema_components: []
+    api_paths: []
 
   # ===========================================================================
   # data_intelligence domain
@@ -1639,6 +1948,17 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['shape.data_delivery']
+    api_paths:
+      - "/api/data-intelligence/namespaces/system/dataSets"
+      - "/api/data-intelligence/namespaces/system/datadictionary/{dataset}"
+      - "/api/data-intelligence/namespaces/system/init-request"
+      - "/api/data-intelligence/namespaces/{namespace}/data-dictionary/datasets"
+      - "/api/data-intelligence/namespaces/{namespace}/di/flowlabels"
+      - "/api/data-intelligence/namespaces/{namespace}/di/summary"
+      - "/api/data-intelligence/namespaces/{namespace}/receivers/{id}/status"
+      - "/api/data-intelligence/namespaces/{namespace}/receivers/{id}/test"
+      - "/api/data-intelligence/namespaces/{namespace}/suggest-values"
 
   data_export:
     description: "Data export configuration for reporting"
@@ -1652,6 +1972,12 @@ resources:
       required: []
       optional: []
     relationship_hints: []
+    schema_components: ['shape.data_delivery.receiver']
+    api_paths:
+      - "/api/data-intelligence/namespaces/{metadata.namespace}/receivers"
+      - "/api/data-intelligence/namespaces/{metadata.namespace}/receivers/{metadata.name}"
+      - "/api/data-intelligence/namespaces/{namespace}/receivers"
+      - "/api/data-intelligence/namespaces/{namespace}/receivers/{name}"
 
   # ===========================================================================
   # label domain

--- a/scripts/discover_resources.py
+++ b/scripts/discover_resources.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Discover unresolvable resources and print candidate components for manual annotation.
+
+Loads merged specs from docs/specifications/api/. Run this before populating
+config/resource_metadata.yaml to see which resources need manual entries.
+
+Usage: PYTHONPATH=. python scripts/discover_resources.py
+"""
+
+import json
+import sys
+from pathlib import Path
+
+from scripts.utils.domain_metadata import DOMAIN_PRIMARY_RESOURCES, _load_resource_metadata
+from scripts.utils.resource_resolver import _get_all_path_components, resolve_resource
+
+
+def main() -> None:
+    """Print unresolvable resources with candidate components."""
+    specs_dir = Path(__file__).parent.parent / "docs" / "specifications" / "api"
+    resource_config = _load_resource_metadata()
+    unresolvable_count = 0
+
+    for domain, resource_names in sorted(DOMAIN_PRIMARY_RESOURCES.items()):
+        spec_file = specs_dir / f"{domain}.json"
+        if not spec_file.exists():
+            print(f"# SKIP: {domain}.json not found (run make all first)", flush=True)
+            continue
+        with spec_file.open() as f:
+            spec = json.load(f)
+        domain_paths = spec.get("paths", {})
+        all_components = sorted(_get_all_path_components(domain_paths))
+        for name in resource_names:
+            entry = resource_config.get(name, {})
+            if "schema_components" in entry or "api_paths" in entry:
+                continue
+            schema_comps, _ = resolve_resource(name, domain_paths)
+            if schema_comps:
+                continue
+            unresolvable_count += 1
+            print(f"\ndomain: {domain}")
+            print(f"resource: {name}")
+            print("  heuristic: empty (no operationId match)")
+            print("  candidate components from domain operationIds:")
+            for comp in all_components[:8]:
+                print(f"    - {comp}")
+            if len(all_components) > 8:
+                print(f"    ... ({len(all_components) - 8} more)")
+            print("  stub:")
+            print(f"    {name}:")
+            print("      schema_components: []  # fill in from candidates above")
+            print("      api_paths: []          # fill in matching path patterns")
+    print(f"\n# Total unresolvable resources: {unresolvable_count}")
+
+
+if __name__ == "__main__":
+    main()
+    sys.exit(0)

--- a/scripts/pipeline.py
+++ b/scripts/pipeline.py
@@ -1396,7 +1396,7 @@ def create_spec_index(domain_specs: dict[str, dict[str, Any]], version: str) -> 
         # Get icon and primary resources for the domain
         icon_info = get_domain_icon(domain)
         # Rich metadata format for IDE tooling (Issues #267-270)
-        primary_resources_metadata = get_primary_resources_metadata(domain)
+        primary_resources_metadata = get_primary_resources_metadata(domain, spec=spec)
 
         # Build spec entry with x-f5xc-* namespace (Issue #292)
         spec_entry = {

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -334,9 +334,7 @@ def get_primary_resources_metadata(
     domain_paths = spec.get("paths", {})
     resource_config = _load_resource_metadata()
 
-    heuristic_results = {
-        name: resolve_resource(name, domain_paths) for name in resource_names
-    }
+    heuristic_results = {name: resolve_resource(name, domain_paths) for name in resource_names}
 
     # Only apply config overrides where the heuristic returned empty.
     # Resource names can appear in multiple domains (e.g. origin_pool in
@@ -347,18 +345,14 @@ def get_primary_resources_metadata(
         name: resource_config[name]
         for name in resource_names
         if name in resource_config
-        and (
-            "schema_components" in resource_config[name]
-            or "api_paths" in resource_config[name]
-        )
+        and ("schema_components" in resource_config[name] or "api_paths" in resource_config[name])
         and not heuristic_results[name][0]
     }
 
     errors = validate_resource_mappings(heuristic_results, config_overrides, domain_paths, domain)
     if errors:
         raise ValueError(
-            f"Resource mapping validation failed for domain '{domain}':\n"
-            + "\n".join(errors)
+            f"Resource mapping validation failed for domain '{domain}':\n" + "\n".join(errors)
         )
 
     for resource in resources:

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -364,8 +364,14 @@ def get_primary_resources_metadata(
     for resource in resources:
         name = resource["name"]
         heuristic = heuristic_results.get(name, ([], []))
-        override_entry = resource_config.get(name, {})
-        schema_components, api_paths = apply_overrides(heuristic, override_entry)
+        if heuristic[0]:
+            # Heuristic resolved — use it directly, skip config override.
+            # This prevents a flat config entry from applying to domains
+            # where the heuristic already finds the correct mapping.
+            schema_components, api_paths = heuristic
+        else:
+            override_entry = resource_config.get(name, {})
+            schema_components, api_paths = apply_overrides(heuristic, override_entry)
         resource.update({"schema_components": schema_components, "api_paths": api_paths})
 
     return resources

--- a/scripts/utils/domain_metadata.py
+++ b/scripts/utils/domain_metadata.py
@@ -299,45 +299,76 @@ def get_resource_metadata(resource_name: str) -> dict[str, Any]:
     }
 
 
-def get_primary_resources_metadata(domain: str) -> list[dict[str, Any]]:
+def get_primary_resources_metadata(
+    domain: str,
+    spec: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
     """Get primary resources with full metadata for a domain.
 
-    Returns rich metadata objects instead of simple resource name strings.
-    This is used by create_spec_index() to generate per-resource metadata
-    in index.json for IDE tooling and CLI integration.
+    When spec is provided, adds 'schema_components' and 'api_paths' to each
+    resource dict by running the heuristic resolver and applying config overrides
+    from resource_metadata.yaml. When spec is None, these keys are absent
+    (backward compatibility for callers without spec data).
 
     Args:
         domain: The domain name (e.g., 'virtual', 'waf', 'dns')
+        spec: Full merged OpenAPI spec for the domain (optional).
+              When provided, schema_components and api_paths are resolved.
 
     Returns:
-        List of resource metadata dictionaries with structure:
-        {
-            "name": str,
-            "description": str,
-            "description_short": str,
-            "tier": str,
-            "icon": str,
-            "category": str,
-            "supports_logs": bool,
-            "supports_metrics": bool,
-            "dependencies": {"required": list, "optional": list},
-            "relationship_hints": list[str]
-        }
-
-    Example:
-        >>> get_primary_resources_metadata("virtual")
-        [
-            {
-                "name": "http_loadbalancer",
-                "description": "Layer 7 HTTP/HTTPS load balancer...",
-                "tier": "Standard",
-                ...
-            },
-            ...
-        ]
+        List of resource metadata dicts. With spec: includes schema_components
+        and api_paths. Without spec: only the original 10 fields.
     """
+    from scripts.utils.resource_resolver import (  # noqa: PLC0415
+        apply_overrides,
+        resolve_resource,
+        validate_resource_mappings,
+    )
+
     resource_names = DOMAIN_PRIMARY_RESOURCES.get(domain, [])
-    return [get_resource_metadata(name) for name in resource_names]
+    resources = [get_resource_metadata(name) for name in resource_names]
+
+    if spec is None:
+        return resources
+
+    domain_paths = spec.get("paths", {})
+    resource_config = _load_resource_metadata()
+
+    heuristic_results = {
+        name: resolve_resource(name, domain_paths) for name in resource_names
+    }
+
+    # Only apply config overrides where the heuristic returned empty.
+    # Resource names can appear in multiple domains (e.g. origin_pool in
+    # virtual and service_mesh). Restricting overrides to heuristic failures
+    # prevents a flat config entry from being validated/applied in domains
+    # where the heuristic already produces the correct result.
+    config_overrides = {
+        name: resource_config[name]
+        for name in resource_names
+        if name in resource_config
+        and (
+            "schema_components" in resource_config[name]
+            or "api_paths" in resource_config[name]
+        )
+        and not heuristic_results[name][0]
+    }
+
+    errors = validate_resource_mappings(heuristic_results, config_overrides, domain_paths, domain)
+    if errors:
+        raise ValueError(
+            f"Resource mapping validation failed for domain '{domain}':\n"
+            + "\n".join(errors)
+        )
+
+    for resource in resources:
+        name = resource["name"]
+        heuristic = heuristic_results.get(name, ([], []))
+        override_entry = resource_config.get(name, {})
+        schema_components, api_paths = apply_overrides(heuristic, override_entry)
+        resource.update({"schema_components": schema_components, "api_paths": api_paths})
+
+    return resources
 
 
 DOMAIN_METADATA = {

--- a/scripts/utils/resource_resolver.py
+++ b/scripts/utils/resource_resolver.py
@@ -54,7 +54,7 @@ def resolve_resource(
     matching_components: list[str] = []
     for comp in sorted(all_domain_components):
         last_segment = comp.rsplit(".", 1)[-1]
-        if last_segment == name or comp == name:
+        if name in (last_segment, comp):
             matching_components.append(comp)
 
     if not matching_components:
@@ -83,13 +83,9 @@ def apply_overrides(
     schema_components = config_entry.get("schema_components", heuristic[0])
     api_paths = config_entry.get("api_paths", heuristic[1])
     if not isinstance(schema_components, list):
-        raise TypeError(
-            f"schema_components must be a list, got {type(schema_components).__name__}"
-        )
+        raise TypeError(f"schema_components must be a list, got {type(schema_components).__name__}")
     if not isinstance(api_paths, list):
-        raise TypeError(
-            f"api_paths must be a list, got {type(api_paths).__name__}"
-        )
+        raise TypeError(f"api_paths must be a list, got {type(api_paths).__name__}")
     return schema_components, api_paths
 
 
@@ -114,16 +110,14 @@ def validate_resource_mappings(
                     f"got {type(entries).__name__}"
                 )
                 continue
-            if not entries:
-                pass
-            else:
-                for comp in entries:
-                    if comp not in all_components:
-                        errors.append(
-                            f"resource '{resource_name}': schema_component '{comp}' "
-                            f"not found in domain '{domain}' operationIds"
-                        )
-                if heuristic[0] and set(override_entry["schema_components"]) != set(heuristic[0]):
+            if entries:
+                errors.extend(
+                    f"resource '{resource_name}': schema_component '{comp}' "
+                    f"not found in domain '{domain}' operationIds"
+                    for comp in entries
+                    if comp not in all_components
+                )
+                if heuristic[0] and set(entries) != set(heuristic[0]):
                     logger.warning(
                         "resource '%s': config schema_components override replaces "
                         "heuristic result — entry may be redundant",
@@ -138,16 +132,14 @@ def validate_resource_mappings(
                     f"got {type(entries).__name__}"
                 )
                 continue
-            if not entries:
-                pass
-            else:
-                for path in entries:
-                    if path not in domain_paths:
-                        errors.append(
-                            f"resource '{resource_name}': api_path '{path}' "
-                            f"not found in domain '{domain}' paths"
-                        )
-                if heuristic[1] and set(override_entry["api_paths"]) != set(heuristic[1]):
+            if entries:
+                errors.extend(
+                    f"resource '{resource_name}': api_path '{path}' "
+                    f"not found in domain '{domain}' paths"
+                    for path in entries
+                    if path not in domain_paths
+                )
+                if heuristic[1] and set(entries) != set(heuristic[1]):
                     logger.warning(
                         "resource '%s': config api_paths override replaces "
                         "heuristic result — entry may be redundant",
@@ -160,7 +152,12 @@ def validate_resource_mappings(
 def _dry_run_discovery() -> None:
     """Print unresolvable resources with candidate components."""
     specs_dir = Path(__file__).parent.parent.parent / "docs" / "specifications" / "api"
-    from scripts.utils.domain_metadata import DOMAIN_PRIMARY_RESOURCES, _load_resource_metadata  # noqa: PLC0415
+
+    from scripts.utils.domain_metadata import (  # noqa: PLC0415
+        DOMAIN_PRIMARY_RESOURCES,
+        _load_resource_metadata,
+    )
+
     resource_config = _load_resource_metadata()
     unresolvable_count = 0
 
@@ -183,16 +180,16 @@ def _dry_run_discovery() -> None:
             unresolvable_count += 1
             print(f"\ndomain: {domain}")
             print(f"resource: {name}")
-            print(f"  heuristic: empty (no operationId match)")
-            print(f"  candidate components from domain operationIds:")
+            print("  heuristic: empty (no operationId match)")
+            print("  candidate components from domain operationIds:")
             for comp in all_components[:8]:
                 print(f"    - {comp}")
             if len(all_components) > 8:
                 print(f"    ... ({len(all_components) - 8} more)")
-            print(f"  stub:")
+            print("  stub:")
             print(f"    {name}:")
-            print(f"      schema_components: []  # fill in from candidates above")
-            print(f"      api_paths: []          # fill in matching path patterns")
+            print("      schema_components: []  # fill in from candidates above")
+            print("      api_paths: []          # fill in matching path patterns")
     print(f"\n# Total unresolvable resources: {unresolvable_count}")
 
 

--- a/scripts/utils/resource_resolver.py
+++ b/scripts/utils/resource_resolver.py
@@ -7,11 +7,8 @@ then ties path inclusion to schema resolution. Config overrides in resource_meta
 take precedence over heuristic results.
 """
 
-import json
 import logging
 import re
-import sys
-from pathlib import Path
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -147,55 +144,3 @@ def validate_resource_mappings(
                     )
 
     return errors
-
-
-def _dry_run_discovery() -> None:
-    """Print unresolvable resources with candidate components."""
-    specs_dir = Path(__file__).parent.parent.parent / "docs" / "specifications" / "api"
-
-    from scripts.utils.domain_metadata import (  # noqa: PLC0415
-        DOMAIN_PRIMARY_RESOURCES,
-        _load_resource_metadata,
-    )
-
-    resource_config = _load_resource_metadata()
-    unresolvable_count = 0
-
-    for domain, resource_names in sorted(DOMAIN_PRIMARY_RESOURCES.items()):
-        spec_file = specs_dir / f"{domain}.json"
-        if not spec_file.exists():
-            print(f"# SKIP: {domain}.json not found (run make all first)", flush=True)
-            continue
-        with spec_file.open() as f:
-            spec = json.load(f)
-        domain_paths = spec.get("paths", {})
-        all_components = sorted(_get_all_path_components(domain_paths))
-        for name in resource_names:
-            entry = resource_config.get(name, {})
-            if "schema_components" in entry or "api_paths" in entry:
-                continue
-            schema_comps, _ = resolve_resource(name, domain_paths)
-            if schema_comps:
-                continue
-            unresolvable_count += 1
-            print(f"\ndomain: {domain}")
-            print(f"resource: {name}")
-            print("  heuristic: empty (no operationId match)")
-            print("  candidate components from domain operationIds:")
-            for comp in all_components[:8]:
-                print(f"    - {comp}")
-            if len(all_components) > 8:
-                print(f"    ... ({len(all_components) - 8} more)")
-            print("  stub:")
-            print(f"    {name}:")
-            print("      schema_components: []  # fill in from candidates above")
-            print("      api_paths: []          # fill in matching path patterns")
-    print(f"\n# Total unresolvable resources: {unresolvable_count}")
-
-
-if __name__ == "__main__":
-    if "--dry-run" in sys.argv:
-        _dry_run_discovery()
-    else:
-        print("Usage: python scripts/utils/resource_resolver.py --dry-run")
-        sys.exit(1)

--- a/scripts/utils/resource_resolver.py
+++ b/scripts/utils/resource_resolver.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Resource resolver for mapping primary resource names to schema components and API paths.
+
+Uses operationId regex to extract dotted component names from merged domain specs,
+then ties path inclusion to schema resolution. Config overrides in resource_metadata.yaml
+take precedence over heuristic results.
+"""
+
+import json
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+OPERATIONID_REGEX = re.compile(r"ves\.io\.schema\.(.+?)\.(?:\w*API)\.")
+
+
+def _get_all_path_components(domain_paths: dict[str, Any]) -> set[str]:
+    """Extract all unique component names from operationIds across all paths."""
+    components: set[str] = set()
+    for path_item in domain_paths.values():
+        for method_item in path_item.values():
+            if not isinstance(method_item, dict):
+                continue
+            match = OPERATIONID_REGEX.match(method_item.get("operationId", ""))
+            if match:
+                components.add(match.group(1))
+    return components
+
+
+def _operationids_for_path(path_item: dict[str, Any]) -> set[str]:
+    """Extract component names from operationIds on a single path item."""
+    components: set[str] = set()
+    for method_item in path_item.values():
+        if not isinstance(method_item, dict):
+            continue
+        match = OPERATIONID_REGEX.match(method_item.get("operationId", ""))
+        if match:
+            components.add(match.group(1))
+    return components
+
+
+def resolve_resource(
+    name: str,
+    domain_paths: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Heuristic resolution. Returns (schema_components, api_paths)."""
+    all_domain_components = _get_all_path_components(domain_paths)
+
+    matching_components: list[str] = []
+    for comp in sorted(all_domain_components):
+        last_segment = comp.rsplit(".", 1)[-1]
+        if last_segment == name or comp == name:
+            matching_components.append(comp)
+
+    if not matching_components:
+        return [], []
+
+    matching_set = set(matching_components)
+    plural = f"{name}s"
+
+    matched_paths: list[str] = []
+    for path_str, path_item in domain_paths.items():
+        segments = path_str.split("/")
+        if name not in segments and plural not in segments:
+            continue
+        path_components = _operationids_for_path(path_item)
+        if path_components & matching_set:
+            matched_paths.append(path_str)
+
+    return matching_components, sorted(matched_paths)
+
+
+def apply_overrides(
+    heuristic: tuple[list[str], list[str]],
+    config_entry: dict[str, Any],
+) -> tuple[list[str], list[str]]:
+    """Apply config overrides to a heuristic result."""
+    schema_components = config_entry.get("schema_components", heuristic[0])
+    api_paths = config_entry.get("api_paths", heuristic[1])
+    if not isinstance(schema_components, list):
+        raise TypeError(
+            f"schema_components must be a list, got {type(schema_components).__name__}"
+        )
+    if not isinstance(api_paths, list):
+        raise TypeError(
+            f"api_paths must be a list, got {type(api_paths).__name__}"
+        )
+    return schema_components, api_paths
+
+
+def validate_resource_mappings(
+    heuristic_results: dict[str, tuple[list[str], list[str]]],
+    config_overrides: dict[str, dict[str, Any]],
+    domain_paths: dict[str, Any],
+    domain: str,
+) -> list[str]:
+    """Validate config overrides against the domain's actual operationIds and paths."""
+    errors: list[str] = []
+    all_components = _get_all_path_components(domain_paths)
+
+    for resource_name, override_entry in config_overrides.items():
+        heuristic = heuristic_results.get(resource_name, ([], []))
+
+        if "schema_components" in override_entry:
+            entries = override_entry["schema_components"]
+            if not isinstance(entries, list):
+                errors.append(
+                    f"resource '{resource_name}': schema_components must be a list, "
+                    f"got {type(entries).__name__}"
+                )
+                continue
+            if not entries:
+                pass
+            else:
+                for comp in entries:
+                    if comp not in all_components:
+                        errors.append(
+                            f"resource '{resource_name}': schema_component '{comp}' "
+                            f"not found in domain '{domain}' operationIds"
+                        )
+                if heuristic[0] and set(override_entry["schema_components"]) != set(heuristic[0]):
+                    logger.warning(
+                        "resource '%s': config schema_components override replaces "
+                        "heuristic result — entry may be redundant",
+                        resource_name,
+                    )
+
+        if "api_paths" in override_entry:
+            entries = override_entry["api_paths"]
+            if not isinstance(entries, list):
+                errors.append(
+                    f"resource '{resource_name}': api_paths must be a list, "
+                    f"got {type(entries).__name__}"
+                )
+                continue
+            if not entries:
+                pass
+            else:
+                for path in entries:
+                    if path not in domain_paths:
+                        errors.append(
+                            f"resource '{resource_name}': api_path '{path}' "
+                            f"not found in domain '{domain}' paths"
+                        )
+                if heuristic[1] and set(override_entry["api_paths"]) != set(heuristic[1]):
+                    logger.warning(
+                        "resource '%s': config api_paths override replaces "
+                        "heuristic result — entry may be redundant",
+                        resource_name,
+                    )
+
+    return errors
+
+
+def _dry_run_discovery() -> None:
+    """Print unresolvable resources with candidate components."""
+    specs_dir = Path(__file__).parent.parent.parent / "docs" / "specifications" / "api"
+    from scripts.utils.domain_metadata import DOMAIN_PRIMARY_RESOURCES, _load_resource_metadata  # noqa: PLC0415
+    resource_config = _load_resource_metadata()
+    unresolvable_count = 0
+
+    for domain, resource_names in sorted(DOMAIN_PRIMARY_RESOURCES.items()):
+        spec_file = specs_dir / f"{domain}.json"
+        if not spec_file.exists():
+            print(f"# SKIP: {domain}.json not found (run make all first)", flush=True)
+            continue
+        with spec_file.open() as f:
+            spec = json.load(f)
+        domain_paths = spec.get("paths", {})
+        all_components = sorted(_get_all_path_components(domain_paths))
+        for name in resource_names:
+            entry = resource_config.get(name, {})
+            if "schema_components" in entry or "api_paths" in entry:
+                continue
+            schema_comps, _ = resolve_resource(name, domain_paths)
+            if schema_comps:
+                continue
+            unresolvable_count += 1
+            print(f"\ndomain: {domain}")
+            print(f"resource: {name}")
+            print(f"  heuristic: empty (no operationId match)")
+            print(f"  candidate components from domain operationIds:")
+            for comp in all_components[:8]:
+                print(f"    - {comp}")
+            if len(all_components) > 8:
+                print(f"    ... ({len(all_components) - 8} more)")
+            print(f"  stub:")
+            print(f"    {name}:")
+            print(f"      schema_components: []  # fill in from candidates above")
+            print(f"      api_paths: []          # fill in matching path patterns")
+    print(f"\n# Total unresolvable resources: {unresolvable_count}")
+
+
+if __name__ == "__main__":
+    if "--dry-run" in sys.argv:
+        _dry_run_discovery()
+    else:
+        print("Usage: python scripts/utils/resource_resolver.py --dry-run")
+        sys.exit(1)

--- a/tests/test_resource_metadata.py
+++ b/tests/test_resource_metadata.py
@@ -327,5 +327,81 @@ class TestCategoryDefinitions:
                 assert category in valid_categories, f"Invalid category {category}"
 
 
+class TestMappingKeyAbsenceWithoutSpec:
+    """Verify schema_components and api_paths are absent when spec is not provided."""
+
+    def test_spec_none_omits_schema_components(self):
+        """get_primary_resources_metadata(domain) must not include schema_components."""
+        result = get_primary_resources_metadata("dns")
+        for resource in result:
+            assert "schema_components" not in resource, (
+                f"resource '{resource['name']}' has 'schema_components' key "
+                f"when spec=None — key must be absent, not empty"
+            )
+
+    def test_spec_none_omits_api_paths(self):
+        """get_primary_resources_metadata(domain) must not include api_paths."""
+        result = get_primary_resources_metadata("dns")
+        for resource in result:
+            assert "api_paths" not in resource, (
+                f"resource '{resource['name']}' has 'api_paths' key "
+                f"when spec=None — key must be absent, not empty"
+            )
+
+    def test_spec_none_all_domains(self):
+        """All domains return dicts without mapping keys when spec is not provided."""
+        for domain in DOMAIN_PRIMARY_RESOURCES:
+            result = get_primary_resources_metadata(domain)
+            for resource in result:
+                assert "schema_components" not in resource, (
+                    f"domain '{domain}' resource '{resource['name']}' has "
+                    f"'schema_components' when spec=None"
+                )
+                assert "api_paths" not in resource, (
+                    f"domain '{domain}' resource '{resource['name']}' has "
+                    f"'api_paths' when spec=None"
+                )
+
+
+class TestMappingKeyPresenceWithSpec:
+    """Verify schema_components and api_paths appear when spec is provided."""
+
+    @pytest.fixture
+    def minimal_virtual_spec(self):
+        return {
+            "paths": {
+                "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                    "post": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Create"},
+                    "get": {"operationId": "ves.io.schema.views.http_loadbalancer.API.List"},
+                },
+            }
+        }
+
+    def test_spec_present_includes_schema_components(self, minimal_virtual_spec):
+        """Every resource dict must have schema_components when spec is provided."""
+        result = get_primary_resources_metadata("virtual", spec=minimal_virtual_spec)
+        for resource in result:
+            assert "schema_components" in resource, (
+                f"resource '{resource['name']}' missing 'schema_components' when spec provided"
+            )
+            assert isinstance(resource["schema_components"], list)
+
+    def test_spec_present_includes_api_paths(self, minimal_virtual_spec):
+        """Every resource dict must have api_paths when spec is provided."""
+        result = get_primary_resources_metadata("virtual", spec=minimal_virtual_spec)
+        for resource in result:
+            assert "api_paths" in resource, (
+                f"resource '{resource['name']}' missing 'api_paths' when spec provided"
+            )
+            assert isinstance(resource["api_paths"], list)
+
+    def test_auto_resolvable_resource_gets_populated(self, minimal_virtual_spec):
+        """http_loadbalancer should auto-resolve from the minimal spec."""
+        result = get_primary_resources_metadata("virtual", spec=minimal_virtual_spec)
+        http_lb = next(r for r in result if r["name"] == "http_loadbalancer")
+        assert "views.http_loadbalancer" in http_lb["schema_components"]
+        assert any("http_loadbalancers" in p for p in http_lb["api_paths"])
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_resource_resolver.py
+++ b/tests/test_resource_resolver.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Unit tests for resource_resolver module (Issue #252)."""
+
+import pytest
+
+from scripts.utils.resource_resolver import (
+    OPERATIONID_REGEX,
+    apply_overrides,
+    resolve_resource,
+    validate_resource_mappings,
+)
+
+
+class TestOperationIdParsing:
+    """Verify OPERATIONID_REGEX extracts components from both API and CustomAPI."""
+
+    def test_standard_api_operationid(self):
+        match = OPERATIONID_REGEX.match("ves.io.schema.views.http_loadbalancer.API.Create")
+        assert match is not None
+        assert match.group(1) == "views.http_loadbalancer"
+
+    def test_custom_api_operationid(self):
+        match = OPERATIONID_REGEX.match("ves.io.schema.dns_zone.CustomAPI.Verify")
+        assert match is not None
+        assert match.group(1) == "dns_zone"
+
+    def test_crudapi_prefix_extracted(self):
+        match = OPERATIONID_REGEX.match("ves.io.schema.crudapi.aws_vpc_site.API.List")
+        assert match is not None
+        assert match.group(1) == "crudapi.aws_vpc_site"
+
+    def test_non_matching_operationid_rejected(self):
+        assert OPERATIONID_REGEX.match("some.other.format.Create") is None
+
+    def test_empty_string_rejected(self):
+        assert OPERATIONID_REGEX.match("") is None
+
+    def test_public_config_custom_api_extracted(self):
+        match = OPERATIONID_REGEX.match(
+            "ves.io.schema.views.api_definition.PublicConfigCustomAPI.ListLoadbalancers"
+        )
+        assert match is not None
+        assert match.group(1) == "views.api_definition"
+
+    def test_custom_data_api_extracted(self):
+        match = OPERATIONID_REGEX.match(
+            "ves.io.schema.dns_zone.CustomDataAPI.GetMetrics"
+        )
+        assert match is not None
+        assert match.group(1) == "dns_zone"
+
+
+class TestSchemaComponentResolution:
+    """Verify component extraction: all prefix variants, no early stop, deduplication."""
+
+    @pytest.fixture
+    def http_lb_paths(self):
+        return {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "post": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Create"},
+                "get": {"operationId": "ves.io.schema.views.http_loadbalancer.API.List"},
+            },
+            "/api/config/namespaces/{namespace}/http_loadbalancers/{name}": {
+                "get": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Get"},
+                "delete": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Delete"},
+            },
+        }
+
+    def test_views_prefix_matched(self, http_lb_paths):
+        schema_comps, _ = resolve_resource("http_loadbalancer", http_lb_paths)
+        assert "views.http_loadbalancer" in schema_comps
+
+    def test_multiple_prefix_variants_collected(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/things": {
+                "post": {"operationId": "ves.io.schema.views.thing.API.Create"},
+                "get": {"operationId": "ves.io.schema.crudapi.thing.API.List"},
+            },
+        }
+        schema_comps, _ = resolve_resource("thing", paths)
+        assert "views.thing" in schema_comps
+        assert "crudapi.thing" in schema_comps
+
+    def test_deduplication(self, http_lb_paths):
+        schema_comps, _ = resolve_resource("http_loadbalancer", http_lb_paths)
+        assert schema_comps.count("views.http_loadbalancer") == 1
+
+    def test_no_match_returns_empty_lists(self):
+        paths = {
+            "/api/other/stuff": {
+                "get": {"operationId": "ves.io.schema.other.thing.API.List"},
+            }
+        }
+        schema_comps, api_paths = resolve_resource("http_loadbalancer", paths)
+        assert schema_comps == []
+        assert api_paths == []
+
+    def test_exact_component_name_matched(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/dns_zones": {
+                "get": {"operationId": "ves.io.schema.dns_zone.API.List"},
+            }
+        }
+        schema_comps, _ = resolve_resource("dns_zone", paths)
+        assert "dns_zone" in schema_comps
+
+    def test_partial_name_not_matched(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "get": {"operationId": "ves.io.schema.views.http_loadbalancer.API.List"},
+            }
+        }
+        schema_comps, _ = resolve_resource("loadbalancer", paths)
+        assert schema_comps == []
+
+
+class TestApiPathResolution:
+    """Verify path selection: schema-tied, pluralized segment, CustomAPI included."""
+
+    def test_pluralized_path_segment_matched(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "post": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Create"},
+            }
+        }
+        _, api_paths = resolve_resource("http_loadbalancer", paths)
+        assert "/api/config/namespaces/{namespace}/http_loadbalancers" in api_paths
+
+    def test_custom_api_path_included(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/dns_zones": {
+                "get": {"operationId": "ves.io.schema.dns_zone.API.List"},
+            },
+            "/api/config/namespaces/{namespace}/dns_zones/{name}/verify": {
+                "post": {"operationId": "ves.io.schema.dns_zone.CustomAPI.Verify"},
+            },
+        }
+        _, api_paths = resolve_resource("dns_zone", paths)
+        assert "/api/config/namespaces/{namespace}/dns_zones/{name}/verify" in api_paths
+
+    def test_path_without_matching_component_excluded(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "post": {"operationId": "ves.io.schema.some_other_thing.API.Create"},
+            },
+        }
+        _, api_paths = resolve_resource("http_loadbalancer", paths)
+        assert api_paths == []
+
+    def test_unrelated_path_sharing_segment_excluded(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "post": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Create"},
+            },
+            "/api/config/namespaces/{namespace}/other_http_loadbalancers": {
+                "get": {"operationId": "ves.io.schema.views.other.API.List"},
+            },
+        }
+        _, api_paths = resolve_resource("http_loadbalancer", paths)
+        assert "/api/config/namespaces/{namespace}/other_http_loadbalancers" not in api_paths
+
+
+class TestOverrideMerge:
+    """Verify apply_overrides behavior: config takes precedence, absent key falls through."""
+
+    @pytest.fixture
+    def heuristic_result(self):
+        return (
+            ["views.http_loadbalancer"],
+            ["/api/config/namespaces/{namespace}/http_loadbalancers"],
+        )
+
+    def test_absent_config_uses_heuristic(self, heuristic_result):
+        schema_comps, api_paths = apply_overrides(heuristic_result, {})
+        assert schema_comps == ["views.http_loadbalancer"]
+        assert api_paths == ["/api/config/namespaces/{namespace}/http_loadbalancers"]
+
+    def test_config_schema_components_replaces_heuristic(self, heuristic_result):
+        override = {"schema_components": ["views.custom_lb"]}
+        schema_comps, api_paths = apply_overrides(heuristic_result, override)
+        assert schema_comps == ["views.custom_lb"]
+        assert api_paths == ["/api/config/namespaces/{namespace}/http_loadbalancers"]
+
+    def test_empty_array_override_replaces_non_empty_heuristic(self, heuristic_result):
+        override = {"schema_components": [], "api_paths": []}
+        schema_comps, api_paths = apply_overrides(heuristic_result, override)
+        assert schema_comps == []
+        assert api_paths == []
+
+    def test_both_fields_overridden_independently(self, heuristic_result):
+        override = {
+            "schema_components": ["views.fleet"],
+            "api_paths": ["/api/config/namespaces/{namespace}/fleets"],
+        }
+        schema_comps, api_paths = apply_overrides(heuristic_result, override)
+        assert schema_comps == ["views.fleet"]
+        assert api_paths == ["/api/config/namespaces/{namespace}/fleets"]
+
+    def test_string_override_raises_type_error(self, heuristic_result):
+        with pytest.raises(TypeError, match="schema_components must be a list"):
+            apply_overrides(heuristic_result, {"schema_components": "views.http_loadbalancer"})
+
+    def test_none_override_raises_type_error(self, heuristic_result):
+        with pytest.raises(TypeError, match="api_paths must be a list"):
+            apply_overrides(heuristic_result, {"api_paths": None})
+
+
+class TestValidation:
+    """Verify validate_resource_mappings error reporting."""
+
+    @pytest.fixture
+    def minimal_domain_paths(self):
+        return {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "post": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Create"},
+            }
+        }
+
+    def test_valid_override_passes(self, minimal_domain_paths):
+        heuristic = {"http_loadbalancer": (["views.http_loadbalancer"], [])}
+        overrides = {
+            "http_loadbalancer": {"schema_components": ["views.http_loadbalancer"]}
+        }
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert errors == []
+
+    def test_invalid_schema_component_fails(self, minimal_domain_paths):
+        heuristic = {"http_loadbalancer": ([], [])}
+        overrides = {
+            "http_loadbalancer": {"schema_components": ["views.nonexistent_resource"]}
+        }
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert len(errors) == 1
+        assert "views.nonexistent_resource" in errors[0]
+        assert "not found in domain" in errors[0]
+
+    def test_invalid_api_path_fails(self, minimal_domain_paths):
+        heuristic = {"http_loadbalancer": ([], [])}
+        overrides = {
+            "http_loadbalancer": {"api_paths": ["/api/config/namespaces/{namespace}/nonexistent"]}
+        }
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert len(errors) == 1
+        assert "/api/config/namespaces/{namespace}/nonexistent" in errors[0]
+
+    def test_empty_array_override_skips_validation(self, minimal_domain_paths):
+        heuristic = {"some_resource": ([], [])}
+        overrides = {"some_resource": {"schema_components": [], "api_paths": []}}
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert errors == []
+
+    def test_redundant_override_emits_warning(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/http_loadbalancers": {
+                "post": {"operationId": "ves.io.schema.views.http_loadbalancer.API.Create"},
+            }
+        }
+        heuristic = {"http_loadbalancer": (["views.old_name"], [])}
+        overrides = {"http_loadbalancer": {"schema_components": ["views.http_loadbalancer"]}}
+        errors = validate_resource_mappings(heuristic, overrides, paths, "virtual")
+        assert errors == []
+
+    def test_multiple_errors_reported(self, minimal_domain_paths):
+        heuristic = {"r1": ([], []), "r2": ([], [])}
+        overrides = {
+            "r1": {"schema_components": ["views.bad1"]},
+            "r2": {"schema_components": ["views.bad2"]},
+        }
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert len(errors) == 2
+
+    def test_string_schema_components_in_validation_reports_error(self, minimal_domain_paths):
+        heuristic = {"r": ([], [])}
+        overrides = {"r": {"schema_components": "views.http_loadbalancer"}}
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert len(errors) == 1
+        assert "must be a list" in errors[0]
+
+    def test_none_api_paths_in_validation_reports_error(self, minimal_domain_paths):
+        heuristic = {"r": ([], [])}
+        overrides = {"r": {"api_paths": None}}
+        errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
+        assert len(errors) == 1
+        assert "must be a list" in errors[0]
+
+
+class TestConceptualResources:
+    """Verify resources with no API entity return empty lists from heuristic."""
+
+    def test_no_operationid_match_returns_empty(self):
+        paths = {
+            "/api/config/namespaces/{namespace}/real_things": {
+                "get": {"operationId": "ves.io.schema.views.real_thing.API.List"},
+            }
+        }
+        schema_comps, api_paths = resolve_resource("conceptual_resource", paths)
+        assert schema_comps == []
+        assert api_paths == []
+
+    def test_empty_paths_returns_empty(self):
+        schema_comps, api_paths = resolve_resource("anything", {})
+        assert schema_comps == []
+        assert api_paths == []
+
+    def test_apply_overrides_empty_config_preserves_empty_heuristic(self):
+        schema_comps, api_paths = apply_overrides(([], []), {"schema_components": [], "api_paths": []})
+        assert schema_comps == []
+        assert api_paths == []

--- a/tests/test_resource_resolver.py
+++ b/tests/test_resource_resolver.py
@@ -44,9 +44,7 @@ class TestOperationIdParsing:
         assert match.group(1) == "views.api_definition"
 
     def test_custom_data_api_extracted(self):
-        match = OPERATIONID_REGEX.match(
-            "ves.io.schema.dns_zone.CustomDataAPI.GetMetrics"
-        )
+        match = OPERATIONID_REGEX.match("ves.io.schema.dns_zone.CustomDataAPI.GetMetrics")
         assert match is not None
         assert match.group(1) == "dns_zone"
 
@@ -219,17 +217,13 @@ class TestValidation:
 
     def test_valid_override_passes(self, minimal_domain_paths):
         heuristic = {"http_loadbalancer": (["views.http_loadbalancer"], [])}
-        overrides = {
-            "http_loadbalancer": {"schema_components": ["views.http_loadbalancer"]}
-        }
+        overrides = {"http_loadbalancer": {"schema_components": ["views.http_loadbalancer"]}}
         errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
         assert errors == []
 
     def test_invalid_schema_component_fails(self, minimal_domain_paths):
         heuristic = {"http_loadbalancer": ([], [])}
-        overrides = {
-            "http_loadbalancer": {"schema_components": ["views.nonexistent_resource"]}
-        }
+        overrides = {"http_loadbalancer": {"schema_components": ["views.nonexistent_resource"]}}
         errors = validate_resource_mappings(heuristic, overrides, minimal_domain_paths, "virtual")
         assert len(errors) == 1
         assert "views.nonexistent_resource" in errors[0]
@@ -304,6 +298,8 @@ class TestConceptualResources:
         assert api_paths == []
 
     def test_apply_overrides_empty_config_preserves_empty_heuristic(self):
-        schema_comps, api_paths = apply_overrides(([], []), {"schema_components": [], "api_paths": []})
+        schema_comps, api_paths = apply_overrides(
+            ([], []), {"schema_components": [], "api_paths": []}
+        )
         assert schema_comps == []
         assert api_paths == []

--- a/tests/test_resource_resolver_integration.py
+++ b/tests/test_resource_resolver_integration.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2026 Robin Mordasiewicz. MIT License.
+
+"""Integration tests for resource resolution against real domain specs (Issue #252).
+
+These tests load actual merged specs from docs/specifications/api/. Run
+`make all` first to generate the spec files.
+"""
+
+import json
+import logging
+from pathlib import Path
+
+import pytest
+
+from scripts.utils.domain_metadata import DOMAIN_PRIMARY_RESOURCES, get_primary_resources_metadata
+from scripts.utils.resource_resolver import (
+    resolve_resource,
+    validate_resource_mappings,
+)
+
+SPECS_DIR = Path(__file__).parent.parent / "docs" / "specifications" / "api"
+
+
+def load_spec(domain: str) -> dict | None:
+    """Load merged spec for a domain. Returns None if not found."""
+    spec_file = SPECS_DIR / f"{domain}.json"
+    if not spec_file.exists():
+        return None
+    return json.loads(spec_file.read_text())
+
+
+@pytest.fixture(scope="module")
+def all_domain_specs() -> dict:
+    """Load all available domain specs. Skip domains with no spec file."""
+    specs = {}
+    for domain in DOMAIN_PRIMARY_RESOURCES:
+        spec = load_spec(domain)
+        if spec is not None:
+            specs[domain] = spec
+    if not specs:
+        pytest.skip("No domain specs found — run `make all` first")
+    return specs
+
+
+class TestAllResourcesResolve:
+    """Every primary resource must have schema_components and api_paths."""
+
+    def test_all_resources_have_mapping_fields(self, all_domain_specs):
+        """After resolution, no resource is missing schema_components or api_paths."""
+        problems: list[str] = []
+        for domain, spec in all_domain_specs.items():
+            resources = get_primary_resources_metadata(domain, spec=spec)
+            for r in resources:
+                if "schema_components" not in r:
+                    problems.append(f"{domain}/{r['name']}: missing schema_components")
+                if "api_paths" not in r:
+                    problems.append(f"{domain}/{r['name']}: missing api_paths")
+
+        assert not problems, "Resources missing mapping fields:\n" + "\n".join(problems)
+
+    def test_resolved_resources_are_lists(self, all_domain_specs):
+        """schema_components and api_paths must always be lists (never None)."""
+        for domain, spec in all_domain_specs.items():
+            resources = get_primary_resources_metadata(domain, spec=spec)
+            for r in resources:
+                assert isinstance(r.get("schema_components"), list), (
+                    f"{domain}/{r['name']}: schema_components is not a list"
+                )
+                assert isinstance(r.get("api_paths"), list), (
+                    f"{domain}/{r['name']}: api_paths is not a list"
+                )
+
+
+class TestAutoResolvePartition:
+    """Dynamically verify the heuristic/manual partition is consistent."""
+
+    def test_manual_resources_have_config_overrides(self, all_domain_specs):
+        """Every resource where heuristic returns empty must have a config entry."""
+        from scripts.utils.domain_metadata import _load_resource_metadata
+
+        resource_config = _load_resource_metadata()
+        needs_config: list[str] = []
+        has_config: list[str] = []
+        auto_resolves: list[str] = []
+
+        for domain, spec in all_domain_specs.items():
+            domain_paths = spec.get("paths", {})
+            for name in DOMAIN_PRIMARY_RESOURCES.get(domain, []):
+                schema_comps, _ = resolve_resource(name, domain_paths)
+                if schema_comps:
+                    auto_resolves.append(f"{domain}/{name}")
+                else:
+                    entry = resource_config.get(name, {})
+                    if "schema_components" in entry or "api_paths" in entry:
+                        has_config.append(f"{domain}/{name}")
+                    else:
+                        needs_config.append(f"{domain}/{name}")
+
+        logging.getLogger(__name__).info(
+            "Resolution partition: %d auto-resolve, %d manual config, %d need config",
+            len(auto_resolves),
+            len(has_config),
+            len(needs_config),
+        )
+
+        assert not needs_config, (
+            "Resources need manual config entry in resource_metadata.yaml:\n"
+            + "\n".join(needs_config)
+        )
+
+    def test_manual_resources_need_config_not_heuristic(self, all_domain_specs):
+        """Resources with config overrides should NOT auto-resolve via heuristic."""
+        from scripts.utils.domain_metadata import _load_resource_metadata
+
+        resource_config = _load_resource_metadata()
+        redundant: list[str] = []
+
+        for domain, spec in all_domain_specs.items():
+            domain_paths = spec.get("paths", {})
+            for name in DOMAIN_PRIMARY_RESOURCES.get(domain, []):
+                entry = resource_config.get(name, {})
+                has_override = "schema_components" in entry or "api_paths" in entry
+                if not has_override:
+                    continue
+
+                schema_comps, _ = resolve_resource(name, domain_paths)
+                if schema_comps:
+                    redundant.append(f"{domain}/{name} (heuristic now finds: {schema_comps})")
+
+        if redundant:
+            logging.getLogger(__name__).warning(
+                "Config overrides may be redundant (heuristic now resolves these):\n%s",
+                "\n".join(redundant),
+            )
+
+
+class TestAllOverridesValidAgainstSpec:
+    """All config overrides must reference valid components and paths."""
+
+    def test_overrides_valid_against_current_spec(self, all_domain_specs):
+        """validate_resource_mappings must pass for every domain."""
+        from scripts.utils.domain_metadata import _load_resource_metadata
+
+        resource_config = _load_resource_metadata()
+        all_errors: list[str] = []
+
+        for domain, spec in all_domain_specs.items():
+            domain_paths = spec.get("paths", {})
+            resource_names = DOMAIN_PRIMARY_RESOURCES.get(domain, [])
+
+            heuristic_results = {
+                name: resolve_resource(name, domain_paths) for name in resource_names
+            }
+            config_overrides = {
+                name: resource_config[name]
+                for name in resource_names
+                if name in resource_config
+                and (
+                    "schema_components" in resource_config[name]
+                    or "api_paths" in resource_config[name]
+                )
+                and not heuristic_results[name][0]
+            }
+
+            errors = validate_resource_mappings(
+                heuristic_results, config_overrides, domain_paths, domain
+            )
+            all_errors.extend(f"[{domain}] {err}" for err in errors)
+
+        assert not all_errors, (
+            "Config overrides reference invalid components or paths:\n" + "\n".join(all_errors)
+        )


### PR DESCRIPTION
## Summary

- Adds `schema_components` (dotted operationId component names) and `api_paths` (primary CRUD path patterns) to every `x-f5xc-primary-resources` entry in `index.json`
- New `scripts/utils/resource_resolver.py` uses operationId regex (`ves.io.schema.<component>.(?:\w*API).<method>`) to heuristically resolve 32 resources; `resource_metadata.yaml` manual overrides cover the remaining 66
- Overrides only apply when heuristic returns empty — prevents flat config entries from cross-contaminating shared resource names across domains
- Build-time validation fails if an override references a component or path absent from the domain spec

## Test plan

- [x] 34 unit tests in `tests/test_resource_resolver.py` (resolver, validation, type safety)
- [x] 6 backward-compat tests in `tests/test_resource_metadata.py` (keys absent when spec=None)
- [x] 5 integration tests in `tests/test_resource_resolver_integration.py` (real specs, partition validation, override validity)
- [x] Full suite: 1996 passed, 0 failures

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)