### PR TITLE
fix(docs): use iframe for api-reference to fix llms-txt prerendering

### DIFF
--- a/docs/api-reference/admin_console_and_ui.mdx
+++ b/docs/api-reference/admin_console_and_ui.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/admin_console_and_ui.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/admin_console_and_ui.json" title="Admin Console And Ui" />
+<iframe
+    src="/specifications/api/viewer/admin_console_and_ui.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Admin Console And Ui API Reference"
+/>

--- a/docs/api-reference/ai_services.mdx
+++ b/docs/api-reference/ai_services.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/ai_services.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/ai_services.json" title="Ai Services" />
+<iframe
+    src="/specifications/api/viewer/ai_services.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Ai Services API Reference"
+/>

--- a/docs/api-reference/api.mdx
+++ b/docs/api-reference/api.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/api.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/api.json" title="Api" />
+<iframe
+    src="/specifications/api/viewer/api.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Api API Reference"
+/>

--- a/docs/api-reference/authentication.mdx
+++ b/docs/api-reference/authentication.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/authentication.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/authentication.json" title="Authentication" />
+<iframe
+    src="/specifications/api/viewer/authentication.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Authentication API Reference"
+/>

--- a/docs/api-reference/bigip.mdx
+++ b/docs/api-reference/bigip.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/bigip.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/bigip.json" title="Bigip" />
+<iframe
+    src="/specifications/api/viewer/bigip.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Bigip API Reference"
+/>

--- a/docs/api-reference/billing_and_usage.mdx
+++ b/docs/api-reference/billing_and_usage.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/billing_and_usage.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/billing_and_usage.json" title="Billing And Usage" />
+<iframe
+    src="/specifications/api/viewer/billing_and_usage.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Billing And Usage API Reference"
+/>

--- a/docs/api-reference/blindfold.mdx
+++ b/docs/api-reference/blindfold.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/blindfold.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/blindfold.json" title="Blindfold" />
+<iframe
+    src="/specifications/api/viewer/blindfold.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Blindfold API Reference"
+/>

--- a/docs/api-reference/bot_and_threat_defense.mdx
+++ b/docs/api-reference/bot_and_threat_defense.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/bot_and_threat_defense.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/bot_and_threat_defense.json" title="Bot And Threat Defense" />
+<iframe
+    src="/specifications/api/viewer/bot_and_threat_defense.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Bot And Threat Defense API Reference"
+/>

--- a/docs/api-reference/cdn.mdx
+++ b/docs/api-reference/cdn.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/cdn.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/cdn.json" title="Cdn" />
+<iframe
+    src="/specifications/api/viewer/cdn.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Cdn API Reference"
+/>

--- a/docs/api-reference/ce_management.mdx
+++ b/docs/api-reference/ce_management.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/ce_management.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/ce_management.json" title="Ce Management" />
+<iframe
+    src="/specifications/api/viewer/ce_management.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Ce Management API Reference"
+/>

--- a/docs/api-reference/certificates.mdx
+++ b/docs/api-reference/certificates.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/certificates.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/certificates.json" title="Certificates" />
+<iframe
+    src="/specifications/api/viewer/certificates.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Certificates API Reference"
+/>

--- a/docs/api-reference/cloud_infrastructure.mdx
+++ b/docs/api-reference/cloud_infrastructure.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/cloud_infrastructure.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/cloud_infrastructure.json" title="Cloud Infrastructure" />
+<iframe
+    src="/specifications/api/viewer/cloud_infrastructure.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Cloud Infrastructure API Reference"
+/>

--- a/docs/api-reference/container_services.mdx
+++ b/docs/api-reference/container_services.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/container_services.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/container_services.json" title="Container Services" />
+<iframe
+    src="/specifications/api/viewer/container_services.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Container Services API Reference"
+/>

--- a/docs/api-reference/data_and_privacy_security.mdx
+++ b/docs/api-reference/data_and_privacy_security.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/data_and_privacy_security.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/data_and_privacy_security.json" title="Data And Privacy Security" />
+<iframe
+    src="/specifications/api/viewer/data_and_privacy_security.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Data And Privacy Security API Reference"
+/>

--- a/docs/api-reference/data_intelligence.mdx
+++ b/docs/api-reference/data_intelligence.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/data_intelligence.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/data_intelligence.json" title="Data Intelligence" />
+<iframe
+    src="/specifications/api/viewer/data_intelligence.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Data Intelligence API Reference"
+/>

--- a/docs/api-reference/ddos.mdx
+++ b/docs/api-reference/ddos.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/ddos.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/ddos.json" title="Ddos" />
+<iframe
+    src="/specifications/api/viewer/ddos.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Ddos API Reference"
+/>

--- a/docs/api-reference/dns.mdx
+++ b/docs/api-reference/dns.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/dns.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/dns.json" title="Dns" />
+<iframe
+    src="/specifications/api/viewer/dns.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Dns API Reference"
+/>

--- a/docs/api-reference/managed_kubernetes.mdx
+++ b/docs/api-reference/managed_kubernetes.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/managed_kubernetes.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/managed_kubernetes.json" title="Managed Kubernetes" />
+<iframe
+    src="/specifications/api/viewer/managed_kubernetes.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Managed Kubernetes API Reference"
+/>

--- a/docs/api-reference/marketplace.mdx
+++ b/docs/api-reference/marketplace.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/marketplace.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/marketplace.json" title="Marketplace" />
+<iframe
+    src="/specifications/api/viewer/marketplace.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Marketplace API Reference"
+/>

--- a/docs/api-reference/network.mdx
+++ b/docs/api-reference/network.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/network.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/network.json" title="Network" />
+<iframe
+    src="/specifications/api/viewer/network.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Network API Reference"
+/>

--- a/docs/api-reference/network_security.mdx
+++ b/docs/api-reference/network_security.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/network_security.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/network_security.json" title="Network Security" />
+<iframe
+    src="/specifications/api/viewer/network_security.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Network Security API Reference"
+/>

--- a/docs/api-reference/nginx_one.mdx
+++ b/docs/api-reference/nginx_one.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/nginx_one.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/nginx_one.json" title="Nginx One" />
+<iframe
+    src="/specifications/api/viewer/nginx_one.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Nginx One API Reference"
+/>

--- a/docs/api-reference/object_storage.mdx
+++ b/docs/api-reference/object_storage.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/object_storage.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/object_storage.json" title="Object Storage" />
+<iframe
+    src="/specifications/api/viewer/object_storage.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Object Storage API Reference"
+/>

--- a/docs/api-reference/observability.mdx
+++ b/docs/api-reference/observability.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/observability.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/observability.json" title="Observability" />
+<iframe
+    src="/specifications/api/viewer/observability.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Observability API Reference"
+/>

--- a/docs/api-reference/other.mdx
+++ b/docs/api-reference/other.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/other.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/other.json" title="Other" />
+<iframe
+    src="/specifications/api/viewer/other.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Other API Reference"
+/>

--- a/docs/api-reference/rate_limiting.mdx
+++ b/docs/api-reference/rate_limiting.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/rate_limiting.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/rate_limiting.json" title="Rate Limiting" />
+<iframe
+    src="/specifications/api/viewer/rate_limiting.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Rate Limiting API Reference"
+/>

--- a/docs/api-reference/secops_and_incident_response.mdx
+++ b/docs/api-reference/secops_and_incident_response.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/secops_and_incident_response.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/secops_and_incident_response.json" title="Secops And Incident Response" />
+<iframe
+    src="/specifications/api/viewer/secops_and_incident_response.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Secops And Incident Response API Reference"
+/>

--- a/docs/api-reference/service_mesh.mdx
+++ b/docs/api-reference/service_mesh.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/service_mesh.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/service_mesh.json" title="Service Mesh" />
+<iframe
+    src="/specifications/api/viewer/service_mesh.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Service Mesh API Reference"
+/>

--- a/docs/api-reference/shape.mdx
+++ b/docs/api-reference/shape.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/shape.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/shape.json" title="Shape" />
+<iframe
+    src="/specifications/api/viewer/shape.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Shape API Reference"
+/>

--- a/docs/api-reference/sites.mdx
+++ b/docs/api-reference/sites.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/sites.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/sites.json" title="Sites" />
+<iframe
+    src="/specifications/api/viewer/sites.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Sites API Reference"
+/>

--- a/docs/api-reference/statistics.mdx
+++ b/docs/api-reference/statistics.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/statistics.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/statistics.json" title="Statistics" />
+<iframe
+    src="/specifications/api/viewer/statistics.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Statistics API Reference"
+/>

--- a/docs/api-reference/support.mdx
+++ b/docs/api-reference/support.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/support.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/support.json" title="Support" />
+<iframe
+    src="/specifications/api/viewer/support.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Support API Reference"
+/>

--- a/docs/api-reference/telemetry_and_insights.mdx
+++ b/docs/api-reference/telemetry_and_insights.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/telemetry_and_insights.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/telemetry_and_insights.json" title="Telemetry And Insights" />
+<iframe
+    src="/specifications/api/viewer/telemetry_and_insights.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Telemetry And Insights API Reference"
+/>

--- a/docs/api-reference/tenant_and_identity.mdx
+++ b/docs/api-reference/tenant_and_identity.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/tenant_and_identity.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/tenant_and_identity.json" title="Tenant And Identity" />
+<iframe
+    src="/specifications/api/viewer/tenant_and_identity.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Tenant And Identity API Reference"
+/>

--- a/docs/api-reference/threat_campaign.mdx
+++ b/docs/api-reference/threat_campaign.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/threat_campaign.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/threat_campaign.json" title="Threat Campaign" />
+<iframe
+    src="/specifications/api/viewer/threat_campaign.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Threat Campaign API Reference"
+/>

--- a/docs/api-reference/users.mdx
+++ b/docs/api-reference/users.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/users.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/users.json" title="Users" />
+<iframe
+    src="/specifications/api/viewer/users.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Users API Reference"
+/>

--- a/docs/api-reference/virtual.mdx
+++ b/docs/api-reference/virtual.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/virtual.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/virtual.json" title="Virtual" />
+<iframe
+    src="/specifications/api/viewer/virtual.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Virtual API Reference"
+/>

--- a/docs/api-reference/vpm_and_node_management.mdx
+++ b/docs/api-reference/vpm_and_node_management.mdx
@@ -5,7 +5,6 @@ tableOfContents: false
 ---
 
 import { LinkCard } from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -13,4 +12,8 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="/specifications/api/vpm_and_node_management.json" />
 </div>
 
-<ScalarViewer specUrl="/specifications/api/vpm_and_node_management.json" title="Vpm And Node Management" />
+<iframe
+    src="/specifications/api/viewer/vpm_and_node_management.html"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="Vpm And Node Management API Reference"
+/>

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,12 +1,16 @@
 {
   "customSets": [
     {
+      "label": "API Reference",
+      "description": "Enriched OpenAPI endpoint documentation for all F5 Distributed Cloud services",
+      "paths": ["api-reference/**"]
+    },
+    {
       "label": "Enhancements",
       "description": "Healthcheck, HTTP load balancer, and origin pool specification enhancements",
       "paths": ["Enhancements/**"]
     }
   ],
-  "promote": ["index*"],
-  "demote": ["development*", "validation-spec*"],
-  "exclude": ["api-reference*"]
+  "promote": ["index*", "api-reference/**"],
+  "demote": ["development*", "validation-spec*"]
 }

--- a/scripts/generate_api_viewer.py
+++ b/scripts/generate_api_viewer.py
@@ -59,7 +59,15 @@ def generate_viewer_html(domain: str, title: str) -> str:
 
 
 def generate_domain_mdx(domain: str, title: str, description: str) -> str:
-    """Generate a Starlight MDX wrapper page for a domain viewer."""
+    """Generate a Starlight MDX wrapper page for a domain viewer.
+
+    Uses an iframe embedding the standalone Scalar HTML viewer rather than the
+    inline React component. The React component (ScalarApiViewerWrapper.astro)
+    uses client:only="react" which cannot be statically prerendered — this
+    causes the starlight-llms-txt plugin to crash when generating llms-full.txt.
+    Iframes have no SSR dependency and render identically in the browser.
+    See: docs-control#424 (fix starlight-llms-txt to pass exclude in llms-full.txt.ts)
+    """
     viewer_path = f"/specifications/api/viewer/{domain}.html"
     spec_path = f"/specifications/api/{domain}.json"
 
@@ -70,7 +78,6 @@ tableOfContents: false
 ---
 
 import {{ LinkCard }} from '@astrojs/starlight/components';
-import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
 
 <div style="margin-bottom: 1rem; display: flex; gap: 0.5rem; flex-wrap: wrap;">
     <LinkCard title="Back to API Catalog" href="/api-reference/" />
@@ -78,7 +85,11 @@ import ScalarViewer from '@components/ScalarApiViewerWrapper.astro';
     <LinkCard title="Download Spec" href="{spec_path}" />
 </div>
 
-<ScalarViewer specUrl="{spec_path}" title="{title}" />
+<iframe
+    src="{viewer_path}"
+    style="width: 100%; height: 80vh; border: none; border-radius: 0.5rem;"
+    title="{title} API Reference"
+/>
 """
 
 


### PR DESCRIPTION
## Summary

- Switch api-reference MDX pages from React `ScalarApiViewer` component (`client:only="react"`) to iframe embedding of standalone HTML viewer pages
- Restore api-reference to `llms-config.json` customSets since iframes are safe for static text rendering
- Fixes `NoMatchingRenderer: Unable to render ScalarApiViewer` crash in starlight-llms-txt plugin during Pages Deploy

Closes #265

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Pages Deploy workflow succeeds after merge
- [ ] API reference pages render correctly with iframe viewer
- [ ] llms-full.txt generates without prerendering errors