### PR TITLE
fix(docs): exclude api-reference from llms-txt to fix Pages Deploy

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,16 +1,11 @@
 {
   "customSets": [
     {
-      "label": "API Reference",
-      "description": "Enriched OpenAPI endpoint documentation for all F5 Distributed Cloud services",
-      "paths": ["api-reference/**"]
-    },
-    {
       "label": "Enhancements",
       "description": "Healthcheck, HTTP load balancer, and origin pool specification enhancements",
       "paths": ["Enhancements/**"]
     }
   ],
-  "promote": ["index*", "api-reference/**"],
-  "demote": ["development*", "validation-spec*"]
+  "promote": ["index*"],
+  "demote": ["development*", "validation-spec*", "api-reference*"]
 }


### PR DESCRIPTION
## Summary

- Remove `api-reference` from `customSets` and `promote` in `docs/llms-config.json`
- Add `api-reference*` to `demote` to prevent the starlight-llms-txt plugin from prerendering interactive React Scalar API viewer components as static text
- Fixes Pages Deploy failure: `NoMatchingRenderer: Unable to render ScalarApiViewer`

Closes #261

## Test plan

- [ ] CI checks pass
- [ ] Pages Deploy workflow succeeds without `NoMatchingRenderer` error
- [ ] llms.txt output no longer includes api-reference pages