### PR TITLE
fix(ci): compile API catalog unconditionally to fix release asset

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -231,7 +231,6 @@ jobs:
         run: python -m scripts.analyze_constraints
 
       - name: Compile API catalog
-        if: steps.enriched-cache.outputs.cache-hit != 'true'
         run: python -m scripts.compile_catalog --input-dir docs/specifications/api --output release/api-catalog.json
 
       - name: Save enriched output cache


### PR DESCRIPTION
## Summary

- Remove the `cache-hit` condition from the "Compile API catalog" step in `sync-and-enrich.yml`
- On cache-hit runs, `release/api-catalog.json` was never created, causing the "Create release" step to fail with `no matches found for release/api-catalog.json`
- The catalog compiler is fast (reads `index.json`) and must always run so the release asset exists

Closes #273

## Test plan

- [ ] CI checks pass (Check linked issues, Lint Code Base)
- [ ] Verify the "Compile API catalog" step no longer has a conditional guard
- [ ] Next Sync and Enrich run creates `release/api-catalog.json` regardless of cache state