### PR TITLE
fix(docs): use exclude to remove api-reference from llms-txt rendering

### DIFF
--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -7,5 +7,6 @@
     }
   ],
   "promote": ["index*"],
-  "demote": ["development*", "validation-spec*", "api-reference*"]
+  "demote": ["development*", "validation-spec*"],
+  "exclude": ["api-reference*"]
 }


### PR DESCRIPTION
## Summary

- Switch from `demote` to `exclude` for `api-reference*` pages in `llms-config.json`
- The `starlight-llms-txt` plugin `exclude` option fully removes pages from `llms-full.txt` generation, preventing `NoMatchingRenderer: Unable to render ScalarApiViewer` errors during GitHub Pages deploy
- The `demote` option only controls ranking priority but still attempts to prerender the interactive React API viewer pages as static text

Closes #263

## Test plan

- [ ] CI checks pass
- [ ] GitHub Pages deploy succeeds without `NoMatchingRenderer` errors
- [ ] `llms-full.txt` no longer contains api-reference content