### PR TITLE
fix(pipeline): Phase 2 — close remaining healthcheck issues

### DIFF
--- a/config/constraint_patterns.yaml
+++ b/config/constraint_patterns.yaml
@@ -17,26 +17,26 @@ metadata:
 # Pattern structure: field name regex → constraint metadata
 string_patterns:
 
-  # Identity and Naming (RFC 1123, Kubernetes standards)
+  # Identity and Naming (DNS-1035, F5 XC API enforcement)
   - pattern: '\bname$'
-    description: "DNS label format resource name"
+    description: "DNS-1035 label format resource name"
     constraints:
       minLength: 1
       maxLength: 63
-      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
       characterSet:
         allowed: '[a-z0-9-]'
         restricted: '[^a-z0-9-]'
         required: '[a-z0-9]'
-        description: "Lowercase alphanumeric with hyphens, not at start/end"
+        description: "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
       format: "dns-label"
-      formatDescription: "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end"
+      formatDescription: "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric"
       validation:
-        rfc: "RFC 1123"
-        standard: "Kubernetes resource naming"
+        rfc: "RFC 1035"
+        standard: "DNS-1035 label (alpha-first)"
     metadata:
-      source: "inferred"
-      confidence: 0.95
+      source: "api-probed"
+      confidence: 0.99
       category: "naming"
 
   - pattern: '\bnamespace$'
@@ -44,14 +44,18 @@ string_patterns:
     constraints:
       minLength: 1
       maxLength: 63
-      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
       characterSet:
         allowed: '[a-z0-9-]'
-        description: "Kubernetes namespace format"
+        description: "DNS-1035 label format (alpha-first)"
       format: "dns-label"
+      formatDescription: "DNS-1035 label: must start with a lowercase letter"
+      validation:
+        rfc: "RFC 1035"
+        standard: "DNS-1035 label (alpha-first)"
     metadata:
-      source: "inferred"
-      confidence: 0.95
+      source: "api-probed"
+      confidence: 0.99
       category: "naming"
 
   - pattern: '\b(user|username)$'
@@ -1066,11 +1070,14 @@ resource_constraint_overrides:
       jitter_percent:
         type: "number"
         constraints:
-          minimum: 0
-          maximum: 50
+          ranges:
+            - minimum: 0
+              maximum: 0
+            - minimum: 10
+              maximum: 50
           multipleOf: 1
         metadata:
           source: "api-probed"
-          confidence: 0.95
+          confidence: 0.99
           category: "timing"
-          note: "Accepts {0} union [10, 50] — simplified to [0, 50] for OpenAPI compat"
+          note: "Non-contiguous: {0} union [10, 50] — values 1-9 rejected by API"

--- a/config/extension_registry.yaml
+++ b/config/extension_registry.yaml
@@ -320,8 +320,9 @@ property_level:
       maxItems: "Maximum array items"
       uniqueItems: "Boolean requiring unique items"
       # Numeric constraint keys (when constraintType=number)
-      minimum: "Minimum numeric value"
-      maximum: "Maximum numeric value"
+      minimum: "Minimum numeric value (contiguous range)"
+      maximum: "Maximum numeric value (contiguous range)"
+      ranges: "Array of {minimum, maximum} objects for non-contiguous valid ranges. When present, replaces top-level minimum/maximum."
       multipleOf: "Value must be multiple of this number"
       exclusiveMinimum: "Exclusive minimum boundary"
       exclusiveMaximum: "Exclusive maximum boundary"

--- a/config/field_metadata.yaml
+++ b/config/field_metadata.yaml
@@ -18,7 +18,7 @@ field_patterns:
     x-f5xc-validation:
       minLength: 1
       maxLength: 63
-      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
     x-f5xc-examples:
       - value: 'example-resource'
         context: 'Basic alphanumeric name'
@@ -27,7 +27,7 @@ field_patterns:
     x-f5xc-completion:
       type: 'string-value'
       hint: 'Resource name (alphanumeric and hyphens, 1-63 chars)'
-      pattern: '^[a-z0-9-]+$'
+      pattern: '^[a-z][a-z0-9-]*$'
     x-f5xc-defaults:
       value: null
       reasoning: 'Name must be explicitly provided by user'
@@ -135,7 +135,7 @@ field_patterns:
     x-f5xc-validation:
       minLength: 1
       maxLength: 63
-      pattern: '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+      pattern: '^[a-z]([-a-z0-9]*[a-z0-9])?$'
     x-f5xc-examples:
       - value: 'default'
         context: 'Default namespace'
@@ -181,6 +181,29 @@ field_patterns:
     x-f5xc-completion:
       type: 'file-path'
       hint: 'File path reference'
+
+  - pattern: '\bexpected_status_codes$'
+    x-f5xc-description: 'List of expected HTTP status codes or code ranges for health check validation'
+    x-f5xc-validation:
+      type: array
+      maxItems: 16
+    x-f5xc-examples:
+      - value: '200'
+        context: 'Single status code'
+      - value: '200-299'
+        context: 'Status code range'
+    x-f5xc-completion:
+      type: 'string-value'
+      hint: 'HTTP status code (200) or range (200-299)'
+      pattern: '^\d{3}(-\d{3})?$'
+    x-f5xc-defaults:
+      value: null
+      reasoning: 'Empty list means accept 200-299 by default'
+    x-f5xc-required-for-operations:
+      create: false
+      read: false
+      update: false
+      delete: false
 
 # Deprecation database - mark fields as deprecated
 deprecations: []

--- a/config/readonly_fields.yaml
+++ b/config/readonly_fields.yaml
@@ -75,3 +75,13 @@ metadata_patterns:
   - "ObjectMetaType"
   - ".*MetadataType$"
   - "SystemMetadata"
+
+# Resource-specific response-only fields (tracking only — not yet enforced by ReadOnlyEnricher)
+# These fields are documented here for audit purposes. Context-aware readOnly marking
+# requires the constraint prober (Phase 3) to identify them per schema.
+resource_specific_fields:
+  healthcheck:
+    jitter:
+      description: "Server-computed absolute jitter value derived from jitter_percent"
+      reason: "Computed by API from jitter_percent; read-only in responses"
+      schema_pattern: "healthcheck.*SpecType"

--- a/docs/specifications/api/admin_console_and_ui.json
+++ b/docs/specifications/api/admin_console_and_ui.json
@@ -611,7 +611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.542721+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -634,7 +634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.542786+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -646,7 +646,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501212+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402088+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -722,7 +722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.542833+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -768,23 +768,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.542878+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048421+00:00"
               },
               "deterministic": true
             },
@@ -797,7 +797,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501276+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402124+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -916,7 +916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:08.543005+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048484+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -932,7 +932,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501349+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402159+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -988,23 +988,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.543053+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048506+00:00"
               },
               "deterministic": true
             },
@@ -1017,7 +1017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501398+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402188+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1034,16 +1034,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.543088+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048522+00:00"
               },
               "deterministic": true
             },
@@ -1056,7 +1061,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501423+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402203+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -1101,7 +1106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543126+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1114,7 +1119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501451+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402220+00:00"
           },
           "name": {
             "type": "string",
@@ -1131,23 +1136,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.543158+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048557+00:00"
               },
               "deterministic": true
             },
@@ -1160,7 +1165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501476+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402236+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1177,16 +1182,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.543192+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048574+00:00"
               },
               "deterministic": true
             },
@@ -1199,7 +1209,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501501+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402252+00:00"
           },
           "tenant": {
             "type": "string",
@@ -1218,7 +1228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543233+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1232,7 +1242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501527+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402268+00:00"
           },
           "uid": {
             "type": "string",
@@ -1251,7 +1261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543262+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1266,7 +1276,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501556+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402284+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -1327,7 +1337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543316+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1339,7 +1349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501597+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402306+00:00"
           },
           "status": {
             "type": "string",
@@ -1357,7 +1367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543370+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1369,7 +1379,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501622+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402322+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -1411,7 +1421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543422+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1438,7 +1448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543472+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1465,7 +1475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543516+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1493,7 +1503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543568+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1558,7 +1568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543636+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1607,7 +1617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543690+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1620,7 +1630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501738+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402393+00:00"
           },
           "uid": {
             "type": "string",
@@ -1639,7 +1649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543720+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1653,7 +1663,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501767+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402412+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -1703,7 +1713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543755+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1715,7 +1725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501795+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402428+00:00"
           },
           "name": {
             "type": "string",
@@ -1732,23 +1742,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.543788+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048845+00:00"
               },
               "deterministic": true
             },
@@ -1761,7 +1771,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501821+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402444+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1778,16 +1788,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.543821+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048861+00:00"
               },
               "deterministic": true
             },
@@ -1800,7 +1815,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501849+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402460+00:00"
           },
           "uid": {
             "type": "string",
@@ -1817,7 +1832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.543850+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1831,7 +1846,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501877+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402478+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -1960,7 +1975,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.501959+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402531+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -2017,7 +2032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:08.543959+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2080,7 +2095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:08.544016+00:00"
+                "validatedAt": "2026-05-05T18:46:01.048948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2092,7 +2107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.502020+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402573+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -2142,23 +2157,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.544055+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048966+00:00"
               },
               "deterministic": true
             },
@@ -2171,7 +2186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.502082+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402622+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2186,16 +2201,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:08.544087+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:01.048982+00:00"
               },
               "deterministic": true
             },
@@ -2208,7 +2228,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.502111+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402639+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -2231,7 +2251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.544127+00:00"
+                "validatedAt": "2026-05-05T18:46:01.049000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2244,7 +2264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.502157+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402665+00:00"
           },
           "uid": {
             "type": "string",
@@ -2262,7 +2282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:08.544156+00:00"
+                "validatedAt": "2026-05-05T18:46:01.049014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2276,7 +2296,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.502187+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.402681+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of static_component is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",

--- a/docs/specifications/api/ai_services.json
+++ b/docs/specifications/api/ai_services.json
@@ -2475,7 +2475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.624817+00:00"
+                "validatedAt": "2026-05-05T18:39:55.590980+00:00"
               },
               "deterministic": true
             },
@@ -2500,16 +2500,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.624868+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.591005+00:00"
               },
               "deterministic": true
             },
@@ -2522,7 +2527,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320474+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.554744+00:00"
           },
           "negative_feedback": {
             "$ref": "#/components/schemas/ai_assistantNegativeFeedbackDetails"
@@ -2546,7 +2551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:03.624925+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2579,7 +2584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.625020+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2630,7 +2635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625074+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2654,16 +2659,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.625113+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.591118+00:00"
               },
               "deterministic": true
             },
@@ -2676,7 +2686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320557+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.554799+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -2715,7 +2725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625164+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2753,7 +2763,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.625228+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2795,7 +2805,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.625340+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2866,7 +2876,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.625404+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3069,7 +3079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625445+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3081,7 +3091,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320695+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.554885+00:00"
           },
           "log_filters": {
             "type": "array",
@@ -3111,16 +3121,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.625496+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.591283+00:00"
               },
               "deterministic": true
             },
@@ -3133,7 +3148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320732+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.554907+00:00"
           },
           "object_name": {
             "type": "string",
@@ -3150,7 +3165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625543+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3175,7 +3190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625588+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3200,7 +3215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625625+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3212,7 +3227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320778+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.554934+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/commonDashboardLinkType"
@@ -3306,7 +3321,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.625679+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3382,23 +3397,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.625719+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.591386+00:00"
               },
               "deterministic": true
             },
@@ -3411,7 +3426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320863+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.554985+00:00"
           },
           "title": {
             "type": "string",
@@ -3428,7 +3443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625757+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3440,7 +3455,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320891+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555001+00:00"
           },
           "tooltip": {
             "type": "string",
@@ -3455,7 +3470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625798+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3565,7 +3580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625835+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3577,7 +3592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320939+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555030+00:00"
           },
           "title": {
             "type": "string",
@@ -3594,7 +3609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625870+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3606,7 +3621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.320965+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555046+00:00"
           },
           "url": {
             "type": "string",
@@ -3631,7 +3646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:04:03.625906+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591472+00:00"
               },
               "deterministic": true
             },
@@ -3698,7 +3713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625952+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3773,7 +3788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.625985+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3785,7 +3800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321051+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555097+00:00"
           },
           "op": {
             "$ref": "#/components/schemas/commonFilterOperator"
@@ -3814,7 +3829,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.626034+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3864,7 +3879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626076+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3876,7 +3891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321104+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555130+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/commonDashboardLinkType"
@@ -3918,7 +3933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626120+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3943,7 +3958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626167+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3968,7 +3983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626209+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3993,7 +4008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626253+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591636+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4018,7 +4033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626292+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4043,7 +4058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626349+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4174,7 +4189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626399+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4197,23 +4212,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.626439+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.591712+00:00"
               },
               "deterministic": true
             },
@@ -4226,7 +4241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321207+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555192+00:00"
           },
           "type": {
             "type": "string",
@@ -4243,7 +4258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626482+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4293,7 +4308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626536+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4318,7 +4333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626577+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4343,7 +4358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626616+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4368,7 +4383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626665+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4442,7 +4457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626712+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4467,7 +4482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626755+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4498,7 +4513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626800+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4579,7 +4594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626844+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4592,7 +4607,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321370+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555282+00:00"
           },
           "rsp_code": {
             "type": "integer",
@@ -4624,7 +4639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626916+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4649,7 +4664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.626978+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4700,7 +4715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627028+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4725,7 +4740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627070+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4752,7 +4767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627100+00:00"
+                "validatedAt": "2026-05-05T18:39:55.591996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4777,7 +4792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627149+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4800,23 +4815,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.627183+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.592034+00:00"
               },
               "deterministic": true
             },
@@ -4829,7 +4844,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321468+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555340+00:00"
           },
           "state": {
             "type": "string",
@@ -4847,7 +4862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627221+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4924,7 +4939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627283+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4949,7 +4964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627349+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4974,7 +4989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627398+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5025,7 +5040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627447+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5052,7 +5067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627476+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5075,23 +5090,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.627509+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.592173+00:00"
               },
               "deterministic": true
             },
@@ -5104,7 +5119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321588+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555409+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5143,7 +5158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627557+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5168,7 +5183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627597+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5193,7 +5208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627644+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5216,23 +5231,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:03.627677+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:55.592259+00:00"
               },
               "deterministic": true
             },
@@ -5245,7 +5260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321642+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555441+00:00"
           },
           "state": {
             "type": "string",
@@ -5263,7 +5278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627714+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5315,7 +5330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627763+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5421,7 +5436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627848+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5462,7 +5477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627898+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5530,7 +5545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:03.627945+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5542,7 +5557,7 @@
             "maxLength": 26,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321780+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555522+00:00"
           },
           "title": {
             "type": "string",
@@ -5559,7 +5574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.627982+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5571,7 +5586,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321806+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555538+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5619,7 +5634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.628038+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5647,7 +5662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:03.628075+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5672,7 +5687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628114+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5747,7 +5762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628163+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5770,7 +5785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628202+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5782,7 +5797,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321875+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555578+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -5874,7 +5889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628246+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5932,7 +5947,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.628303+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5967,7 +5982,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.628367+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5995,7 +6010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628409+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6050,7 +6065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628450+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6062,7 +6077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.321994+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.555660+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6144,7 +6159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:03.628518+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6231,7 +6246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:03.628581+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6256,7 +6271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:03.628621+00:00"
+                "validatedAt": "2026-05-05T18:39:55.592695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6358,7 +6373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:01.758636+00:00"
+                "validatedAt": "2026-05-05T18:40:23.528339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6405,7 +6420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:01.758704+00:00"
+                "validatedAt": "2026-05-05T18:40:23.528370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6450,7 +6465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:05.578086+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6496,7 +6511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:05.578167+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6523,7 +6538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:05.578217+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6550,7 +6565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:05.578265+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6577,7 +6592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:05:05.578317+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6625,7 +6640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:05.578395+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6671,7 +6686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:05:05.578443+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6716,7 +6731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:05.578492+00:00"
+                "validatedAt": "2026-05-05T18:40:25.505885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6779,7 +6794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:11.329015+00:00"
+                "validatedAt": "2026-05-05T18:44:00.828139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6840,7 +6855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:11.329093+00:00"
+                "validatedAt": "2026-05-05T18:44:00.828173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6866,7 +6881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:11.329124+00:00"
+                "validatedAt": "2026-05-05T18:44:00.828186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6914,7 +6929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:11.329167+00:00"
+                "validatedAt": "2026-05-05T18:44:00.828206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6947,7 +6962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:11.329228+00:00"
+                "validatedAt": "2026-05-05T18:44:00.828241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6994,7 +7009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:11.329274+00:00"
+                "validatedAt": "2026-05-05T18:44:00.828263+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/api.json
+++ b/docs/specifications/api/api.json
@@ -11987,7 +11987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.677713+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12099,7 +12099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.677871+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538329+00:00"
               },
               "deterministic": true
             },
@@ -12157,23 +12157,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.677940+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.538349+00:00"
               },
               "deterministic": true
             },
@@ -12186,7 +12186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.359810+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.576843+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12202,16 +12202,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.677992+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.538366+00:00"
               },
               "deterministic": true
             },
@@ -12224,7 +12229,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.359840+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.576861+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12276,7 +12281,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.678109+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12289,7 +12294,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.359873+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.576879+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/api_crawlerSimpleLogin"
@@ -12394,7 +12399,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.359971+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577019+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -12453,7 +12458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.678257+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538468+00:00"
               },
               "deterministic": true
             },
@@ -12519,7 +12524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:05.678306+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12582,7 +12587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:05.678389+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12594,7 +12599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360053+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577068+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12644,23 +12649,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.678432+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.538538+00:00"
               },
               "deterministic": true
             },
@@ -12673,7 +12678,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360348+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577105+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12688,16 +12693,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.678465+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.538555+00:00"
               },
               "deterministic": true
             },
@@ -12710,7 +12720,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360376+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577121+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -12749,7 +12759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678524+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12762,7 +12772,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360428+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577153+00:00"
           },
           "uid": {
             "type": "string",
@@ -12779,7 +12789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678555+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12793,7 +12803,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360456+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577169+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_crawler is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -12895,7 +12905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.678630+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538634+00:00"
               },
               "deterministic": true
             },
@@ -12942,7 +12952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678683+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12967,7 +12977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678725+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12980,7 +12990,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360527+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577210+00:00"
           },
           "endpoint_count": {
             "type": "integer",
@@ -13013,7 +13023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678786+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13039,7 +13049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678842+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13065,7 +13075,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.678894+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13160,7 +13170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.678961+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538779+00:00"
               },
               "deterministic": true
             },
@@ -13286,7 +13296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679039+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13299,7 +13309,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360664+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577293+00:00"
           },
           "name": {
             "type": "string",
@@ -13316,23 +13326,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.679073+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.538830+00:00"
               },
               "deterministic": true
             },
@@ -13345,7 +13355,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360691+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577309+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13362,16 +13372,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.679106+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.538846+00:00"
               },
               "deterministic": true
             },
@@ -13384,7 +13399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360719+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577324+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13403,7 +13418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679145+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13417,7 +13432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360746+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577341+00:00"
           },
           "uid": {
             "type": "string",
@@ -13436,7 +13451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679175+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13451,7 +13466,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360772+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577357+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13489,7 +13504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679220+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13512,7 +13527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679260+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13524,7 +13539,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360810+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577380+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -13567,7 +13582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679313+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13605,7 +13620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.679395+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13617,7 +13632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360851+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577403+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -13636,7 +13651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679446+00:00"
+                "validatedAt": "2026-05-05T18:39:56.538995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13687,7 +13702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679490+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13699,7 +13714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360892+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577426+00:00"
           },
           "url": {
             "type": "string",
@@ -13737,7 +13752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.679562+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539052+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13794,7 +13809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.679602+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539069+00:00"
               },
               "deterministic": true
             },
@@ -13820,7 +13835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679652+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13846,7 +13861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679694+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13858,7 +13873,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360947+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577459+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13875,7 +13890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679742+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13908,7 +13923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679786+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13920,7 +13935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.360982+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577480+00:00"
           },
           "type": {
             "type": "string",
@@ -13945,7 +13960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679824+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14033,7 +14048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.679870+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14079,23 +14094,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.679906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539208+00:00"
               },
               "deterministic": true
             },
@@ -14108,7 +14123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361048+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577520+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14226,7 +14241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.680016+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539259+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14242,7 +14257,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361106+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577555+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14296,23 +14311,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.680059+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539279+00:00"
               },
               "deterministic": true
             },
@@ -14325,7 +14340,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361152+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577582+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14342,16 +14357,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.680093+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539296+00:00"
               },
               "deterministic": true
             },
@@ -14364,7 +14384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361177+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577597+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -14446,7 +14466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.680182+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539340+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14462,7 +14482,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361215+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577627+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14518,23 +14538,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.680225+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539359+00:00"
               },
               "deterministic": true
             },
@@ -14547,7 +14567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361260+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577655+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14564,16 +14584,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.680257+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539374+00:00"
               },
               "deterministic": true
             },
@@ -14586,7 +14611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361285+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577671+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14668,7 +14693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:05.680357+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539418+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14684,7 +14709,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361332+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577694+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14738,23 +14763,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.680397+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539437+00:00"
               },
               "deterministic": true
             },
@@ -14767,7 +14792,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361377+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577722+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14784,16 +14809,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.680429+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539453+00:00"
               },
               "deterministic": true
             },
@@ -14806,7 +14836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361403+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577738+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -14901,7 +14931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680486+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14929,7 +14959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680536+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14957,7 +14987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680582+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14986,7 +15016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680626+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15013,7 +15043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680657+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15027,7 +15057,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361495+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577793+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15043,7 +15073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680701+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15152,7 +15182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680756+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15164,7 +15194,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361551+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577826+00:00"
           },
           "status": {
             "type": "string",
@@ -15182,7 +15212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680795+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15194,7 +15224,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361579+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577842+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15236,7 +15266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680848+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15263,7 +15293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680895+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15290,7 +15320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680940+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15318,7 +15348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.680990+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15383,7 +15413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.681060+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15432,7 +15462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.681116+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15445,7 +15475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361695+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577912+00:00"
           },
           "uid": {
             "type": "string",
@@ -15464,7 +15494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.681144+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15478,7 +15508,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361722+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577928+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -15528,7 +15558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.681190+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15540,7 +15570,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361751+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577945+00:00"
           },
           "name": {
             "type": "string",
@@ -15557,23 +15587,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.681225+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539807+00:00"
               },
               "deterministic": true
             },
@@ -15586,7 +15616,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361776+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577961+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15603,16 +15633,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:05.681260+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:56.539824+00:00"
               },
               "deterministic": true
             },
@@ -15625,7 +15660,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361803+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577977+00:00"
           },
           "uid": {
             "type": "string",
@@ -15642,7 +15677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:05.681295+00:00"
+                "validatedAt": "2026-05-05T18:39:56.539837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15656,7 +15691,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.361829+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.577993+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -15714,7 +15749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.909020+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15738,23 +15773,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909080+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553163+00:00"
               },
               "deterministic": true
             },
@@ -15767,7 +15802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404292+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601102+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15783,16 +15818,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909115+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553180+00:00"
               },
               "deterministic": true
             },
@@ -15805,7 +15845,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404335+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601119+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for various API Inventory Requests.",
@@ -15893,7 +15933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:07.909183+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15923,23 +15963,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909224+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553226+00:00"
               },
               "deterministic": true
             },
@@ -15952,7 +15992,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404388+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601149+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16057,23 +16097,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909272+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553248+00:00"
               },
               "deterministic": true
             },
@@ -16086,7 +16126,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404476+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601198+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16102,16 +16142,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909304+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553263+00:00"
               },
               "deterministic": true
             },
@@ -16124,7 +16169,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404502+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601214+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16301,7 +16346,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404616+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601280+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16402,7 +16447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:07.909483+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16465,7 +16510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:07.909548+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16477,7 +16522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404696+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601326+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -16527,23 +16572,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909593+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553376+00:00"
               },
               "deterministic": true
             },
@@ -16556,7 +16601,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404758+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601364+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16571,16 +16616,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.909625+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553392+00:00"
               },
               "deterministic": true
             },
@@ -16593,7 +16643,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404784+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601380+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -16632,7 +16682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:07.909680+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16645,7 +16695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404836+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601411+00:00"
           },
           "uid": {
             "type": "string",
@@ -16662,7 +16712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:07.909709+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16676,7 +16726,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.404865+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601428+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_definition is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16907,7 +16957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:07.910442+00:00"
+                "validatedAt": "2026-05-05T18:39:57.553763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16919,7 +16969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.405311+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601696+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16949,23 +16999,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:07.910477+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:57.553779+00:00"
               },
               "deterministic": true
             },
@@ -16978,7 +17028,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.405358+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.601718+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Message Metadata\" MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -17041,7 +17091,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.911918+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17088,7 +17138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912003+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17147,23 +17197,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912068+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554487+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17179,7 +17229,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.406150+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.602189+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17202,16 +17252,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912123+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554517+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17227,7 +17282,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.406177+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.602206+00:00"
           },
           "tenant": {
             "type": "string",
@@ -17256,7 +17311,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912187+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17270,7 +17325,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.406203+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.602221+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -17332,7 +17387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912269+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554589+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -17396,7 +17451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912343+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17433,7 +17488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912403+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17472,7 +17527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912463+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554684+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17519,7 +17574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912520+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17600,7 +17655,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912597+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17637,7 +17692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912659+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17676,7 +17731,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912719+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17723,7 +17778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912781+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17788,7 +17843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912843+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17825,7 +17880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912898+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17864,7 +17919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.912955+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17911,7 +17966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:07.913012+00:00"
+                "validatedAt": "2026-05-05T18:39:57.554955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18050,7 +18105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:09.934802+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18115,7 +18170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:09.934959+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18176,23 +18231,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:09.935012+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:58.480636+00:00"
               },
               "deterministic": true
             },
@@ -18205,7 +18260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456555+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629587+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18221,16 +18276,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:09.935048+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:58.480653+00:00"
               },
               "deterministic": true
             },
@@ -18243,7 +18303,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456585+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629605+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18346,7 +18406,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456674+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629665+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18402,7 +18462,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:09.935177+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18468,7 +18528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:09.935231+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18531,7 +18591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:09.935299+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18543,7 +18603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456756+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629712+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18593,23 +18653,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:09.935353+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:58.480782+00:00"
               },
               "deterministic": true
             },
@@ -18622,7 +18682,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456820+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629750+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18637,16 +18697,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:09.935384+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:58.480798+00:00"
               },
               "deterministic": true
             },
@@ -18659,7 +18724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456846+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629768+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18698,7 +18763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:09.935440+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18711,7 +18776,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456898+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629799+00:00"
           },
           "uid": {
             "type": "string",
@@ -18728,7 +18793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:09.935471+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18742,7 +18807,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.456926+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.629816+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_discovery is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18841,7 +18906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:09.935537+00:00"
+                "validatedAt": "2026-05-05T18:39:58.480869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19002,7 +19067,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490179+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648048+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19068,7 +19133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:11.815976+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19130,7 +19195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:11.816059+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19142,7 +19207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490254+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648090+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19192,23 +19257,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:11.816105+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:59.350295+00:00"
               },
               "deterministic": true
             },
@@ -19221,7 +19286,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490339+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648127+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19236,16 +19301,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:11.816139+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:59.350311+00:00"
               },
               "deterministic": true
             },
@@ -19258,7 +19328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490366+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648143+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19297,7 +19367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:11.816195+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19310,7 +19380,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490417+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648194+00:00"
           },
           "uid": {
             "type": "string",
@@ -19327,7 +19397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:11.816229+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19341,7 +19411,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490445+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648218+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19451,7 +19521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:11.816947+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19464,7 +19534,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490828+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648452+00:00"
           },
           "name": {
             "type": "string",
@@ -19481,23 +19551,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:11.816979+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:59.350704+00:00"
               },
               "deterministic": true
             },
@@ -19510,7 +19580,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490855+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648467+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19527,16 +19597,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:11.817011+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:39:59.350720+00:00"
               },
               "deterministic": true
             },
@@ -19549,7 +19624,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490882+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648483+00:00"
           },
           "tenant": {
             "type": "string",
@@ -19568,7 +19643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:11.817050+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19582,7 +19657,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490909+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648499+00:00"
           },
           "uid": {
             "type": "string",
@@ -19601,7 +19676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:11.817080+00:00"
+                "validatedAt": "2026-05-05T18:39:59.350750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19616,7 +19691,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.490937+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.648516+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -19665,7 +19740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:11.818011+00:00"
+                "validatedAt": "2026-05-05T18:39:59.351169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19697,7 +19772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:11.818073+00:00"
+                "validatedAt": "2026-05-05T18:39:59.351203+00:00"
               },
               "deterministic": true
             },
@@ -19803,7 +19878,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.515744+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.661531+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19870,7 +19945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:13.668964+00:00"
+                "validatedAt": "2026-05-05T18:40:00.210882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19916,7 +19991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:13.669052+00:00"
+                "validatedAt": "2026-05-05T18:40:00.210947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19983,7 +20058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:13.669110+00:00"
+                "validatedAt": "2026-05-05T18:40:00.210983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20046,7 +20121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:13.669179+00:00"
+                "validatedAt": "2026-05-05T18:40:00.211016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20058,7 +20133,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.515838+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.661583+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20108,23 +20183,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:13.669222+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:00.211035+00:00"
               },
               "deterministic": true
             },
@@ -20137,7 +20212,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.515904+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.661625+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20152,16 +20227,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:13.669257+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:00.211054+00:00"
               },
               "deterministic": true
             },
@@ -20174,7 +20254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.515933+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.661641+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20213,7 +20293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:13.669312+00:00"
+                "validatedAt": "2026-05-05T18:40:00.211079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20226,7 +20306,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.515987+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.661672+00:00"
           },
           "uid": {
             "type": "string",
@@ -20244,7 +20324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:13.669358+00:00"
+                "validatedAt": "2026-05-05T18:40:00.211094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20258,7 +20338,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.516015+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.661688+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_group_element is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -20372,7 +20452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.695361+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20384,7 +20464,7 @@
             "x-original-maxLength": 128,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544278+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676240+00:00"
           },
           "value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -20440,7 +20520,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.695446+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148231+00:00"
               },
               "deterministic": true
             },
@@ -20569,7 +20649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.695542+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20606,7 +20686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.695618+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148311+00:00"
               },
               "deterministic": true
             },
@@ -20689,7 +20769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.695704+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20759,23 +20839,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:15.695753+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:01.148373+00:00"
               },
               "deterministic": true
             },
@@ -20788,7 +20868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544528+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676381+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20804,16 +20884,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:15.695789+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:01.148389+00:00"
               },
               "deterministic": true
             },
@@ -20826,7 +20911,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544555+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676397+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20916,7 +21001,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.695887+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20929,7 +21014,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544604+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676425+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21032,7 +21117,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544694+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676480+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -21085,7 +21170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.696037+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21122,7 +21207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.696109+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148535+00:00"
               },
               "deterministic": true
             },
@@ -21201,7 +21286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:15.696158+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21264,7 +21349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:15.696222+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21276,7 +21361,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544811+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676546+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21326,23 +21411,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:15.696260+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:01.148604+00:00"
               },
               "deterministic": true
             },
@@ -21355,7 +21440,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544878+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676583+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21370,16 +21455,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:15.696293+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:01.148627+00:00"
               },
               "deterministic": true
             },
@@ -21392,7 +21482,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544904+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676598+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21431,7 +21521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:15.696361+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21444,7 +21534,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544956+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676636+00:00"
           },
           "uid": {
             "type": "string",
@@ -21461,7 +21551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:15.696392+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21475,7 +21565,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.544985+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.676652+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of api_testing is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21543,7 +21633,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.696478+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148709+00:00"
               },
               "deterministic": true
             },
@@ -21574,7 +21664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:15.696533+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21667,7 +21757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.696620+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21704,7 +21794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:15.696685+00:00"
+                "validatedAt": "2026-05-05T18:40:01.148810+00:00"
               },
               "deterministic": true
             },
@@ -21868,7 +21958,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.987288+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21975,7 +22065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987408+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22039,23 +22129,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987473+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217750+00:00"
               },
               "deterministic": true
             },
@@ -22068,7 +22158,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593453+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702355+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22083,16 +22173,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987509+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217767+00:00"
               },
               "deterministic": true
             },
@@ -22105,7 +22200,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593484+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702372+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/api_credentialCustomCreateSpecType"
@@ -22164,7 +22259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987553+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22188,7 +22283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987610+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22208,23 +22303,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987648+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217829+00:00"
               },
               "deterministic": true
             },
@@ -22237,7 +22332,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593550+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702411+00:00"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -22300,23 +22395,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987702+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217853+00:00"
               },
               "deterministic": true
             },
@@ -22329,7 +22424,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593608+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702443+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22344,16 +22439,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987736+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217869+00:00"
               },
               "deterministic": true
             },
@@ -22366,7 +22466,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593637+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702459+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -22410,7 +22510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987799+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22460,7 +22560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987865+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22486,7 +22586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987919+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22557,7 +22657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987969+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22586,7 +22686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988020+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22612,7 +22712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988074+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22694,23 +22794,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988118+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218036+00:00"
               },
               "deterministic": true
             },
@@ -22723,7 +22823,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593792+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702550+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22746,16 +22846,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988157+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218055+00:00"
               },
               "deterministic": true
             },
@@ -22768,7 +22873,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593820+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702565+00:00"
           }
         },
         "x-f5xc-description-short": "GET credential object with a given name.",
@@ -22847,7 +22952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988215+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22872,7 +22977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988267+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22895,23 +23000,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988300+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218116+00:00"
               },
               "deterministic": true
             },
@@ -22924,7 +23029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593885+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702604+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22939,16 +23044,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988341+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218132+00:00"
               },
               "deterministic": true
             },
@@ -22961,7 +23071,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593912+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702633+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -22984,7 +23094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988372+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22998,7 +23108,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593958+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702660+00:00"
           },
           "user_email": {
             "type": "string",
@@ -23016,7 +23126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988418+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23110,7 +23220,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.988527+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23135,7 +23245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988578+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23158,7 +23268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988618+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23183,7 +23293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988671+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23208,7 +23318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988716+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23245,7 +23355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.988774+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23269,7 +23379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988824+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23293,7 +23403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988876+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23351,7 +23461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:17.988920+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23413,7 +23523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988974+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23438,7 +23548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989028+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23461,23 +23571,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989065+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218455+00:00"
               },
               "deterministic": true
             },
@@ -23490,7 +23600,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594132+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702762+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23505,16 +23615,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989099+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218470+00:00"
               },
               "deterministic": true
             },
@@ -23527,7 +23642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594158+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702781+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/api_credentialAPICredentialType"
@@ -23547,7 +23662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989131+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23561,7 +23676,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594196+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702803+00:00"
           },
           "user_email": {
             "type": "string",
@@ -23579,7 +23694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989176+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23634,7 +23749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:17.989214+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23696,7 +23811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989269+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23721,7 +23836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989318+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23744,23 +23859,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989364+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218586+00:00"
               },
               "deterministic": true
             },
@@ -23773,7 +23888,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594271+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702847+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23788,16 +23903,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989397+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218602+00:00"
               },
               "deterministic": true
             },
@@ -23810,7 +23930,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594298+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702862+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -23833,7 +23953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989431+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23847,7 +23967,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594357+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702889+00:00"
           },
           "user_email": {
             "type": "string",
@@ -23865,7 +23985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989476+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23958,7 +24078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.989552+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24058,16 +24178,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989617+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218711+00:00"
               },
               "deterministic": true
             },
@@ -24080,7 +24205,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594453+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702944+00:00"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -24141,23 +24266,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989674+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218735+00:00"
               },
               "deterministic": true
             },
@@ -24170,7 +24295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594491+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702967+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24193,16 +24318,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989710+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218756+00:00"
               },
               "deterministic": true
             },
@@ -24215,7 +24345,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594520+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702983+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24260,23 +24390,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989747+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218775+00:00"
               },
               "deterministic": true
             },
@@ -24289,7 +24419,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594547+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702999+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24305,16 +24435,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989778+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218790+00:00"
               },
               "deterministic": true
             },
@@ -24327,7 +24462,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594575+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703016+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -24405,7 +24540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989851+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24428,23 +24563,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989884+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218836+00:00"
               },
               "deterministic": true
             },
@@ -24457,7 +24592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594641+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703053+00:00"
           }
         },
         "x-f5xc-description-short": "Response format for the credential's replace request.",
@@ -24503,16 +24638,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989923+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218855+00:00"
               },
               "deterministic": true
             },
@@ -24525,7 +24665,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594670+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703070+00:00"
           }
         },
         "x-f5xc-description-short": "ScimTokenRequest is used for fetching or revoking scim token.",
@@ -24582,7 +24722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.989997+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24653,7 +24793,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594719+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703099+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24696,7 +24836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990059+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24728,7 +24868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990110+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24842,16 +24982,21 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.990234+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218999+00:00"
               },
               "deterministic": true
             },
@@ -24864,7 +25009,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594832+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703164+00:00"
           },
           "role": {
             "type": "string",
@@ -24894,7 +25039,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.990298+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24979,7 +25124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.990399+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219073+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24995,7 +25140,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594880+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703192+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -25051,23 +25196,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990441+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219092+00:00"
               },
               "deterministic": true
             },
@@ -25080,7 +25225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594924+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703219+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25097,16 +25242,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990471+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219107+00:00"
               },
               "deterministic": true
             },
@@ -25119,7 +25269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594950+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703235+00:00"
           },
           "uid": {
             "type": "string",
@@ -25138,7 +25288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990501+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25153,7 +25303,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594979+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703251+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -25200,7 +25350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990817+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25228,7 +25378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990864+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25257,7 +25407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990912+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25284,7 +25434,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990954+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25313,7 +25463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991005+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25338,7 +25488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991061+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25403,7 +25553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991135+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25441,7 +25591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.991196+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25453,7 +25603,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595293+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703436+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -25494,7 +25644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991257+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25538,7 +25688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991301+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25552,7 +25702,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595365+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703472+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -25571,7 +25721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991357+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25598,7 +25748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991389+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25613,7 +25763,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595400+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703493+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -25628,7 +25778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991431+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25730,7 +25880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:36.894293+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287631+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -25780,23 +25930,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894368+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287655+00:00"
               },
               "deterministic": true
             },
@@ -25809,7 +25959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980381+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.911796+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25824,16 +25974,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894405+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287671+00:00"
               },
               "deterministic": true
             },
@@ -25846,7 +26001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980411+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.911812+00:00"
           }
         },
         "x-f5xc-description-short": "The API Group ID for the API Groups stats response.",
@@ -26089,23 +26244,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894490+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287705+00:00"
               },
               "deterministic": true
             },
@@ -26118,7 +26273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980559+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.911898+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26134,16 +26289,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894523+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287721+00:00"
               },
               "deterministic": true
             },
@@ -26156,7 +26316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980585+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.911914+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26197,16 +26357,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894561+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287738+00:00"
               },
               "deterministic": true
             },
@@ -26219,7 +26384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980622+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.911936+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26262,7 +26427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:36.894613+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26327,16 +26492,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894671+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287797+00:00"
               },
               "deterministic": true
             },
@@ -26349,7 +26519,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980678+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.911970+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26390,7 +26560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:36.894710+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26500,7 +26670,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980780+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.912028+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26568,7 +26738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:36.894821+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26631,7 +26801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:36.894883+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26643,7 +26813,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980848+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.912068+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26693,23 +26863,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894922+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287913+00:00"
               },
               "deterministic": true
             },
@@ -26722,7 +26892,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980911+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.912105+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26737,16 +26907,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:36.894954+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:11.287929+00:00"
               },
               "deterministic": true
             },
@@ -26759,7 +26934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980938+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.912121+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26798,7 +26973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:36.895008+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26811,7 +26986,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.980989+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.912151+00:00"
           },
           "uid": {
             "type": "string",
@@ -26828,7 +27003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:36.895039+00:00"
+                "validatedAt": "2026-05-05T18:40:11.287966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26842,7 +27017,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.981017+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.912168+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_api_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27009,7 +27184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:36.897678+00:00"
+                "validatedAt": "2026-05-05T18:40:11.289139+00:00"
               },
               "deterministic": true
             },
@@ -27097,7 +27272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:36.897781+00:00"
+                "validatedAt": "2026-05-05T18:40:11.289177+00:00"
               },
               "deterministic": true
             },
@@ -27188,7 +27363,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:36.897896+00:00"
+                "validatedAt": "2026-05-05T18:40:11.289214+00:00"
               },
               "deterministic": true
             },
@@ -27261,7 +27436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:36.897990+00:00"
+                "validatedAt": "2026-05-05T18:40:11.289246+00:00"
               },
               "deterministic": true
             },
@@ -27337,7 +27512,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173283+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27382,7 +27557,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173395+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27482,7 +27657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173470+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27520,7 +27695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173560+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936687+00:00"
               },
               "deterministic": true
             },
@@ -27587,7 +27762,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173645+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27633,7 +27808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173730+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27702,7 +27877,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173795+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27769,7 +27944,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173873+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27808,7 +27983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.173944+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27885,7 +28060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:46.174004+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28109,7 +28284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174085+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28183,7 +28358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174147+00:00"
+                "validatedAt": "2026-05-05T18:40:15.936976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28246,7 +28421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174220+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28285,7 +28460,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174295+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28326,7 +28501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174387+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28468,7 +28643,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174456+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29119,7 +29294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174711+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29178,7 +29353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174770+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29313,23 +29488,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174849+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937312+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -29345,7 +29520,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.221865+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040549+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -29417,7 +29592,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174910+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29523,7 +29698,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.174976+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29602,23 +29777,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175047+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937408+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -29634,7 +29809,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.221964+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040610+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -29731,7 +29906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175109+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29777,7 +29952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175167+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29815,7 +29990,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175225+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29894,7 +30069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175284+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29951,7 +30126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175355+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29988,7 +30163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175430+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937594+00:00"
               },
               "deterministic": true
             },
@@ -30024,7 +30199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175484+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30059,7 +30234,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175540+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30120,7 +30295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175598+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30161,7 +30336,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175659+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30203,7 +30378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175718+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30314,16 +30489,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:46.175761+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:15.937769+00:00"
               },
               "deterministic": true
             },
@@ -30336,7 +30516,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.222115+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040719+00:00"
           },
           "path": {
             "type": "string",
@@ -30367,7 +30547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.175839+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937808+00:00"
               },
               "deterministic": true
             },
@@ -30401,7 +30581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:46.175892+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30508,16 +30688,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:46.175950+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:15.937857+00:00"
               },
               "deterministic": true
             },
@@ -30530,7 +30715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.222203+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040774+00:00"
           },
           "path": {
             "type": "string",
@@ -30561,7 +30746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.176027+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937896+00:00"
               },
               "deterministic": true
             },
@@ -30595,7 +30780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:46.176080+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30691,16 +30876,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:46.176121+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:15.937941+00:00"
               },
               "deterministic": true
             },
@@ -30713,7 +30903,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.222293+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040830+00:00"
           },
           "path": {
             "type": "string",
@@ -30744,7 +30934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.176200+00:00"
+                "validatedAt": "2026-05-05T18:40:15.937980+00:00"
               },
               "deterministic": true
             },
@@ -30778,7 +30968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:46.176253+00:00"
+                "validatedAt": "2026-05-05T18:40:15.938003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30868,16 +31058,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:46.176297+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:15.938023+00:00"
               },
               "deterministic": true
             },
@@ -30890,7 +31085,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.222382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040878+00:00"
           },
           "path": {
             "type": "string",
@@ -30921,7 +31116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.176385+00:00"
+                "validatedAt": "2026-05-05T18:40:15.938061+00:00"
               },
               "deterministic": true
             },
@@ -30955,7 +31150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:46.176436+00:00"
+                "validatedAt": "2026-05-05T18:40:15.938087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31099,23 +31294,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.176725+00:00"
+                "validatedAt": "2026-05-05T18:40:15.938226+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31131,7 +31326,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.222559+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.040984+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -31191,7 +31386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.176782+00:00"
+                "validatedAt": "2026-05-05T18:40:15.938256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31274,7 +31469,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:46.176849+00:00"
+                "validatedAt": "2026-05-05T18:40:15.938289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31286,7 +31481,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.222632+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.041027+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -31394,7 +31589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.520917+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31455,7 +31650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:07:47.520972+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832791+00:00"
               },
               "deterministic": true
             },
@@ -31493,7 +31688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.521013+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31694,23 +31889,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:47.521073+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:49.832839+00:00"
               },
               "deterministic": true
             },
@@ -31723,7 +31918,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115130+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260221+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31739,16 +31934,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:47.521107+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:49.832857+00:00"
               },
               "deterministic": true
             },
@@ -31761,7 +31961,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115162+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260239+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31864,7 +32064,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260297+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -31951,7 +32151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:47.521263+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832926+00:00"
               },
               "deterministic": true
             },
@@ -32016,7 +32216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:47.521306+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832946+00:00"
               },
               "deterministic": true
             },
@@ -32054,7 +32254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.521359+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32115,7 +32315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.521397+00:00"
+                "validatedAt": "2026-05-05T18:41:49.832981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32212,7 +32412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:07:47.521442+00:00"
+                "validatedAt": "2026-05-05T18:41:49.833004+00:00"
               },
               "deterministic": true
             },
@@ -32288,7 +32488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.521484+00:00"
+                "validatedAt": "2026-05-05T18:41:49.833024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32300,7 +32500,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115446+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260410+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32358,7 +32558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:47.521537+00:00"
+                "validatedAt": "2026-05-05T18:41:49.833049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32421,7 +32621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:47.521601+00:00"
+                "validatedAt": "2026-05-05T18:41:49.833079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32433,7 +32633,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115507+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260447+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32483,23 +32683,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:47.521639+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:49.833100+00:00"
               },
               "deterministic": true
             },
@@ -32512,7 +32712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115567+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260485+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32527,16 +32727,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:47.521671+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:49.833116+00:00"
               },
               "deterministic": true
             },
@@ -32549,7 +32754,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115593+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260501+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32588,7 +32793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.521725+00:00"
+                "validatedAt": "2026-05-05T18:41:49.833141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32601,7 +32806,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115643+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260533+00:00"
           },
           "uid": {
             "type": "string",
@@ -32619,7 +32824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:47.521754+00:00"
+                "validatedAt": "2026-05-05T18:41:49.833155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32633,7 +32838,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.115670+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.260550+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of code_base_integration is returned in 'List'.",
@@ -32813,7 +33018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.710211+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32906,7 +33111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.710314+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33064,7 +33269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.710430+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33191,7 +33396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.710519+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33233,16 +33438,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.710559+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.369603+00:00"
               },
               "deterministic": true
             },
@@ -33255,7 +33465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.803673+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.895835+00:00"
           },
           "namespace_regex": {
             "type": "string",
@@ -33271,7 +33481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.710611+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33411,7 +33621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.710695+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33489,23 +33699,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.710738+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.369694+00:00"
               },
               "deterministic": true
             },
@@ -33518,7 +33728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.803836+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.895927+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33534,16 +33744,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.710772+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.369710+00:00"
               },
               "deterministic": true
             },
@@ -33556,7 +33771,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.803866+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.895944+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33603,7 +33818,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.710849+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33636,7 +33851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.710925+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33687,16 +33902,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.710997+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369818+00:00"
               },
               "deterministic": true
             },
@@ -33709,7 +33929,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.803926+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.895978+00:00"
           },
           "pods": {
             "type": "array",
@@ -33765,7 +33985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711088+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33798,7 +34018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711161+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33856,23 +34076,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.711201+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.369920+00:00"
               },
               "deterministic": true
             },
@@ -33885,7 +34105,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.803992+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896015+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33908,16 +34128,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.711235+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.369938+00:00"
               },
               "deterministic": true
             },
@@ -33930,7 +34155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804018+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896031+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33973,7 +34198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.711272+00:00"
+                "validatedAt": "2026-05-05T18:43:17.369956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34086,7 +34311,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804116+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896090+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -34143,7 +34368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711426+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34283,7 +34508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711501+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34384,7 +34609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711576+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370104+00:00"
               },
               "deterministic": true
             },
@@ -34429,16 +34654,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.711609+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.370121+00:00"
               },
               "deterministic": true
             },
@@ -34451,7 +34681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804299+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896199+00:00"
           },
           "namespace_regex": {
             "type": "string",
@@ -34477,7 +34707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711688+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34533,16 +34763,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.711751+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370190+00:00"
               },
               "deterministic": true
             },
@@ -34555,7 +34790,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804347+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896222+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34648,7 +34883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:46.711800+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34710,7 +34945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:46.711862+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34722,7 +34957,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804445+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896279+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34772,23 +35007,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.711903+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.370261+00:00"
               },
               "deterministic": true
             },
@@ -34801,7 +35036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804506+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896316+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34816,16 +35051,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.711935+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.370277+00:00"
               },
               "deterministic": true
             },
@@ -34838,7 +35078,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804535+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896331+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34877,7 +35117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.711989+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34890,7 +35130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804588+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896362+00:00"
           },
           "uid": {
             "type": "string",
@@ -34907,7 +35147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712019+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34921,7 +35161,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804615+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896379+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovery is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -34973,7 +35213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712058+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370334+00:00"
               },
               "deterministic": true
             },
@@ -35021,7 +35261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:46.712095+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35063,16 +35303,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:46.712129+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:17.370369+00:00"
               },
               "deterministic": true
             },
@@ -35085,7 +35330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.804665+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.896409+00:00"
           },
           "partition_regex": {
             "type": "string",
@@ -35101,7 +35346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712177+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35149,7 +35394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712206+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35174,7 +35419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712247+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35237,7 +35482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712285+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370443+00:00"
               },
               "deterministic": true
             },
@@ -35271,7 +35516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712340+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35396,7 +35641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712437+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35476,7 +35721,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712514+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35608,7 +35853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712640+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370605+00:00"
               },
               "deterministic": true
             },
@@ -35649,7 +35894,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712718+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35689,7 +35934,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.712800+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35766,7 +36011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712854+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35837,7 +36082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712907+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35875,7 +36120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.712954+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35900,7 +36145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:46.713000+00:00"
+                "validatedAt": "2026-05-05T18:43:17.370783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36005,7 +36250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.714062+00:00"
+                "validatedAt": "2026-05-05T18:43:17.371274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36106,7 +36351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.714619+00:00"
+                "validatedAt": "2026-05-05T18:43:17.371539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36177,7 +36422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:46.715388+00:00"
+                "validatedAt": "2026-05-05T18:43:17.371893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36256,7 +36501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:11.804538+00:00"
+                "validatedAt": "2026-05-05T18:43:30.830081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36300,7 +36545,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:11.804635+00:00"
+                "validatedAt": "2026-05-05T18:43:30.830128+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/authentication.json
+++ b/docs/specifications/api/authentication.json
@@ -3975,7 +3975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.987288+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4082,7 +4082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987408+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4146,23 +4146,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987473+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217750+00:00"
               },
               "deterministic": true
             },
@@ -4175,7 +4175,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593453+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702355+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4190,16 +4190,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987509+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217767+00:00"
               },
               "deterministic": true
             },
@@ -4212,7 +4217,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593484+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702372+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/api_credentialCustomCreateSpecType"
@@ -4271,7 +4276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987553+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4295,7 +4300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987610+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4315,23 +4320,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987648+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217829+00:00"
               },
               "deterministic": true
             },
@@ -4344,7 +4349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593550+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702411+00:00"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -4407,23 +4412,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987702+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217853+00:00"
               },
               "deterministic": true
             },
@@ -4436,7 +4441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593608+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702443+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4451,16 +4456,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.987736+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.217869+00:00"
               },
               "deterministic": true
             },
@@ -4473,7 +4483,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593637+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702459+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -4517,7 +4527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987799+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4567,7 +4577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987865+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4593,7 +4603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987919+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4664,7 +4674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.987969+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4693,7 +4703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988020+00:00"
+                "validatedAt": "2026-05-05T18:40:02.217994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4719,7 +4729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988074+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4801,23 +4811,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988118+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218036+00:00"
               },
               "deterministic": true
             },
@@ -4830,7 +4840,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593792+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702550+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4853,16 +4863,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988157+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218055+00:00"
               },
               "deterministic": true
             },
@@ -4875,7 +4890,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593820+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702565+00:00"
           }
         },
         "x-f5xc-description-short": "GET credential object with a given name.",
@@ -4954,7 +4969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988215+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4979,7 +4994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988267+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5002,23 +5017,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988300+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218116+00:00"
               },
               "deterministic": true
             },
@@ -5031,7 +5046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593885+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702604+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5046,16 +5061,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.988341+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218132+00:00"
               },
               "deterministic": true
             },
@@ -5068,7 +5088,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593912+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702633+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -5091,7 +5111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988372+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5105,7 +5125,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.593958+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702660+00:00"
           },
           "user_email": {
             "type": "string",
@@ -5123,7 +5143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988418+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5217,7 +5237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.988527+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5242,7 +5262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988578+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5265,7 +5285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988618+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5290,7 +5310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988671+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5315,7 +5335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988716+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5352,7 +5372,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.988774+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5376,7 +5396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988824+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5400,7 +5420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988876+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5458,7 +5478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:17.988920+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5520,7 +5540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.988974+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5545,7 +5565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989028+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5568,23 +5588,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989065+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218455+00:00"
               },
               "deterministic": true
             },
@@ -5597,7 +5617,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594132+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702762+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5612,16 +5632,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989099+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218470+00:00"
               },
               "deterministic": true
             },
@@ -5634,7 +5659,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594158+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702781+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/api_credentialAPICredentialType"
@@ -5654,7 +5679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989131+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5668,7 +5693,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594196+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702803+00:00"
           },
           "user_email": {
             "type": "string",
@@ -5686,7 +5711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989176+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5741,7 +5766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:17.989214+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5803,7 +5828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989269+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5828,7 +5853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989318+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5851,23 +5876,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989364+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218586+00:00"
               },
               "deterministic": true
             },
@@ -5880,7 +5905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594271+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702847+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5895,16 +5920,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989397+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218602+00:00"
               },
               "deterministic": true
             },
@@ -5917,7 +5947,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594298+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702862+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -5940,7 +5970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989431+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5954,7 +5984,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594357+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702889+00:00"
           },
           "user_email": {
             "type": "string",
@@ -5972,7 +6002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989476+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6065,7 +6095,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.989552+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6165,16 +6195,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989617+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218711+00:00"
               },
               "deterministic": true
             },
@@ -6187,7 +6222,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594453+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702944+00:00"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -6248,23 +6283,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989674+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218735+00:00"
               },
               "deterministic": true
             },
@@ -6277,7 +6312,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594491+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702967+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6300,16 +6335,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989710+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218756+00:00"
               },
               "deterministic": true
             },
@@ -6322,7 +6362,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594520+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702983+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6367,23 +6407,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989747+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218775+00:00"
               },
               "deterministic": true
             },
@@ -6396,7 +6436,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594547+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.702999+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6412,16 +6452,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989778+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218790+00:00"
               },
               "deterministic": true
             },
@@ -6434,7 +6479,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594575+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703016+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -6512,7 +6557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.989851+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6535,23 +6580,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989884+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218836+00:00"
               },
               "deterministic": true
             },
@@ -6564,7 +6609,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594641+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703053+00:00"
           }
         },
         "x-f5xc-description-short": "Response format for the credential's replace request.",
@@ -6610,16 +6655,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.989923+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218855+00:00"
               },
               "deterministic": true
             },
@@ -6632,7 +6682,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594670+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703070+00:00"
           }
         },
         "x-f5xc-description-short": "ScimTokenRequest is used for fetching or revoking scim token.",
@@ -6689,7 +6739,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.989997+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6760,7 +6810,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594719+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703099+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6803,7 +6853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990059+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6835,7 +6885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990110+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6895,23 +6945,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990149+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.218957+00:00"
               },
               "deterministic": true
             },
@@ -6924,7 +6974,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594771+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703128+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -7056,16 +7106,21 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.990234+00:00"
+                "validatedAt": "2026-05-05T18:40:02.218999+00:00"
               },
               "deterministic": true
             },
@@ -7078,7 +7133,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594832+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703164+00:00"
           },
           "role": {
             "type": "string",
@@ -7108,7 +7163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.990298+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7193,7 +7248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.990399+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219073+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7209,7 +7264,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594880+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703192+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7265,23 +7320,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990441+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219092+00:00"
               },
               "deterministic": true
             },
@@ -7294,7 +7349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594924+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703219+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7311,16 +7366,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990471+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219107+00:00"
               },
               "deterministic": true
             },
@@ -7333,7 +7393,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594950+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703235+00:00"
           },
           "uid": {
             "type": "string",
@@ -7352,7 +7412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990501+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7367,7 +7427,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.594979+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703251+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -7414,7 +7474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990538+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7427,7 +7487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595009+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703268+00:00"
           },
           "name": {
             "type": "string",
@@ -7444,23 +7504,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990570+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219155+00:00"
               },
               "deterministic": true
             },
@@ -7473,7 +7533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595037+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703283+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7490,16 +7550,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.990602+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219170+00:00"
               },
               "deterministic": true
             },
@@ -7512,7 +7577,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595063+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703299+00:00"
           },
           "tenant": {
             "type": "string",
@@ -7531,7 +7596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990643+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7545,7 +7610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595089+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703315+00:00"
           },
           "uid": {
             "type": "string",
@@ -7564,7 +7629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990673+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7579,7 +7644,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595116+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703330+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7640,7 +7705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990724+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7652,7 +7717,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595152+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703352+00:00"
           },
           "status": {
             "type": "string",
@@ -7670,7 +7735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990764+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7682,7 +7747,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595178+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703367+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7724,7 +7789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990817+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7752,7 +7817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990864+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7781,7 +7846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990912+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7808,7 +7873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.990954+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7837,7 +7902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991005+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7862,7 +7927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991061+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7927,7 +7992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991135+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7965,7 +8030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:17.991196+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7977,7 +8042,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595293+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703436+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -8018,7 +8083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991257+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8062,7 +8127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991301+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8076,7 +8141,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595365+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703472+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -8095,7 +8160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991357+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8122,7 +8187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991389+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8137,7 +8202,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595400+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703493+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8152,7 +8217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991431+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8233,7 +8298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991476+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8245,7 +8310,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595445+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703520+00:00"
           },
           "name": {
             "type": "string",
@@ -8262,23 +8327,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.991511+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219576+00:00"
               },
               "deterministic": true
             },
@@ -8291,7 +8356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595473+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703535+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8308,16 +8373,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:17.991545+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:02.219592+00:00"
               },
               "deterministic": true
             },
@@ -8330,7 +8400,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595499+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703551+00:00"
           },
           "uid": {
             "type": "string",
@@ -8347,7 +8417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:17.991576+00:00"
+                "validatedAt": "2026-05-05T18:40:02.219605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8361,7 +8431,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.595525+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.703567+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",

--- a/docs/specifications/api/bigip.json
+++ b/docs/specifications/api/bigip.json
@@ -8228,7 +8228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.804900+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8275,7 +8275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.804978+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8315,7 +8315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.805052+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8542,23 +8542,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.805120+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998534+00:00"
               },
               "deterministic": true
             },
@@ -8571,7 +8571,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084350+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547011+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8587,16 +8587,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.805155+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998552+00:00"
               },
               "deterministic": true
             },
@@ -8609,7 +8614,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084380+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547027+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8753,7 +8758,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084486+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547088+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8821,7 +8826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:27.805275+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8883,7 +8888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:27.805351+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8895,7 +8900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084557+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547128+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8944,23 +8949,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.805392+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998662+00:00"
               },
               "deterministic": true
             },
@@ -8973,7 +8978,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084621+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547165+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8988,16 +8993,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.805425+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998678+00:00"
               },
               "deterministic": true
             },
@@ -9010,7 +9020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084648+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547181+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9049,7 +9059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805481+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9062,7 +9072,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084702+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547214+00:00"
           },
           "uid": {
             "type": "string",
@@ -9079,7 +9089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805511+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9093,7 +9103,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084733+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547232+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of apm is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9219,7 +9229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805571+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9264,7 +9274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.805635+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9291,7 +9301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805676+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9330,16 +9340,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.805724+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998820+00:00"
               },
               "deterministic": true
             },
@@ -9352,7 +9367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.084827+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547287+00:00"
           },
           "start_time": {
             "type": "string",
@@ -9377,7 +9392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805772+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9410,7 +9425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805808+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9487,7 +9502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.805859+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9757,7 +9772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.805983+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9907,7 +9922,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085198+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547508+00:00"
           },
           "value": {
             "type": "array",
@@ -9926,7 +9941,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085228+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547525+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -10018,7 +10033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.806049+00:00"
+                "validatedAt": "2026-05-05T18:40:35.998968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10031,7 +10046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085284+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547559+00:00"
           },
           "name": {
             "type": "string",
@@ -10048,23 +10063,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.806084+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998983+00:00"
               },
               "deterministic": true
             },
@@ -10077,7 +10092,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085310+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547575+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10094,16 +10109,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.806116+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.998999+00:00"
               },
               "deterministic": true
             },
@@ -10116,7 +10136,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085344+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547591+00:00"
           },
           "tenant": {
             "type": "string",
@@ -10135,7 +10155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.806155+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10149,7 +10169,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547606+00:00"
           },
           "uid": {
             "type": "string",
@@ -10168,7 +10188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.806183+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10183,7 +10203,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085400+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547629+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -10289,7 +10309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806265+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10329,7 +10349,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806353+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10372,7 +10392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806426+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10416,7 +10436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806495+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999178+00:00"
               },
               "deterministic": true
             },
@@ -10504,7 +10524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806574+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10551,7 +10571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806630+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10587,7 +10607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806704+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10627,7 +10647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806779+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10691,7 +10711,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806854+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10725,7 +10745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.806914+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10810,7 +10830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.806998+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10906,7 +10926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.807110+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10952,7 +10972,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.807188+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10987,7 +11007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807239+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11072,7 +11092,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.807329+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11117,7 +11137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807372+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11140,7 +11160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807411+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11152,7 +11172,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085756+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547844+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11195,7 +11215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807464+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11233,7 +11253,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.807532+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11245,7 +11265,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085796+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547866+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11264,7 +11284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807581+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11315,7 +11335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807623+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11327,7 +11347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085834+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547888+00:00"
           },
           "url": {
             "type": "string",
@@ -11365,7 +11385,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.807696+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999764+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11422,7 +11442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.807733+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999781+00:00"
               },
               "deterministic": true
             },
@@ -11448,7 +11468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807780+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11475,7 +11495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807819+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11487,7 +11507,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085889+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547921+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11504,7 +11524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807866+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11537,7 +11557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807909+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11549,7 +11569,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.085923+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547942+00:00"
           },
           "type": {
             "type": "string",
@@ -11574,7 +11594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807947+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11662,7 +11682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.807990+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11753,7 +11773,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.808057+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11797,23 +11817,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808095+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:35.999949+00:00"
               },
               "deterministic": true
             },
@@ -11826,7 +11846,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086002+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.547987+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -11924,7 +11944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808163+00:00"
+                "validatedAt": "2026-05-05T18:40:35.999979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11936,7 +11956,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086067+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548025+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -12014,7 +12034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.808255+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000024+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12030,7 +12050,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086105+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548048+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12084,23 +12104,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808296+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000045+00:00"
               },
               "deterministic": true
             },
@@ -12113,7 +12133,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086150+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548076+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12130,16 +12150,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808339+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000060+00:00"
               },
               "deterministic": true
             },
@@ -12152,7 +12177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086177+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548091+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -12234,7 +12259,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.808429+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000105+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12250,7 +12275,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086217+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548114+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12306,23 +12331,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808471+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000125+00:00"
               },
               "deterministic": true
             },
@@ -12335,7 +12360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086260+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548141+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12352,16 +12377,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808502+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000140+00:00"
               },
               "deterministic": true
             },
@@ -12374,7 +12404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086288+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548157+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12456,7 +12486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.808588+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000184+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12472,7 +12502,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086335+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548180+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12526,23 +12556,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808627+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000203+00:00"
               },
               "deterministic": true
             },
@@ -12555,7 +12585,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086380+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548207+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12572,16 +12602,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.808657+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000218+00:00"
               },
               "deterministic": true
             },
@@ -12594,7 +12629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086406+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548223+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -12654,7 +12689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.808708+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12751,7 +12786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808763+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12779,7 +12814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808808+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12807,7 +12842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808852+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12836,7 +12871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808895+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12863,7 +12898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808925+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12877,7 +12912,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086508+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548285+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -12893,7 +12928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.808966+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13002,7 +13037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809019+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13014,7 +13049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086562+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548318+00:00"
           },
           "status": {
             "type": "string",
@@ -13032,7 +13067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809058+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13044,7 +13079,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086588+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548334+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -13086,7 +13121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809110+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13113,7 +13148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809157+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13140,7 +13175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809201+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13168,7 +13203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809252+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13233,7 +13268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809332+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13282,7 +13317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809385+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13295,7 +13330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086705+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548404+00:00"
           },
           "uid": {
             "type": "string",
@@ -13314,7 +13349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809415+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13328,7 +13363,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086734+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548420+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -13401,7 +13436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.809497+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13433,7 +13468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:27.809553+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13445,7 +13480,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086782+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548447+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -13547,7 +13582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:27.809612+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13559,7 +13594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086837+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548480+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -13577,7 +13612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809660+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13605,7 +13640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809700+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13617,7 +13652,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086879+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548506+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -13706,7 +13741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809736+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13718,7 +13753,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086907+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548523+00:00"
           },
           "name": {
             "type": "string",
@@ -13735,23 +13770,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.809770+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000727+00:00"
               },
               "deterministic": true
             },
@@ -13764,7 +13799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086933+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548539+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13781,16 +13816,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:27.809802+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:36.000742+00:00"
               },
               "deterministic": true
             },
@@ -13803,7 +13843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086958+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548555+00:00"
           },
           "uid": {
             "type": "string",
@@ -13820,7 +13860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.809830+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13834,7 +13874,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.086984+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548571+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13914,23 +13954,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.809897+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000791+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13946,7 +13986,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.087013+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548588+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13969,16 +14009,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.809959+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000822+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13994,7 +14039,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.087039+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548605+00:00"
           },
           "tenant": {
             "type": "string",
@@ -14023,7 +14068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.810025+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14037,7 +14082,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.087066+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.548626+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -14102,7 +14147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810078+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14130,7 +14175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810127+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14160,7 +14205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810178+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14186,7 +14231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810227+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14212,7 +14257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810270+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14235,7 +14280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810313+00:00"
+                "validatedAt": "2026-05-05T18:40:36.000985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14372,7 +14417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:27.810365+00:00"
+                "validatedAt": "2026-05-05T18:40:36.001004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14430,7 +14475,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.810465+00:00"
+                "validatedAt": "2026-05-05T18:40:36.001053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14499,7 +14544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.810519+00:00"
+                "validatedAt": "2026-05-05T18:40:36.001084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14574,7 +14619,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.810582+00:00"
+                "validatedAt": "2026-05-05T18:40:36.001118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14672,7 +14717,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:27.810669+00:00"
+                "validatedAt": "2026-05-05T18:40:36.001161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14887,7 +14932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:29.918996+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14917,7 +14962,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:29.919085+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14945,7 +14990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.919130+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15004,23 +15049,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:29.919179+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:37.000563+00:00"
               },
               "deterministic": true
             },
@@ -15033,7 +15078,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141486+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578686+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15049,16 +15094,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:29.919215+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:37.000580+00:00"
               },
               "deterministic": true
             },
@@ -15071,7 +15121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141514+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578704+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15174,7 +15224,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141604+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578756+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15235,7 +15285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:29.919376+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15265,7 +15315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:29.919447+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15293,7 +15343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.919491+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15360,7 +15410,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:29.919546+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15423,7 +15473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:29.919612+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15435,7 +15485,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141700+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578813+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15485,23 +15535,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:29.919653+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:37.000790+00:00"
               },
               "deterministic": true
             },
@@ -15514,7 +15564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141763+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578851+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15529,16 +15579,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:29.919686+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:37.000806+00:00"
               },
               "deterministic": true
             },
@@ -15551,7 +15606,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141788+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578866+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15590,7 +15645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.919741+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15603,7 +15658,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141838+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578897+00:00"
           },
           "uid": {
             "type": "string",
@@ -15620,7 +15675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.919772+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15634,7 +15689,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.141864+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.578914+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_irule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -15738,7 +15793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:29.919847+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15768,7 +15823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:29.919918+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15796,7 +15851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.919960+00:00"
+                "validatedAt": "2026-05-05T18:40:37.000936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15903,7 +15958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.920792+00:00"
+                "validatedAt": "2026-05-05T18:40:37.001325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15916,7 +15971,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.142402+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.579229+00:00"
           },
           "name": {
             "type": "string",
@@ -15933,23 +15988,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:29.920824+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:37.001341+00:00"
               },
               "deterministic": true
             },
@@ -15962,7 +16017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.142427+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.579245+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15979,16 +16034,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:29.920855+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:37.001356+00:00"
               },
               "deterministic": true
             },
@@ -16001,7 +16061,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.142454+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.579264+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16020,7 +16080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.920893+00:00"
+                "validatedAt": "2026-05-05T18:40:37.001375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16034,7 +16094,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.142481+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.579279+00:00"
           },
           "uid": {
             "type": "string",
@@ -16053,7 +16113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:29.920922+00:00"
+                "validatedAt": "2026-05-05T18:40:37.001388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16068,7 +16128,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.142510+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.579296+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16109,7 +16169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.185925+00:00"
+                "validatedAt": "2026-05-05T18:40:38.098900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16168,23 +16228,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:32.186016+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:38.098940+00:00"
               },
               "deterministic": true
             },
@@ -16197,7 +16257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.180549+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.599821+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -16252,7 +16312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186069+00:00"
+                "validatedAt": "2026-05-05T18:40:38.098963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16277,7 +16337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186114+00:00"
+                "validatedAt": "2026-05-05T18:40:38.098986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16310,7 +16370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186164+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16434,7 +16494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186226+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16523,7 +16583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186308+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16547,7 +16607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186368+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16618,7 +16678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186418+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16642,7 +16702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186465+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16711,7 +16771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.186532+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16839,7 +16899,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.180875+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600010+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16899,16 +16959,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:32.186641+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:38.099231+00:00"
               },
               "deterministic": true
             },
@@ -16921,7 +16986,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.180934+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600042+00:00"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -16981,7 +17046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:32.186692+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17044,7 +17109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:32.186755+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17056,7 +17121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.180993+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600076+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17106,23 +17171,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:32.186796+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:38.099305+00:00"
               },
               "deterministic": true
             },
@@ -17135,7 +17200,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.181058+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600113+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17150,16 +17215,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:32.186829+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:38.099321+00:00"
               },
               "deterministic": true
             },
@@ -17172,7 +17242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.181084+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600129+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17211,7 +17281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186882+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17224,7 +17294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.181136+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600159+00:00"
           },
           "uid": {
             "type": "string",
@@ -17242,7 +17312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.186913+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17256,7 +17326,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.181165+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600175+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_virtual_server is returned in 'List'.",
@@ -17672,7 +17742,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187127+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099461+00:00"
               },
               "deterministic": true
             },
@@ -17755,7 +17825,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187187+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17867,7 +17937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187247+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17905,7 +17975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187332+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099566+00:00"
               },
               "deterministic": true
             },
@@ -17997,7 +18067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187394+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18055,7 +18125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187467+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18068,7 +18138,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.181533+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600384+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/common_wafSimpleLogin"
@@ -18131,7 +18201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187543+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18170,7 +18240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187613+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099733+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18399,7 +18469,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187687+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18473,7 +18543,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187745+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18536,7 +18606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187819+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18575,7 +18645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187891+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18616,7 +18686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.187968+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18687,7 +18757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.188035+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099962+00:00"
               },
               "deterministic": true
             },
@@ -18752,7 +18822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.188093+00:00"
+                "validatedAt": "2026-05-05T18:40:38.099991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18922,7 +18992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.189075+00:00"
+                "validatedAt": "2026-05-05T18:40:38.100473+00:00"
               },
               "deterministic": true
             },
@@ -18935,7 +19005,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.182374+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600874+00:00"
           },
           "name": {
             "type": "string",
@@ -18963,23 +19033,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.189135+00:00"
+                "validatedAt": "2026-05-05T18:40:38.100504+00:00"
               },
               "deterministic": true
             },
@@ -18991,7 +19061,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.182401+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.600889+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -19064,7 +19134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.190528+00:00"
+                "validatedAt": "2026-05-05T18:40:38.101204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19097,7 +19167,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.190602+00:00"
+                "validatedAt": "2026-05-05T18:40:38.101244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19119,7 +19189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:32.190651+00:00"
+                "validatedAt": "2026-05-05T18:40:38.101266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19164,7 +19234,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:32.190723+00:00"
+                "validatedAt": "2026-05-05T18:40:38.101304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19375,7 +19445,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.210879+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19411,7 +19481,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.210955+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19504,23 +19574,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:27.211011+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:09.035131+00:00"
               },
               "deterministic": true
             },
@@ -19533,7 +19603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168006+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854533+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19549,16 +19619,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:27.211049+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:09.035149+00:00"
               },
               "deterministic": true
             },
@@ -19571,7 +19646,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168037+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854553+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19718,7 +19793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211166+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19754,7 +19829,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211226+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19817,7 +19892,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211288+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19854,7 +19929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211384+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19891,7 +19966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211445+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19928,7 +20003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211502+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19965,7 +20040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211560+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20002,7 +20077,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211618+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20039,7 +20114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211675+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20101,7 +20176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211731+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20138,7 +20213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211790+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20175,7 +20250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211844+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20212,7 +20287,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211903+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20249,7 +20324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.211962+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20286,7 +20361,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212017+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20323,7 +20398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212077+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20394,7 +20469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:27.212130+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20457,7 +20532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:27.212196+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20469,7 +20544,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168348+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854773+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20519,23 +20594,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:27.212237+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:09.035742+00:00"
               },
               "deterministic": true
             },
@@ -20548,7 +20623,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168412+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854819+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20563,16 +20638,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:27.212269+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:09.035761+00:00"
               },
               "deterministic": true
             },
@@ -20585,7 +20665,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854838+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20608,7 +20688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:27.212311+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20621,7 +20701,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168481+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854869+00:00"
           },
           "uid": {
             "type": "string",
@@ -20639,7 +20719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:27.212353+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20653,7 +20733,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.168509+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.854889+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of application_profiles is returned in 'List'.",
@@ -20761,7 +20841,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212412+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20797,7 +20877,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212473+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20861,7 +20941,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212532+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20898,7 +20978,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212593+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20956,7 +21036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212653+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20993,7 +21073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212710+00:00"
+                "validatedAt": "2026-05-05T18:42:09.035983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21061,7 +21141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212770+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21099,7 +21179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212829+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21185,7 +21265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212931+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21223,7 +21303,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.212988+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21260,7 +21340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.213049+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21297,7 +21377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.213106+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21343,7 +21423,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.213163+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21386,7 +21466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.213218+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21426,7 +21506,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:27.213277+00:00"
+                "validatedAt": "2026-05-05T18:42:09.036272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22085,23 +22165,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:41.609775+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:16.414779+00:00"
               },
               "deterministic": true
             },
@@ -22114,7 +22194,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761067+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.188826+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22130,16 +22210,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:41.609840+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:16.414800+00:00"
               },
               "deterministic": true
             },
@@ -22152,7 +22237,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761099+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.188844+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22255,7 +22340,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761190+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.188898+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22333,7 +22418,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.609999+00:00"
+                "validatedAt": "2026-05-05T18:42:16.414872+00:00"
               },
               "deterministic": true
             },
@@ -22454,7 +22539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610070+00:00"
+                "validatedAt": "2026-05-05T18:42:16.414906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22521,7 +22606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:08:41.610148+00:00"
+                "validatedAt": "2026-05-05T18:42:16.414940+00:00"
               },
               "deterministic": true
             },
@@ -22562,7 +22647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:08:41.610192+00:00"
+                "validatedAt": "2026-05-05T18:42:16.414961+00:00"
               },
               "deterministic": true
             },
@@ -22667,7 +22752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610276+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22757,7 +22842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:41.610347+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22820,7 +22905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:41.610415+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22832,7 +22917,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761397+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.189012+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22882,23 +22967,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:41.610460+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:16.415077+00:00"
               },
               "deterministic": true
             },
@@ -22911,7 +22996,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761460+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.189049+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22926,16 +23011,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:41.610496+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:16.415094+00:00"
               },
               "deterministic": true
             },
@@ -22948,7 +23038,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761489+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.189065+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22987,7 +23077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:41.610551+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23000,7 +23090,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761539+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.189096+00:00"
           },
           "uid": {
             "type": "string",
@@ -23018,7 +23108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:41.610583+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23032,7 +23122,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.761567+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.189113+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bigip_http_proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23094,7 +23184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610651+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415167+00:00"
               },
               "deterministic": true
             },
@@ -23169,7 +23259,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610713+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23207,7 +23297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610752+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415217+00:00"
               },
               "deterministic": true
             },
@@ -23403,7 +23493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610879+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23438,7 +23528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610958+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23531,7 +23621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.610999+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415332+00:00"
               },
               "deterministic": true
             },
@@ -23577,7 +23667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611078+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23927,7 +24017,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611161+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24029,7 +24119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611226+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415443+00:00"
               },
               "deterministic": true
             },
@@ -24075,7 +24165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611307+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24111,7 +24201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611395+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24470,7 +24560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611480+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24574,7 +24664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611546+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415589+00:00"
               },
               "deterministic": true
             },
@@ -24620,7 +24710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611628+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24656,7 +24746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.611702+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25007,7 +25097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:41.611941+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25079,7 +25169,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.612001+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25150,7 +25240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.612058+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25225,7 +25315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.612131+00:00"
+                "validatedAt": "2026-05-05T18:42:16.415923+00:00"
               },
               "deterministic": true
             },
@@ -25413,7 +25503,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.614557+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25510,7 +25600,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.614828+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25572,7 +25662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.614944+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25645,7 +25735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615091+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25810,7 +25900,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615157+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25883,7 +25973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615203+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417354+00:00"
               },
               "deterministic": true
             },
@@ -25930,7 +26020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615278+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26053,7 +26143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615374+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26088,7 +26178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615448+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26183,7 +26273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:41.615508+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26337,23 +26427,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:41.615592+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:16.417535+00:00"
               },
               "deterministic": true
             },
@@ -26366,7 +26456,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.764382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.190722+00:00"
           },
           "origin_servers": {
             "$ref": "#/components/schemas/bigip_http_proxyOriginServers"
@@ -26396,7 +26486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:41.615638+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26425,7 +26515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:41.615676+00:00"
+                "validatedAt": "2026-05-05T18:42:16.417573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26658,7 +26748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:14.198002+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297306+00:00"
               },
               "deterministic": true
             },
@@ -26671,7 +26761,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752169+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729668+00:00"
           },
           "irule": {
             "type": "string",
@@ -26698,7 +26788,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:14.198072+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26757,23 +26847,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:14.198117+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:32.297360+00:00"
               },
               "deterministic": true
             },
@@ -26786,7 +26876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752218+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729696+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26802,16 +26892,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:14.198152+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:32.297376+00:00"
               },
               "deterministic": true
             },
@@ -26824,7 +26919,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729712+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26964,7 +27059,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:14.198295+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297444+00:00"
               },
               "deterministic": true
             },
@@ -26977,7 +27072,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752353+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729769+00:00"
           },
           "irule": {
             "type": "string",
@@ -27004,7 +27099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:14.198375+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27070,7 +27165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:14.198428+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27132,7 +27227,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:14.198490+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27144,7 +27239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752424+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729810+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27194,23 +27289,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:14.198532+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:32.297553+00:00"
               },
               "deterministic": true
             },
@@ -27223,7 +27318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752488+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729847+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27238,16 +27333,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:14.198566+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:32.297571+00:00"
               },
               "deterministic": true
             },
@@ -27260,7 +27360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752514+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729862+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27283,7 +27383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:14.198608+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27296,7 +27396,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752556+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729887+00:00"
           },
           "uid": {
             "type": "string",
@@ -27313,7 +27413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:14.198639+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27327,7 +27427,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752583+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729903+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of irule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27428,7 +27528,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:14.198729+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297657+00:00"
               },
               "deterministic": true
             },
@@ -27441,7 +27541,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.752630+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.729932+00:00"
           },
           "irule": {
             "type": "string",
@@ -27468,7 +27568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:14.198795+00:00"
+                "validatedAt": "2026-05-05T18:42:32.297690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27721,23 +27821,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:17.884902+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:03.644060+00:00"
               },
               "deterministic": true
             },
@@ -27750,7 +27850,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.211745+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546509+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27766,16 +27866,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:17.884945+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:03.644087+00:00"
               },
               "deterministic": true
             },
@@ -27788,7 +27893,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.211774+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546526+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27977,7 +28082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:17.885062+00:00"
+                "validatedAt": "2026-05-05T18:43:03.644137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28040,7 +28145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:17.885128+00:00"
+                "validatedAt": "2026-05-05T18:43:03.644169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28052,7 +28157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.211916+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546611+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -28102,23 +28207,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:17.885171+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:03.644188+00:00"
               },
               "deterministic": true
             },
@@ -28131,7 +28236,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.211978+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546655+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28146,16 +28251,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:17.885207+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:03.644205+00:00"
               },
               "deterministic": true
             },
@@ -28168,7 +28278,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.212004+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546672+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -28191,7 +28301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:17.885249+00:00"
+                "validatedAt": "2026-05-05T18:43:03.644224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28204,7 +28314,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.212048+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546698+00:00"
           },
           "uid": {
             "type": "string",
@@ -28221,7 +28331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:17.885278+00:00"
+                "validatedAt": "2026-05-05T18:43:03.644239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28235,7 +28345,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.212076+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.546715+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of data_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",

--- a/docs/specifications/api/billing_and_usage.json
+++ b/docs/specifications/api/billing_and_usage.json
@@ -5741,7 +5741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039121+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5768,7 +5768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039184+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5780,7 +5780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.298080+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.663800+00:00"
           }
         },
         "x-f5xc-description-short": "Billing Metric Data represents billing metric metadata like unit as well as converted metric value.",
@@ -5827,7 +5827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039238+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5860,7 +5860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039286+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5944,7 +5944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039362+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5993,23 +5993,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:38.039406+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:40.924491+00:00"
               },
               "deterministic": true
             },
@@ -6022,7 +6022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.298173+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.663856+00:00"
           },
           "service": {
             "type": "string",
@@ -6040,7 +6040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039448+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6108,7 +6108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:38.039505+00:00"
+                "validatedAt": "2026-05-05T18:40:40.924538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6120,7 +6120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.298229+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.663890+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Billing Metrics query.",
@@ -6160,7 +6160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:31.481832+00:00"
+                "validatedAt": "2026-05-05T18:44:39.240229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6251,7 +6251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:31.481907+00:00"
+                "validatedAt": "2026-05-05T18:44:39.240263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6276,7 +6276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:31.481951+00:00"
+                "validatedAt": "2026-05-05T18:44:39.240282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6299,23 +6299,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:31.481994+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:39.240302+00:00"
               },
               "deterministic": true
             },
@@ -6328,7 +6328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.895224+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.557176+00:00"
           },
           "period_end": {
             "type": "string",
@@ -6347,7 +6347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:31.482041+00:00"
+                "validatedAt": "2026-05-05T18:44:39.240324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6374,7 +6374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:31.482091+00:00"
+                "validatedAt": "2026-05-05T18:44:39.240347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6488,7 +6488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.829930+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6513,7 +6513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830025+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6538,7 +6538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830081+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6566,7 +6566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830147+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6591,7 +6591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830212+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6617,7 +6617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830296+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6642,7 +6642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830349+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6667,7 +6667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830394+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6692,7 +6692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:06.830435+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6751,16 +6751,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830482+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095695+00:00"
               },
               "deterministic": true
             },
@@ -6773,7 +6778,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725682+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112736+00:00"
           },
           "role": {
             "$ref": "#/components/schemas/payment_methodPaymentMethodRole"
@@ -6796,7 +6801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:16:06.830528+00:00"
+                "validatedAt": "2026-05-05T18:45:55.095717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6840,23 +6845,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830567+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095735+00:00"
               },
               "deterministic": true
             },
@@ -6869,7 +6874,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725731+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112766+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6905,23 +6910,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830602+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095751+00:00"
               },
               "deterministic": true
             },
@@ -6934,7 +6939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725762+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112783+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6950,16 +6955,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830633+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095767+00:00"
               },
               "deterministic": true
             },
@@ -6972,7 +6982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725791+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112799+00:00"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role to primary.",
@@ -7035,23 +7045,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830668+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095784+00:00"
               },
               "deterministic": true
             },
@@ -7064,7 +7074,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112816+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7080,16 +7090,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830698+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095801+00:00"
               },
               "deterministic": true
             },
@@ -7102,7 +7117,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725849+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112832+00:00"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role (from/to primary or backup).",
@@ -7140,23 +7155,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830733+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095817+00:00"
               },
               "deterministic": true
             },
@@ -7169,7 +7184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725879+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112849+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7185,16 +7200,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:06.830765+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.095833+00:00"
               },
               "deterministic": true
             },
@@ -7207,7 +7227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.725904+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.112865+00:00"
           }
         },
         "x-f5xc-description-short": "Changes a payment method role to secondary.",
@@ -7269,16 +7289,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:18.534261+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:00.678352+00:00"
               },
               "deterministic": true
             },
@@ -7291,7 +7316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.894558+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.205541+00:00"
           },
           "new_plan": {
             "type": "string",
@@ -7309,7 +7334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534315+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7363,7 +7388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534364+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7456,7 +7481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534431+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7497,7 +7522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534485+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7525,7 +7550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534529+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7538,7 +7563,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.894677+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.205608+00:00"
           },
           "payment_address": {
             "$ref": "#/components/schemas/schemacontactGlobalSpecType"
@@ -7559,7 +7584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534582+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7603,7 +7628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534650+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7629,7 +7654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534701+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7705,7 +7730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534762+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7730,7 +7755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534802+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7755,7 +7780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534839+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7783,7 +7808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534879+00:00"
+                "validatedAt": "2026-05-05T18:46:00.678991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7808,7 +7833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534918+00:00"
+                "validatedAt": "2026-05-05T18:46:00.679023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7834,7 +7859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.534964+00:00"
+                "validatedAt": "2026-05-05T18:46:00.679057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7859,7 +7884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.535002+00:00"
+                "validatedAt": "2026-05-05T18:46:00.679077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7884,7 +7909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.535045+00:00"
+                "validatedAt": "2026-05-05T18:46:00.679113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7909,7 +7934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:18.535088+00:00"
+                "validatedAt": "2026-05-05T18:46:00.679158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7986,7 +8011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.355684+00:00"
+                "validatedAt": "2026-05-05T18:46:16.073981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8009,7 +8034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.355750+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8021,7 +8046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.422947+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485574+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -8128,23 +8153,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.355809+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074036+00:00"
               },
               "deterministic": true
             },
@@ -8157,7 +8182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423036+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485634+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8173,16 +8198,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.355846+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074054+00:00"
               },
               "deterministic": true
             },
@@ -8195,7 +8225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423064+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485651+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8433,7 +8463,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423270+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485748+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8639,7 +8669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:49.356035+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8701,7 +8731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:49.356099+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8713,7 +8743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423446+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485832+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8763,23 +8793,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.356142+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074180+00:00"
               },
               "deterministic": true
             },
@@ -8792,7 +8822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423511+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485869+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8807,16 +8837,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.356174+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074197+00:00"
               },
               "deterministic": true
             },
@@ -8829,7 +8864,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423538+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485885+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8868,7 +8903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356229+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8881,7 +8916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423593+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485916+00:00"
           },
           "uid": {
             "type": "string",
@@ -8898,7 +8933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356260+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8912,7 +8947,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423622+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.485932+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of quota is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8988,7 +9023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356318+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9138,7 +9173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.356406+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074295+00:00"
               },
               "deterministic": true
             },
@@ -9164,7 +9199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356456+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9191,7 +9226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356495+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9203,7 +9238,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423745+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486004+00:00"
           },
           "service_name": {
             "type": "string",
@@ -9220,7 +9255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356542+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9253,7 +9288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356590+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9265,7 +9300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423781+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486025+00:00"
           },
           "type": {
             "type": "string",
@@ -9290,7 +9325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356628+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9378,7 +9413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.356672+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9424,23 +9459,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.356709+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074434+00:00"
               },
               "deterministic": true
             },
@@ -9453,7 +9488,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423846+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486064+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -9571,7 +9606,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:49.356827+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074487+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9587,7 +9622,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423907+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486099+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9641,23 +9676,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.356871+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074508+00:00"
               },
               "deterministic": true
             },
@@ -9670,7 +9705,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423951+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486126+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9687,16 +9722,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.356901+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074525+00:00"
               },
               "deterministic": true
             },
@@ -9709,7 +9749,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.423977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486141+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -9791,7 +9831,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:49.356995+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074571+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9807,7 +9847,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486165+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9863,23 +9903,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.357037+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074591+00:00"
               },
               "deterministic": true
             },
@@ -9892,7 +9932,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424061+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486192+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9909,16 +9949,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.357068+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074607+00:00"
               },
               "deterministic": true
             },
@@ -9931,7 +9976,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424087+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486208+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -9976,7 +10021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357105+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9989,7 +10034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424115+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486224+00:00"
           },
           "name": {
             "type": "string",
@@ -10006,23 +10051,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.357137+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074652+00:00"
               },
               "deterministic": true
             },
@@ -10035,7 +10080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424142+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486240+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10052,16 +10097,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.357168+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074668+00:00"
               },
               "deterministic": true
             },
@@ -10074,7 +10124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424169+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486255+00:00"
           },
           "tenant": {
             "type": "string",
@@ -10093,7 +10143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357207+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10107,7 +10157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486271+00:00"
           },
           "uid": {
             "type": "string",
@@ -10126,7 +10176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357236+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10141,7 +10191,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424223+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486287+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -10223,7 +10273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:49.357335+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074745+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10239,7 +10289,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424264+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486310+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10293,23 +10343,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.357376+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074764+00:00"
               },
               "deterministic": true
             },
@@ -10322,7 +10372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424311+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486337+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10339,16 +10389,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.357407+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.074779+00:00"
               },
               "deterministic": true
             },
@@ -10361,7 +10416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424355+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486353+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -10406,7 +10461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357460+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10434,7 +10489,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357508+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10462,7 +10517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357555+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10491,7 +10546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357602+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10518,7 +10573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357632+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10532,7 +10587,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424431+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486396+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -10548,7 +10603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357672+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10657,7 +10712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357726+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10669,7 +10724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424488+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486428+00:00"
           },
           "status": {
             "type": "string",
@@ -10687,7 +10742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357763+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10699,7 +10754,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424514+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486444+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -10741,7 +10796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357817+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10768,7 +10823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357863+00:00"
+                "validatedAt": "2026-05-05T18:46:16.074984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10795,7 +10850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357907+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10823,7 +10878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.357958+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10888,7 +10943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.358027+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10937,7 +10992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.358081+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10950,7 +11005,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486513+00:00"
           },
           "uid": {
             "type": "string",
@@ -10969,7 +11024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.358110+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10983,7 +11038,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424660+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486529+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -11033,7 +11088,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.358146+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11045,7 +11100,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424690+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486545+00:00"
           },
           "name": {
             "type": "string",
@@ -11062,23 +11117,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.358180+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.075127+00:00"
               },
               "deterministic": true
             },
@@ -11091,7 +11146,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424716+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486561+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11108,16 +11163,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:49.358211+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:16.075144+00:00"
               },
               "deterministic": true
             },
@@ -11130,7 +11190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424741+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486576+00:00"
           },
           "uid": {
             "type": "string",
@@ -11147,7 +11207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:49.358240+00:00"
+                "validatedAt": "2026-05-05T18:46:16.075157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11161,7 +11221,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.424767+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.486592+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -11629,7 +11689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614605+00:00"
+                "validatedAt": "2026-05-05T18:45:16.048949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11657,7 +11717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614680+00:00"
+                "validatedAt": "2026-05-05T18:45:16.048983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11685,7 +11745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614732+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11744,7 +11804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614804+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11783,7 +11843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614838+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11797,7 +11857,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.837708+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.504832+00:00"
           }
         },
         "x-f5xc-description-short": "Response to call to GET list of tenant subscriptions.",
@@ -11846,7 +11906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614892+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11902,7 +11962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.614955+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11930,7 +11990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.615013+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11955,23 +12015,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:37.615058+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:16.049155+00:00"
               },
               "deterministic": true
             },
@@ -11984,7 +12044,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.837789+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.504880+00:00"
           },
           "plan_name": {
             "type": "string",
@@ -12001,7 +12061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.615105+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12026,7 +12086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.615155+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12068,7 +12128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:37.615220+00:00"
+                "validatedAt": "2026-05-05T18:45:16.049227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12344,7 +12404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.026972+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12369,7 +12429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027048+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12396,7 +12456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027099+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12472,7 +12532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027190+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12499,7 +12559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027239+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12527,7 +12587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027287+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12552,7 +12612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027355+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12577,7 +12637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027401+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12661,7 +12721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027468+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12673,7 +12733,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.652795+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.484960+00:00"
           }
         },
         "x-f5xc-description-short": "Coupon details, discount type, amount and name.",
@@ -12738,7 +12798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027518+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12771,7 +12831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027571+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12798,7 +12858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027620+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12840,7 +12900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027684+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12865,7 +12925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027730+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12919,7 +12979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027768+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12942,16 +13002,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:20.027812+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:06.687535+00:00"
               },
               "deterministic": true
             },
@@ -12964,7 +13029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.652892+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.485015+00:00"
           },
           "to": {
             "type": "string",
@@ -12983,7 +13048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027843+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13048,7 +13113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027903+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13075,7 +13140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.027950+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13138,16 +13203,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:20.028004+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:06.687640+00:00"
               },
               "deterministic": true
             },
@@ -13160,7 +13230,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.652967+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.485059+00:00"
           },
           "query": {
             "type": "string",
@@ -13179,7 +13249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:21:20.028053+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13261,16 +13331,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:20.028107+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:06.687691+00:00"
               },
               "deterministic": true
             },
@@ -13283,7 +13358,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.653014+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.485087+00:00"
           }
         },
         "x-f5xc-description-short": "Request message to GET mon thly usage details.",
@@ -13361,7 +13436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028163+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13384,16 +13459,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:20.028198+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:06.687736+00:00"
               },
               "deterministic": true
             },
@@ -13406,7 +13486,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.653060+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.485115+00:00"
           },
           "to": {
             "type": "string",
@@ -13425,7 +13505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028227+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13510,7 +13590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028288+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687777+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13535,7 +13615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028348+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13562,7 +13642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028398+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13589,7 +13669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028448+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13640,7 +13720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028499+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13691,7 +13771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028574+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13722,7 +13802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028626+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13745,16 +13825,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:20.028661+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:06.687942+00:00"
               },
               "deterministic": true
             },
@@ -13767,7 +13852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.653182+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.485185+00:00"
           },
           "object_name": {
             "type": "string",
@@ -13785,7 +13870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028710+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13827,7 +13912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028772+00:00"
+                "validatedAt": "2026-05-05T18:46:06.687993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13852,7 +13937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028817+00:00"
+                "validatedAt": "2026-05-05T18:46:06.688014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13877,7 +13962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:20.028862+00:00"
+                "validatedAt": "2026-05-05T18:46:06.688034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13936,7 +14021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:23.742657+00:00"
+                "validatedAt": "2026-05-05T18:46:08.519119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13959,23 +14044,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:23.742724+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:08.519141+00:00"
               },
               "deterministic": true
             },
@@ -13988,7 +14073,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.700197+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.510462+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14061,7 +14146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:23.742824+00:00"
+                "validatedAt": "2026-05-05T18:46:08.519170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14200,7 +14285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:23.742974+00:00"
+                "validatedAt": "2026-05-05T18:46:08.519212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14212,7 +14297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.700294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.510518+00:00"
           },
           "flat_price": {
             "type": "integer",
@@ -14258,23 +14343,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:23.743062+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:08.519242+00:00"
               },
               "deterministic": true
             },
@@ -14287,7 +14372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.700352+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.510544+00:00"
           },
           "renewal_period_unit": {
             "$ref": "#/components/schemas/planPeriodUnitType"
@@ -14311,7 +14396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:23.743110+00:00"
+                "validatedAt": "2026-05-05T18:46:08.519262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14339,7 +14424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:23.743150+00:00"
+                "validatedAt": "2026-05-05T18:46:08.519280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14351,7 +14436,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.700413+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.510580+00:00"
           },
           "transition_flow": {
             "$ref": "#/components/schemas/planUsagePlanTransitionFlow"

--- a/docs/specifications/api/blindfold.json
+++ b/docs/specifications/api/blindfold.json
@@ -7347,7 +7347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:17.608002+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7393,7 +7393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:17.608076+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7431,7 +7431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:17.608133+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7579,7 +7579,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:17.608192+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7642,7 +7642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:17.608284+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7767,7 +7767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:17.608380+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7793,7 +7793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:17.608436+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7818,7 +7818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:17.608476+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7831,7 +7831,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.399515+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.222967+00:00"
           }
         },
         "x-f5xc-description-short": "F5XC Secret Management uses asymmetric cryptography for securing secrets.",
@@ -7871,23 +7871,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:17.608519+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:33.859901+00:00"
               },
               "deterministic": true
             },
@@ -7900,7 +7900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.399548+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.222985+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7915,16 +7915,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:17.608556+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:33.859920+00:00"
               },
               "deterministic": true
             },
@@ -7937,7 +7942,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.399573+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.223001+00:00"
           },
           "policy_id": {
             "type": "string",
@@ -7966,7 +7971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:17.608604+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7995,7 +8000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:17.608645+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8008,7 +8013,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.399618+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.223028+00:00"
           }
         },
         "x-f5xc-description-short": "Policy_data contains the information about the secret policy and all the secret policy rules for the policy.",
@@ -8059,7 +8064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:17.608689+00:00"
+                "validatedAt": "2026-05-05T18:43:33.859987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8103,7 +8108,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472358+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261749+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -8139,7 +8144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974505+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8188,7 +8193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974567+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8245,7 +8250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974616+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8284,7 +8289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:11:21.974674+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913168+00:00"
               },
               "deterministic": true
             },
@@ -8351,7 +8356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974730+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8434,7 +8439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974785+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8457,7 +8462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974816+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8469,7 +8474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472523+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261843+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -8562,7 +8567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974876+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8586,7 +8591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974907+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8598,7 +8603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472603+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261891+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -8640,7 +8645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974950+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8664,7 +8669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.974981+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8676,7 +8681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472649+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261919+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -8714,7 +8719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975021+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8771,7 +8776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975064+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8795,7 +8800,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975096+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8807,7 +8812,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472710+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261953+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -8887,7 +8892,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472752+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261976+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -8944,7 +8949,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472790+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.261999+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -8980,7 +8985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975166+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9091,7 +9096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975227+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9157,7 +9162,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262059+00:00"
           },
           "value": {
             "type": "number",
@@ -9173,7 +9178,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.472914+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262074+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -9210,7 +9215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975290+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9314,7 +9319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975373+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9339,7 +9344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975417+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9364,7 +9369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975457+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9390,7 +9395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975504+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9470,7 +9475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975546+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9482,7 +9487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473036+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262146+00:00"
           }
         },
         "x-f5xc-description-short": "VoltShare Access metric is tagged with labels mentioned in MetricLabel.",
@@ -9560,7 +9565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975600+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9572,7 +9577,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473076+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262168+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a VoltShare Access Metrics query.",
@@ -9656,7 +9661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:21.975662+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9668,7 +9673,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473107+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262187+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -9683,7 +9688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975710+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9709,7 +9714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975751+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9721,7 +9726,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473151+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262214+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -9785,7 +9790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975812+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9809,16 +9814,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:21.975848+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:35.913699+00:00"
               },
               "deterministic": true
             },
@@ -9831,7 +9841,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473198+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262242+00:00"
           },
           "query": {
             "type": "string",
@@ -9851,7 +9861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:21.975897+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9884,7 +9894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975947+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9951,7 +9961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.975996+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10020,7 +10030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976048+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10049,7 +10059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:21.976091+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10073,16 +10083,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:21.976128+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:35.913830+00:00"
               },
               "deterministic": true
             },
@@ -10095,7 +10110,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262297+00:00"
           },
           "query": {
             "type": "string",
@@ -10115,7 +10130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:21.976176+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10168,7 +10183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976226+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10255,7 +10270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976285+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10284,7 +10299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976339+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10332,16 +10347,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:21.976373+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:35.913939+00:00"
               },
               "deterministic": true
             },
@@ -10354,7 +10374,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473406+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262357+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -10372,7 +10392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976417+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10429,7 +10449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976479+00:00"
+                "validatedAt": "2026-05-05T18:43:35.913986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10465,7 +10485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976542+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10513,7 +10533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976593+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10578,7 +10598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976659+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10609,7 +10629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976703+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10635,7 +10655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976749+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10695,7 +10715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:21.976821+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10721,7 +10741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.976873+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10789,7 +10809,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:21.976962+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10840,7 +10860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.977020+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10877,7 +10897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:11:21.977077+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914254+00:00"
               },
               "deterministic": true
             },
@@ -10947,7 +10967,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:21.977164+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914299+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10992,7 +11012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:21.977237+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11004,7 +11024,7 @@
             "x-field-mutability": "read-only",
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473609+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262476+00:00"
           }
         },
         "x-f5xc-description-short": "UserRecordType contains information about a user.",
@@ -11051,7 +11071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.977287+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11109,16 +11129,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:21.977362+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:35.914390+00:00"
               },
               "deterministic": true
             },
@@ -11131,7 +11156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.473666+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.262508+00:00"
           },
           "start_time": {
             "type": "string",
@@ -11156,7 +11181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.977409+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11189,7 +11214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.977447+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11266,7 +11291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:21.977499+00:00"
+                "validatedAt": "2026-05-05T18:43:35.914453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11315,7 +11340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:46.719768+00:00"
+                "validatedAt": "2026-05-05T18:43:48.651967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11390,7 +11415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.469858+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11413,7 +11438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.469922+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11425,7 +11450,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.645650+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688575+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11465,7 +11490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.469968+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11526,7 +11551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470014+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11665,7 +11690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470086+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11703,7 +11728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.470167+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11715,7 +11740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.645760+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688669+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11734,7 +11759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470217+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11785,7 +11810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470261+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11797,7 +11822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.645800+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688697+00:00"
           },
           "url": {
             "type": "string",
@@ -11835,7 +11860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.470363+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498629+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11892,7 +11917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.470406+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498648+00:00"
               },
               "deterministic": true
             },
@@ -11918,7 +11943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470455+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11945,7 +11970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470495+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11957,7 +11982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.645858+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688740+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11974,7 +11999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470543+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12007,7 +12032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470586+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12019,7 +12044,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.645893+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688773+00:00"
           },
           "type": {
             "type": "string",
@@ -12044,7 +12069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470624+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12132,7 +12157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.470668+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12223,7 +12248,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.470737+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12291,7 +12316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.470826+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12345,23 +12370,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.470869+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.498863+00:00"
               },
               "deterministic": true
             },
@@ -12374,7 +12399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646018+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688874+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -12466,7 +12491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.470939+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12584,7 +12609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.471038+00:00"
+                "validatedAt": "2026-05-05T18:46:45.498944+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12600,7 +12625,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646121+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688947+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12654,23 +12679,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471081+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.498964+00:00"
               },
               "deterministic": true
             },
@@ -12683,7 +12708,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646170+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.688983+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12700,16 +12725,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471115+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.498980+00:00"
               },
               "deterministic": true
             },
@@ -12722,7 +12752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646199+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689001+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -12804,7 +12834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.471207+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499025+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12820,7 +12850,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646241+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689029+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12876,23 +12906,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471247+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499043+00:00"
               },
               "deterministic": true
             },
@@ -12905,7 +12935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646289+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689068+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12922,16 +12952,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471281+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499060+00:00"
               },
               "deterministic": true
             },
@@ -12944,7 +12979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646316+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689087+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12989,7 +13024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471318+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13002,7 +13037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646357+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689109+00:00"
           },
           "name": {
             "type": "string",
@@ -13019,23 +13054,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471361+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499092+00:00"
               },
               "deterministic": true
             },
@@ -13048,7 +13083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646383+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689131+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13065,16 +13100,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471394+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499108+00:00"
               },
               "deterministic": true
             },
@@ -13087,7 +13127,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646409+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689152+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13106,7 +13146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471434+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13120,7 +13160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646435+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689171+00:00"
           },
           "uid": {
             "type": "string",
@@ -13139,7 +13179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471464+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13154,7 +13194,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646464+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689196+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13236,7 +13276,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.471559+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499185+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13252,7 +13292,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646504+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689228+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13306,23 +13346,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471601+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499203+00:00"
               },
               "deterministic": true
             },
@@ -13335,7 +13375,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689261+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13352,16 +13392,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.471636+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499220+00:00"
               },
               "deterministic": true
             },
@@ -13374,7 +13419,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646580+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689278+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -13521,7 +13566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.471698+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13572,7 +13617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471750+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13600,7 +13645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471799+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13628,7 +13673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471843+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13657,7 +13702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471888+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13684,7 +13729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471919+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13698,7 +13743,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646738+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689384+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -13714,7 +13759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.471959+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13823,7 +13868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472017+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13835,7 +13880,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646795+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689424+00:00"
           },
           "status": {
             "type": "string",
@@ -13853,7 +13898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472057+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13865,7 +13910,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689445+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -13907,7 +13952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472107+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13934,7 +13979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472153+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13961,7 +14006,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472197+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13989,7 +14034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472248+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14054,7 +14099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472317+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14103,7 +14148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472382+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14116,7 +14161,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646940+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689533+00:00"
           },
           "uid": {
             "type": "string",
@@ -14135,7 +14180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.472412+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14149,7 +14194,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.646968+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689552+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -14222,7 +14267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.472498+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14254,7 +14299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:45.472555+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14266,7 +14311,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647015+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689587+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -14328,7 +14373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.472612+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14460,7 +14505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.472717+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14540,7 +14585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.472792+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14648,7 +14693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.472861+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14761,7 +14806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.472950+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499828+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14843,7 +14888,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.473004+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14920,7 +14965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.473045+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499874+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14932,7 +14977,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647340+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689828+00:00"
           },
           "name": {
             "type": "string",
@@ -14949,23 +14994,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.473080+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499891+00:00"
               },
               "deterministic": true
             },
@@ -14978,7 +15023,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647366+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689847+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14995,16 +15040,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.473114+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499907+00:00"
               },
               "deterministic": true
             },
@@ -15017,7 +15067,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647392+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689866+00:00"
           },
           "uid": {
             "type": "string",
@@ -15034,7 +15084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.473144+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15048,7 +15098,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647422+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689886+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -15197,7 +15247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.473229+00:00"
+                "validatedAt": "2026-05-05T18:46:45.499962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15260,23 +15310,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.473267+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499980+00:00"
               },
               "deterministic": true
             },
@@ -15289,7 +15339,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647534+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689968+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15305,16 +15355,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.473300+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.499996+00:00"
               },
               "deterministic": true
             },
@@ -15327,7 +15382,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.689986+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15430,7 +15485,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647649+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.690045+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15497,7 +15552,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.473454+00:00"
+                "validatedAt": "2026-05-05T18:46:45.500062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15568,7 +15623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:45.473506+00:00"
+                "validatedAt": "2026-05-05T18:46:45.500085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15631,7 +15686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:45.473565+00:00"
+                "validatedAt": "2026-05-05T18:46:45.500111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15643,7 +15698,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647746+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.690112+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15694,23 +15749,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.473604+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.500129+00:00"
               },
               "deterministic": true
             },
@@ -15723,7 +15778,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647809+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.690154+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15738,16 +15793,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:45.473634+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.500144+00:00"
               },
               "deterministic": true
             },
@@ -15760,7 +15820,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647837+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.690172+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15799,7 +15859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.473688+00:00"
+                "validatedAt": "2026-05-05T18:46:45.500167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15812,7 +15872,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.690210+00:00"
           },
           "uid": {
             "type": "string",
@@ -15830,7 +15890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:45.473718+00:00"
+                "validatedAt": "2026-05-05T18:46:45.500180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15844,7 +15904,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.647919+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.690230+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_management_access is returned in 'List'.",
@@ -15954,7 +16014,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:45.473801+00:00"
+                "validatedAt": "2026-05-05T18:46:45.500221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16064,7 +16124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.749894+00:00"
+                "validatedAt": "2026-05-05T18:46:46.732536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16077,7 +16137,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731558+00:00"
           },
           "name": {
             "type": "string",
@@ -16094,23 +16154,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.749977+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.732565+00:00"
               },
               "deterministic": true
             },
@@ -16123,7 +16183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696226+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731575+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16140,16 +16200,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.750029+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.732583+00:00"
               },
               "deterministic": true
             },
@@ -16162,7 +16227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731594+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16181,7 +16246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.750092+00:00"
+                "validatedAt": "2026-05-05T18:46:46.732602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16195,7 +16260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696281+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731624+00:00"
           },
           "uid": {
             "type": "string",
@@ -16214,7 +16279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.750143+00:00"
+                "validatedAt": "2026-05-05T18:46:46.732625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16229,7 +16294,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696309+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731646+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16282,7 +16347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:47.750969+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733003+00:00"
               },
               "deterministic": true
             },
@@ -16295,7 +16360,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696612+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731822+00:00"
           },
           "name": {
             "type": "string",
@@ -16323,23 +16388,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:47.751033+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733035+00:00"
               },
               "deterministic": true
             },
@@ -16351,7 +16416,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.696640+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.731838+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -16409,7 +16474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.752448+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16478,7 +16543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.752504+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16505,7 +16570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.752551+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16595,7 +16660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.752608+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16717,23 +16782,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.752739+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.733833+00:00"
               },
               "deterministic": true
             },
@@ -16746,7 +16811,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697634+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732438+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16762,16 +16827,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.752769+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.733848+00:00"
               },
               "deterministic": true
             },
@@ -16784,7 +16854,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697662+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732454+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16887,7 +16957,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697749+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732507+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16947,7 +17017,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:47.752902+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733909+00:00"
               },
               "deterministic": true
             },
@@ -17015,7 +17085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:47.752947+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17078,7 +17148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:47.753006+00:00"
+                "validatedAt": "2026-05-05T18:46:46.733955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17090,7 +17160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697827+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732553+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17140,23 +17210,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753043+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.733972+00:00"
               },
               "deterministic": true
             },
@@ -17169,7 +17239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697888+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732590+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17184,16 +17254,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753074+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.733988+00:00"
               },
               "deterministic": true
             },
@@ -17206,7 +17281,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697914+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732606+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -17226,7 +17301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.753112+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17239,7 +17314,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697947+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732634+00:00"
           },
           "uid": {
             "type": "string",
@@ -17256,7 +17331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.753142+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17270,7 +17345,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.697974+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732650+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17337,7 +17412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:47.753189+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17400,7 +17475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:47.753247+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17412,7 +17487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732685+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17462,23 +17537,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753284+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.734085+00:00"
               },
               "deterministic": true
             },
@@ -17491,7 +17566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698096+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732722+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17506,16 +17581,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753315+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.734101+00:00"
               },
               "deterministic": true
             },
@@ -17528,7 +17608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698124+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732738+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17567,7 +17647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.753376+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17580,7 +17660,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698176+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732769+00:00"
           },
           "uid": {
             "type": "string",
@@ -17597,7 +17677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.753405+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17611,7 +17691,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698202+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732785+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17668,23 +17748,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753442+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.734156+00:00"
               },
               "deterministic": true
             },
@@ -17697,7 +17777,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732802+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17720,16 +17800,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753474+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.734173+00:00"
               },
               "deterministic": true
             },
@@ -17742,7 +17827,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698256+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732818+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'RecoverPolicy' RPC.",
@@ -17782,7 +17867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.753513+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17794,7 +17879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698284+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732836+00:00"
           }
         },
         "x-f5xc-description-short": "Response message of the 'RecoverPolicy' RPC.",
@@ -17915,7 +18000,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:47.753582+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734227+00:00"
               },
               "deterministic": true
             },
@@ -17968,23 +18053,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753617+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.734244+00:00"
               },
               "deterministic": true
             },
@@ -17997,7 +18082,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698373+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732883+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18020,16 +18105,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:47.753651+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:46.734261+00:00"
               },
               "deterministic": true
             },
@@ -18042,7 +18132,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698398+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732899+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'DeletePolicy' RPC.",
@@ -18082,7 +18172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:47.753690+00:00"
+                "validatedAt": "2026-05-05T18:46:46.734280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18094,7 +18184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.698426+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.732915+00:00"
           }
         },
         "x-f5xc-description-short": "Response message of the 'DeletePolicy' RPC.",
@@ -18207,7 +18297,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:54.645694+00:00"
+                "validatedAt": "2026-05-05T18:46:50.106976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18253,7 +18343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:54.645754+00:00"
+                "validatedAt": "2026-05-05T18:46:50.107007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18316,7 +18406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:54.647713+00:00"
+                "validatedAt": "2026-05-05T18:46:50.107924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18390,7 +18480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:54.647791+00:00"
+                "validatedAt": "2026-05-05T18:46:50.107963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18464,7 +18554,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:54.647870+00:00"
+                "validatedAt": "2026-05-05T18:46:50.108002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18590,23 +18680,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:54.647917+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:50.108023+00:00"
               },
               "deterministic": true
             },
@@ -18619,7 +18709,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.859798+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.029850+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18635,16 +18725,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:54.647948+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:50.108039+00:00"
               },
               "deterministic": true
             },
@@ -18657,7 +18752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.859825+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.029873+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18760,7 +18855,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.859913+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.029947+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18828,7 +18923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:54.648061+00:00"
+                "validatedAt": "2026-05-05T18:46:50.108087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18891,7 +18986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:54.648123+00:00"
+                "validatedAt": "2026-05-05T18:46:50.108114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18903,7 +18998,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.859981+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.029998+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18953,23 +19048,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:54.648162+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:50.108132+00:00"
               },
               "deterministic": true
             },
@@ -18982,7 +19077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.860042+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.030043+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18997,16 +19092,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:54.648193+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:50.108148+00:00"
               },
               "deterministic": true
             },
@@ -19019,7 +19119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.860069+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.030064+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19058,7 +19158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:54.648247+00:00"
+                "validatedAt": "2026-05-05T18:46:50.108171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19071,7 +19171,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.860119+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.030101+00:00"
           },
           "uid": {
             "type": "string",
@@ -19089,7 +19189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:54.648276+00:00"
+                "validatedAt": "2026-05-05T18:46:50.108184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19103,7 +19203,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.860146+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.030120+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of secret_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19255,7 +19355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:10.583146+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19289,7 +19389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.583210+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19342,7 +19442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:10.583262+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19376,7 +19476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.583318+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19443,7 +19543,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.583415+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19487,7 +19587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.583492+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19543,7 +19643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:10.583546+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19577,7 +19677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.583600+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19694,7 +19794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.583663+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19752,23 +19852,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:10.583705+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.411305+00:00"
               },
               "deterministic": true
             },
@@ -19781,7 +19881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609660+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120222+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19797,16 +19897,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:10.583741+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.411322+00:00"
               },
               "deterministic": true
             },
@@ -19819,7 +19924,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609686+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120238+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19922,7 +20027,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609777+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120290+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19990,7 +20095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:22:10.583851+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20053,7 +20158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:22:10.583913+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20065,7 +20170,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609847+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120330+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20116,23 +20221,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:10.583950+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.411416+00:00"
               },
               "deterministic": true
             },
@@ -20145,7 +20250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609909+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120367+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20160,16 +20265,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:10.583983+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.411431+00:00"
               },
               "deterministic": true
             },
@@ -20182,7 +20292,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609935+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120382+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20221,7 +20331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:10.584038+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411455+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20234,7 +20344,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.609989+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120413+00:00"
           },
           "uid": {
             "type": "string",
@@ -20252,7 +20362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:10.584067+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20266,7 +20376,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.610015+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.120429+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of voltshare_admin_policy is returned in 'List'.",
@@ -20475,7 +20585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:10.584177+00:00"
+                "validatedAt": "2026-05-05T18:46:33.411521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20487,7 +20597,7 @@
             "x-field-mutability": "read-only",
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.610141+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:14.120504+00:00",
             "x-f5xc-conflicts-with": [
               "all_tenants",
               "individual_users"

--- a/docs/specifications/api/bot_and_threat_defense.json
+++ b/docs/specifications/api/bot_and_threat_defense.json
@@ -4809,23 +4809,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.032275+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.857758+00:00"
               },
               "deterministic": true
             },
@@ -4838,7 +4838,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.313900+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672256+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4854,16 +4854,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.032348+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.857783+00:00"
               },
               "deterministic": true
             },
@@ -4876,7 +4881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.313929+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672272+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4928,7 +4933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.032463+00:00"
+                "validatedAt": "2026-05-05T18:40:41.857825+00:00"
               },
               "deterministic": true
             },
@@ -5141,7 +5146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.032644+00:00"
+                "validatedAt": "2026-05-05T18:40:41.857883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5177,7 +5182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.032724+00:00"
+                "validatedAt": "2026-05-05T18:40:41.857921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5220,7 +5225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.032788+00:00"
+                "validatedAt": "2026-05-05T18:40:41.857958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5280,7 +5285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.032866+00:00"
+                "validatedAt": "2026-05-05T18:40:41.857995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5318,7 +5323,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.032939+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858033+00:00"
               },
               "deterministic": true
             },
@@ -5392,7 +5397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:40.032989+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5455,7 +5460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:40.033052+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5467,7 +5472,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314183+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672424+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5518,23 +5523,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033092+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858105+00:00"
               },
               "deterministic": true
             },
@@ -5547,7 +5552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314249+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672461+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5562,16 +5567,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033124+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858121+00:00"
               },
               "deterministic": true
             },
@@ -5584,7 +5594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314276+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672476+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5607,7 +5617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033166+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5620,7 +5630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314328+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672502+00:00"
           },
           "uid": {
             "type": "string",
@@ -5638,7 +5648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033194+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5652,7 +5662,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314357+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672519+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bot_defense_app_infrastructure is returned in 'List'.",
@@ -5803,7 +5813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033240+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5816,7 +5826,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314443+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672569+00:00"
           },
           "name": {
             "type": "string",
@@ -5833,23 +5843,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033273+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858190+00:00"
               },
               "deterministic": true
             },
@@ -5862,7 +5872,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314470+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672585+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5879,16 +5889,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033305+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858205+00:00"
               },
               "deterministic": true
             },
@@ -5901,7 +5916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314498+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672601+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5920,7 +5935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033360+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5934,7 +5949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314526+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672629+00:00"
           },
           "uid": {
             "type": "string",
@@ -5953,7 +5968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033389+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5968,7 +5983,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314553+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672648+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -6006,7 +6021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033433+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6029,7 +6044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033472+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6041,7 +6056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314592+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672670+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -6117,7 +6132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.033517+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6163,23 +6178,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033552+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858315+00:00"
               },
               "deterministic": true
             },
@@ -6192,7 +6207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314650+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672705+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -6310,7 +6325,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.033664+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858367+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6326,7 +6341,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314709+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672739+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6380,23 +6395,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033706+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858386+00:00"
               },
               "deterministic": true
             },
@@ -6409,7 +6424,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314755+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672766+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6426,16 +6441,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033739+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858402+00:00"
               },
               "deterministic": true
             },
@@ -6448,7 +6468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314782+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672782+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6530,7 +6550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.033830+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858447+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6546,7 +6566,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314823+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672808+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6602,23 +6622,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033872+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858466+00:00"
               },
               "deterministic": true
             },
@@ -6631,7 +6651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314867+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672836+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6648,16 +6668,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.033903+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858482+00:00"
               },
               "deterministic": true
             },
@@ -6670,7 +6695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314892+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672852+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -6752,7 +6777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:40.033993+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858527+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6768,7 +6793,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314931+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672875+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6822,23 +6847,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.034032+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858546+00:00"
               },
               "deterministic": true
             },
@@ -6851,7 +6876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.314977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672902+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6868,16 +6893,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.034063+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858561+00:00"
               },
               "deterministic": true
             },
@@ -6890,7 +6920,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315002+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672918+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -6951,7 +6981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034114+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6963,7 +6993,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315037+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672940+00:00"
           },
           "status": {
             "type": "string",
@@ -6981,7 +7011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034154+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6993,7 +7023,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.672956+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7035,7 +7065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034206+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7062,7 +7092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034253+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7089,7 +7119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034297+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7117,7 +7147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034357+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7182,7 +7212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034428+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7231,7 +7261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034483+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7244,7 +7274,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.673025+00:00"
           },
           "uid": {
             "type": "string",
@@ -7263,7 +7293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034511+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7277,7 +7307,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315210+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.673041+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7327,7 +7357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034548+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7339,7 +7369,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315237+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.673058+00:00"
           },
           "name": {
             "type": "string",
@@ -7356,23 +7386,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.034583+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858796+00:00"
               },
               "deterministic": true
             },
@@ -7385,7 +7415,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315262+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.673073+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7402,16 +7432,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:40.034615+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:41.858812+00:00"
               },
               "deterministic": true
             },
@@ -7424,7 +7459,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315287+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.673089+00:00"
           },
           "uid": {
             "type": "string",
@@ -7441,7 +7476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:40.034644+00:00"
+                "validatedAt": "2026-05-05T18:40:41.858825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7455,7 +7490,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.315313+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.673106+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -7673,7 +7708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:18:30.174981+00:00"
+                "validatedAt": "2026-05-05T18:47:07.310313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7736,7 +7771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:18:30.175041+00:00"
+                "validatedAt": "2026-05-05T18:47:07.310341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7748,7 +7783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.607730+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.975093+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7799,23 +7834,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:30.175079+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:07.310359+00:00"
               },
               "deterministic": true
             },
@@ -7828,7 +7863,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.607793+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.975130+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7843,16 +7878,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:30.175110+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:07.310376+00:00"
               },
               "deterministic": true
             },
@@ -7865,7 +7905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.607819+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.975146+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7888,7 +7928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:30.175149+00:00"
+                "validatedAt": "2026-05-05T18:47:07.310394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7901,7 +7941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.607862+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.975172+00:00"
           },
           "uid": {
             "type": "string",
@@ -7919,7 +7959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:30.175179+00:00"
+                "validatedAt": "2026-05-05T18:47:07.310408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7933,7 +7973,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.607890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.975188+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of shape_bot_defense_instance is returned in 'List'.",
@@ -7989,7 +8029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:53.980945+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671492+00:00"
               },
               "deterministic": true
             },
@@ -8015,7 +8055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.980998+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8042,7 +8082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981040+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8054,7 +8094,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.119689+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.652861+00:00"
           },
           "service_name": {
             "type": "string",
@@ -8071,7 +8111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981089+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8104,7 +8144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981147+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8116,7 +8156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.119724+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.652883+00:00"
           },
           "type": {
             "type": "string",
@@ -8141,7 +8181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981187+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8195,7 +8235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981717+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8208,7 +8248,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653083+00:00"
           },
           "name": {
             "type": "string",
@@ -8225,23 +8265,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:53.981754+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:24.671849+00:00"
               },
               "deterministic": true
             },
@@ -8254,7 +8294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120090+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653099+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8271,16 +8311,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:53.981787+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:24.671865+00:00"
               },
               "deterministic": true
             },
@@ -8293,7 +8338,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120115+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653115+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8312,7 +8357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981827+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8326,7 +8371,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120143+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653131+00:00"
           },
           "uid": {
             "type": "string",
@@ -8345,7 +8390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.981858+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8360,7 +8405,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120170+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653148+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8405,7 +8450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.982080+00:00"
+                "validatedAt": "2026-05-05T18:45:24.671998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8433,7 +8478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.982131+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8461,7 +8506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.982179+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8490,7 +8535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.982225+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8517,7 +8562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.982257+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8531,7 +8576,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120366+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653258+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8547,7 +8592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.982299+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8710,7 +8755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:53.982981+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8838,7 +8883,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120855+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653551+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8903,7 +8948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:53.983110+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8962,7 +9007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.983162+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8989,7 +9034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.983212+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9058,7 +9103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:53.983267+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9121,7 +9166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:53.983336+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9133,7 +9178,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.120969+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653624+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9183,23 +9228,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:53.983376+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:24.672565+00:00"
               },
               "deterministic": true
             },
@@ -9212,7 +9257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.121031+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653662+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9227,16 +9272,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:53.983409+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:24.672581+00:00"
               },
               "deterministic": true
             },
@@ -9249,7 +9299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.121058+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653678+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9288,7 +9338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.983464+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9301,7 +9351,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.121108+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653709+00:00"
           },
           "uid": {
             "type": "string",
@@ -9318,7 +9368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.983495+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9332,7 +9382,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.121134+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.653725+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_api_key is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9441,7 +9491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.983550+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9468,7 +9518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:53.983602+00:00"
+                "validatedAt": "2026-05-05T18:45:24.672671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9664,7 +9714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:58.174083+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9775,7 +9825,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.192881+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.692044+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9824,7 +9874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:58.174203+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9850,7 +9900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:58.174252+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9876,7 +9926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:58.174301+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9902,7 +9952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:58.174369+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9961,7 +10011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:58.174448+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10031,7 +10081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:58.174504+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10094,7 +10144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:58.174566+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10106,7 +10156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.193001+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.692115+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10156,23 +10206,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:58.174606+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:26.756402+00:00"
               },
               "deterministic": true
             },
@@ -10185,7 +10235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.193062+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.692152+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10200,16 +10250,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:58.174638+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:26.756419+00:00"
               },
               "deterministic": true
             },
@@ -10222,7 +10277,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.193089+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.692168+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10261,7 +10316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:58.174693+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10274,7 +10329,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.193140+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.692199+00:00"
           },
           "uid": {
             "type": "string",
@@ -10291,7 +10346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:58.174724+00:00"
+                "validatedAt": "2026-05-05T18:45:26.756457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10305,7 +10360,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.193167+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.692215+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_category is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10626,7 +10681,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.225362+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.709678+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -10673,7 +10728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:00.174742+00:00"
+                "validatedAt": "2026-05-05T18:45:27.722026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10700,7 +10755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:00.174793+00:00"
+                "validatedAt": "2026-05-05T18:45:27.722049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10766,7 +10821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:00.174846+00:00"
+                "validatedAt": "2026-05-05T18:45:27.722072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10829,7 +10884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:00.174907+00:00"
+                "validatedAt": "2026-05-05T18:45:27.722098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10841,7 +10896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.225449+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.709730+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10891,23 +10946,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:00.174948+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:27.722116+00:00"
               },
               "deterministic": true
             },
@@ -10920,7 +10975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.225514+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.709768+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10935,16 +10990,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:00.174982+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:27.722132+00:00"
               },
               "deterministic": true
             },
@@ -10957,7 +11017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.225539+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.709786+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10996,7 +11056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:00.175036+00:00"
+                "validatedAt": "2026-05-05T18:45:27.722155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11009,7 +11069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.225595+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.709818+00:00"
           },
           "uid": {
             "type": "string",
@@ -11026,7 +11086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:00.175065+00:00"
+                "validatedAt": "2026-05-05T18:45:27.722169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11040,7 +11100,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.225623+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.709834+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tpm_manager is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11154,23 +11214,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:05.308506+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.377843+00:00"
               },
               "deterministic": true
             },
@@ -11183,7 +11243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.270606+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.734495+00:00"
           },
           "serial": {
             "type": "string",
@@ -11207,7 +11267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308563+00:00"
+                "validatedAt": "2026-05-05T18:45:30.377871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11239,7 +11299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308614+00:00"
+                "validatedAt": "2026-05-05T18:45:30.377890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11271,7 +11331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308660+00:00"
+                "validatedAt": "2026-05-05T18:45:30.377911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11283,7 +11343,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.270653+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.734522+00:00"
           }
         },
         "x-f5xc-description-short": "DeviceInfo defines device parameters like Serial-Number to include in the TPM provisioning data.",
@@ -11337,7 +11397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308715+00:00"
+                "validatedAt": "2026-05-05T18:45:30.377937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11444,7 +11504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308773+00:00"
+                "validatedAt": "2026-05-05T18:45:30.377962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11482,7 +11542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308822+00:00"
+                "validatedAt": "2026-05-05T18:45:30.377985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11515,7 +11575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308855+00:00"
+                "validatedAt": "2026-05-05T18:45:30.378000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11551,7 +11611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308900+00:00"
+                "validatedAt": "2026-05-05T18:45:30.378019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11584,7 +11644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.308949+00:00"
+                "validatedAt": "2026-05-05T18:45:30.378041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11635,7 +11695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.309003+00:00"
+                "validatedAt": "2026-05-05T18:45:30.378071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11661,7 +11721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.309053+00:00"
+                "validatedAt": "2026-05-05T18:45:30.378094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11687,7 +11747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:05.309091+00:00"
+                "validatedAt": "2026-05-05T18:45:30.378111+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/cdn.json
+++ b/docs/specifications/api/cdn.json
@@ -7577,7 +7577,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.728799+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7601,7 +7601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.728853+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7650,23 +7650,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.728901+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734604+00:00"
               },
               "deterministic": true
             },
@@ -7679,7 +7679,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.289973+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077555+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7695,16 +7695,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.728936+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734635+00:00"
               },
               "deterministic": true
             },
@@ -7717,7 +7722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290003+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077572+00:00"
           },
           "path": {
             "type": "string",
@@ -7748,7 +7753,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729018+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734678+00:00"
               },
               "deterministic": true
             },
@@ -7833,7 +7838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729101+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7896,7 +7901,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729194+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7920,23 +7925,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729233+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734788+00:00"
               },
               "deterministic": true
             },
@@ -7949,7 +7954,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077633+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7965,16 +7970,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729267+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734805+00:00"
               },
               "deterministic": true
             },
@@ -7987,7 +7997,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077650+00:00"
           },
           "user_id": {
             "type": "string",
@@ -8011,7 +8021,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729368+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8065,23 +8075,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729405+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734858+00:00"
               },
               "deterministic": true
             },
@@ -8094,7 +8104,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290165+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077679+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -8152,7 +8162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729474+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8182,23 +8192,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729510+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734909+00:00"
               },
               "deterministic": true
             },
@@ -8211,7 +8221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290237+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077725+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8227,16 +8237,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729543+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734926+00:00"
               },
               "deterministic": true
             },
@@ -8249,7 +8264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290262+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077741+00:00"
           },
           "tls_fingerprint_matcher": {
             "$ref": "#/components/schemas/policyTlsFingerprintMatcherType"
@@ -8303,7 +8318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.729598+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8370,23 +8385,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729650+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734973+00:00"
               },
               "deterministic": true
             },
@@ -8399,7 +8414,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290356+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077793+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8415,16 +8430,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729681+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734989+00:00"
               },
               "deterministic": true
             },
@@ -8437,7 +8457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077810+00:00"
           },
           "path": {
             "type": "string",
@@ -8468,7 +8488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729761+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735028+00:00"
               },
               "deterministic": true
             },
@@ -8554,23 +8574,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729801+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735044+00:00"
               },
               "deterministic": true
             },
@@ -8583,7 +8603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290461+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077859+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8599,16 +8619,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729833+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735060+00:00"
               },
               "deterministic": true
             },
@@ -8621,7 +8646,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290487+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077875+00:00"
           },
           "path": {
             "type": "string",
@@ -8652,7 +8677,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729909+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735098+00:00"
               },
               "deterministic": true
             },
@@ -8732,23 +8757,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729946+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735115+00:00"
               },
               "deterministic": true
             },
@@ -8761,7 +8786,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077914+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8777,16 +8802,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729977+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735131+00:00"
               },
               "deterministic": true
             },
@@ -8799,7 +8829,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290580+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077930+00:00"
           },
           "path": {
             "type": "string",
@@ -8830,7 +8860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730048+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735169+00:00"
               },
               "deterministic": true
             },
@@ -8915,7 +8945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730127+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8978,7 +9008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730214+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9018,23 +9048,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730255+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735269+00:00"
               },
               "deterministic": true
             },
@@ -9047,7 +9077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290672+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077985+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9063,16 +9093,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730287+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735285+00:00"
               },
               "deterministic": true
             },
@@ -9085,7 +9120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290699+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078002+00:00"
           },
           "sec_event_name": {
             "type": "string",
@@ -9102,7 +9137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.730347+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9141,7 +9176,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730407+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9189,7 +9224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730479+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9247,23 +9282,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730515+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735390+00:00"
               },
               "deterministic": true
             },
@@ -9276,7 +9311,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290771+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078047+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -9332,7 +9367,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730592+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9345,7 +9380,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290821+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078076+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -9376,7 +9411,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730651+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9415,7 +9450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730706+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9454,7 +9489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730763+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9478,23 +9513,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730797+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735535+00:00"
               },
               "deterministic": true
             },
@@ -9507,7 +9542,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290874+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078108+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9523,16 +9558,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730828+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735551+00:00"
               },
               "deterministic": true
             },
@@ -9545,7 +9585,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290902+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078125+00:00"
           },
           "req_path": {
             "type": "string",
@@ -9569,7 +9609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730895+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9603,7 +9643,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730987+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9659,23 +9699,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731025+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735659+00:00"
               },
               "deterministic": true
             },
@@ -9688,7 +9728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290958+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078158+00:00"
           },
           "waf_exclusion_policy": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -9733,23 +9773,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731061+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735677+00:00"
               },
               "deterministic": true
             },
@@ -9762,7 +9802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291005+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078186+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9777,16 +9817,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731094+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735693+00:00"
               },
               "deterministic": true
             },
@@ -9799,7 +9844,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291030+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078202+00:00"
           },
           "request_data": {
             "$ref": "#/components/schemas/app_securityRequestData"
@@ -9847,7 +9892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731136+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9875,7 +9920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731179+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9903,7 +9948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731220+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9966,7 +10011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.731279+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9978,7 +10023,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078278+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -10072,7 +10117,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.731347+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10096,16 +10141,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731380+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735831+00:00"
               },
               "deterministic": true
             },
@@ -10118,7 +10168,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291161+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078303+00:00"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -10249,7 +10299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731449+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10273,16 +10323,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731482+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735877+00:00"
               },
               "deterministic": true
             },
@@ -10295,7 +10350,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291223+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078340+00:00"
           },
           "query": {
             "type": "string",
@@ -10315,7 +10370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.731529+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10348,7 +10403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731577+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10415,7 +10470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731629+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10470,7 +10525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731676+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10528,16 +10583,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731737+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735994+00:00"
               },
               "deterministic": true
             },
@@ -10550,7 +10610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291329+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078397+00:00"
           },
           "start_time": {
             "type": "string",
@@ -10575,7 +10635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731783+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10608,7 +10668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731820+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10683,7 +10743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731869+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10732,7 +10792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731907+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10760,7 +10820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731948+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10788,7 +10848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731990+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10857,7 +10917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732040+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10886,7 +10946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732082+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10910,16 +10970,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732115+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736169+00:00"
               },
               "deterministic": true
             },
@@ -10932,7 +10997,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078524+00:00"
           },
           "query": {
             "type": "string",
@@ -10952,7 +11017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732163+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10997,7 +11062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732206+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11030,7 +11095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732254+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11117,7 +11182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732314+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11146,7 +11211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732369+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11194,16 +11259,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732403+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736296+00:00"
               },
               "deterministic": true
             },
@@ -11216,7 +11286,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291561+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078595+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -11234,7 +11304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732445+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11305,7 +11375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732494+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11329,16 +11399,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732526+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736353+00:00"
               },
               "deterministic": true
             },
@@ -11351,7 +11426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291617+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078641+00:00"
           },
           "query": {
             "type": "string",
@@ -11371,7 +11446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732571+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11404,7 +11479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732619+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11471,7 +11546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732667+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11540,7 +11615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732718+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11569,7 +11644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732757+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11593,16 +11668,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732790+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736475+00:00"
               },
               "deterministic": true
             },
@@ -11615,7 +11695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291711+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078702+00:00"
           },
           "query": {
             "type": "string",
@@ -11635,7 +11715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732836+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11680,7 +11760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732877+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11713,7 +11793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732924+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11800,7 +11880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732984+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11829,7 +11909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733028+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11877,16 +11957,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733061+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736600+00:00"
               },
               "deterministic": true
             },
@@ -11899,7 +11984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078769+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -11917,7 +12002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733104+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11988,7 +12073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733160+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12012,16 +12097,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733194+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736665+00:00"
               },
               "deterministic": true
             },
@@ -12034,7 +12124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291880+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078804+00:00"
           },
           "query": {
             "type": "string",
@@ -12054,7 +12144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.733246+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12087,7 +12177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733297+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12154,7 +12244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733360+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12223,7 +12313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733415+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12252,7 +12342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.733454+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12276,16 +12366,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733487+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736785+00:00"
               },
               "deterministic": true
             },
@@ -12298,7 +12393,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291972+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078861+00:00"
           },
           "query": {
             "type": "string",
@@ -12318,7 +12413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.733536+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12363,7 +12458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733584+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12396,7 +12491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733635+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12483,7 +12578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733694+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12512,7 +12607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733740+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12560,16 +12655,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733776+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736907+00:00"
               },
               "deterministic": true
             },
@@ -12582,7 +12682,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.292080+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078928+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -12600,7 +12700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733818+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12649,7 +12749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733868+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12678,7 +12778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:49.733925+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12690,7 +12790,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.292125+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078961+00:00"
           },
           "id": {
             "type": "string",
@@ -12716,7 +12816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733956+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12741,7 +12841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733998+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12774,7 +12874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734051+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12829,23 +12929,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.734106+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.737061+00:00"
               },
               "deterministic": true
             },
@@ -12858,7 +12958,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.292185+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078999+00:00"
           },
           "references": {
             "type": "array",
@@ -12899,7 +12999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734164+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13000,7 +13100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734225+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13322,7 +13422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734315+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13531,7 +13631,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734423+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13604,7 +13704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734485+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13683,7 +13783,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734570+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13728,7 +13828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734649+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13828,7 +13928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734712+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13866,7 +13966,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734794+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737376+00:00"
               },
               "deterministic": true
             },
@@ -13933,7 +14033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734880+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13979,7 +14079,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734960+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14077,7 +14177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735019+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14144,7 +14244,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735102+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14183,7 +14283,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735177+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14256,7 +14356,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735253+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737601+00:00"
               },
               "deterministic": true
             },
@@ -14320,7 +14420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.735300+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14544,7 +14644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735385+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14618,7 +14718,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735452+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14681,7 +14781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735528+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14720,7 +14820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735601+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14761,7 +14861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735683+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14835,7 +14935,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735748+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14904,7 +15004,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.735828+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14939,7 +15039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.735878+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14977,7 +15077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.735932+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15021,7 +15121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736012+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15171,7 +15271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736075+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15813,7 +15913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736151+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15868,23 +15968,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736223+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738085+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -15900,7 +16000,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293250+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079667+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -15945,7 +16045,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736309+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738125+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -16006,7 +16106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736356+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16019,7 +16119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293300+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079696+00:00"
           },
           "name": {
             "type": "string",
@@ -16036,23 +16136,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.736390+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.738158+00:00"
               },
               "deterministic": true
             },
@@ -16065,7 +16165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293335+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079712+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16082,16 +16182,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.736425+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.738177+00:00"
               },
               "deterministic": true
             },
@@ -16104,7 +16209,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293360+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079729+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16123,7 +16228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736465+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16137,7 +16242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293385+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079745+00:00"
           },
           "uid": {
             "type": "string",
@@ -16156,7 +16261,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736495+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16171,7 +16276,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293411+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079762+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16211,7 +16316,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079780+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -16247,7 +16352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736555+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16296,7 +16401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736597+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16335,7 +16440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:04:49.736647+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738274+00:00"
               },
               "deterministic": true
             },
@@ -16402,7 +16507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736699+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16447,7 +16552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736740+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16470,7 +16575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736769+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16482,7 +16587,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293551+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079850+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -16575,7 +16680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736831+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16599,7 +16704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736860+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16611,7 +16716,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293624+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079895+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -16653,7 +16758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736901+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16677,7 +16782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736932+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16689,7 +16794,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293670+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079924+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -16727,7 +16832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736971+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16784,7 +16889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737014+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16808,7 +16913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737043+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16820,7 +16925,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293727+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079977+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -16870,7 +16975,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293764+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080001+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -16927,7 +17032,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293802+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080026+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -16963,7 +17068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737112+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17074,7 +17179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737173+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17140,7 +17245,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293901+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080091+00:00"
           },
           "value": {
             "type": "number",
@@ -17156,7 +17261,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293926+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080109+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -17193,7 +17298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737235+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17294,16 +17399,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.737301+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.738571+00:00"
               },
               "deterministic": true
             },
@@ -17316,7 +17426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293992+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080149+00:00"
           },
           "sec_event_type": {
             "type": "string",
@@ -17333,7 +17443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737359+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17358,7 +17468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737406+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17383,7 +17493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737448+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17408,7 +17518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737490+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17489,7 +17599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737531+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17501,7 +17611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294073+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080198+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -17579,7 +17689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737585+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17591,7 +17701,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080221+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -17642,7 +17752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737670+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17705,7 +17815,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737735+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17743,7 +17853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737791+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17780,7 +17890,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737852+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17817,7 +17927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737907+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17879,7 +17989,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737984+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17968,7 +18078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738083+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18042,7 +18152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738146+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18101,7 +18211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738203+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18154,7 +18264,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.738252+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18289,23 +18399,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738346+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739070+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18321,7 +18431,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294413+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080397+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -18696,7 +18806,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738401+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18802,7 +18912,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738458+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18864,7 +18974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738517+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18942,23 +19052,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738590+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739196+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18974,7 +19084,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294525+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080470+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -19071,7 +19181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738649+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19117,7 +19227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738700+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19155,7 +19265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738753+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19234,7 +19344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738813+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19291,7 +19401,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738868+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19328,7 +19438,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738932+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739378+00:00"
               },
               "deterministic": true
             },
@@ -19364,7 +19474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738986+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19399,7 +19509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739041+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19475,7 +19585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739127+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19508,7 +19618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.739179+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19551,7 +19661,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739239+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19587,7 +19697,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739317+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19630,7 +19740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739400+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19675,7 +19785,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739482+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19752,7 +19862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739537+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19793,7 +19903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739610+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19835,7 +19945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739668+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20006,7 +20116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739722+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20063,7 +20173,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739812+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739807+00:00"
               },
               "deterministic": true
             },
@@ -20076,7 +20186,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294783+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080629+00:00"
           },
           "name": {
             "type": "string",
@@ -20104,23 +20214,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739876+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739841+00:00"
               },
               "deterministic": true
             },
@@ -20132,7 +20242,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294809+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080646+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -20246,7 +20356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:49.739933+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20258,7 +20368,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294844+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080667+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -20273,7 +20383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.739981+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20299,7 +20409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.740022+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20311,7 +20421,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080694+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -20374,7 +20484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.740063+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20773,23 +20883,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740187+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739984+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20805,7 +20915,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080815+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -20865,7 +20975,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740245+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20948,7 +21058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740309+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20960,7 +21070,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295167+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080859+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -21015,23 +21125,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740383+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740080+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21047,7 +21157,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080877+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21070,16 +21180,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740446+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740112+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21095,7 +21210,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295220+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080893+00:00"
           },
           "tenant": {
             "type": "string",
@@ -21124,7 +21239,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740513+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21138,7 +21253,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295248+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080909+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -21283,7 +21398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:55.662384+00:00"
+                "validatedAt": "2026-05-05T18:40:20.563083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21386,7 +21501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234088+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21445,23 +21560,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.234179+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.220833+00:00"
               },
               "deterministic": true
             },
@@ -21474,7 +21589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.952578+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.014857+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -21529,7 +21644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234232+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21554,7 +21669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234279+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21587,7 +21702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234345+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21711,7 +21826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234406+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21800,7 +21915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234489+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21824,7 +21939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234536+00:00"
+                "validatedAt": "2026-05-05T18:40:57.220988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21895,7 +22010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234584+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21919,7 +22034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234632+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22080,7 +22195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234694+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22104,16 +22219,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.234730+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.221077+00:00"
               },
               "deterministic": true
             },
@@ -22126,7 +22246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.952974+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015090+00:00"
           },
           "query": {
             "type": "array",
@@ -22161,7 +22281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234786+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22236,7 +22356,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.234856+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22330,7 +22450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.234908+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22367,7 +22487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:06:12.234955+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22391,16 +22511,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.234989+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.221198+00:00"
               },
               "deterministic": true
             },
@@ -22413,7 +22538,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.953082+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015151+00:00"
           },
           "query": {
             "type": "array",
@@ -22439,7 +22564,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.235044+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22469,7 +22594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235091+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22515,7 +22640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235144+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22559,7 +22684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235181+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22800,7 +22925,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.235275+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22862,7 +22987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235335+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22945,7 +23070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235393+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23061,7 +23186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235464+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23085,7 +23210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235516+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23345,23 +23470,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.235606+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.221474+00:00"
               },
               "deterministic": true
             },
@@ -23374,7 +23499,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.953671+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015484+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23390,16 +23515,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.235639+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.221490+00:00"
               },
               "deterministic": true
             },
@@ -23412,7 +23542,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.953698+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015500+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23483,16 +23613,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.235678+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.221508+00:00"
               },
               "deterministic": true
             },
@@ -23505,7 +23640,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.953761+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015539+00:00"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -23609,7 +23744,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.953847+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015591+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23683,7 +23818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235790+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23708,7 +23843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235832+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23733,7 +23868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235874+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23759,7 +23894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235918+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23784,7 +23919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.235966+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23808,7 +23943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236007+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23832,7 +23967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236055+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23858,7 +23993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236090+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23883,7 +24018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236136+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23908,7 +24043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236183+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23933,7 +24068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236224+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23958,7 +24093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236265+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23983,7 +24118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236315+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24008,7 +24143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236367+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24034,7 +24169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236409+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24059,7 +24194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236456+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24084,7 +24219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236499+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24109,7 +24244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236546+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24134,7 +24269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236596+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24161,7 +24296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236639+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24186,7 +24321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236680+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24211,7 +24346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236723+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24236,7 +24371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236762+00:00"
+                "validatedAt": "2026-05-05T18:40:57.221999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24277,7 +24412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.236819+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222026+00:00"
               },
               "deterministic": true
             },
@@ -24303,7 +24438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236863+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24328,7 +24463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236912+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24352,7 +24487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.236960+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24376,7 +24511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237012+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24401,7 +24536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237065+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24426,7 +24561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237113+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24456,7 +24591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237147+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24481,7 +24616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237191+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24690,7 +24825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237259+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24727,7 +24862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.237328+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24788,16 +24923,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.237391+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222279+00:00"
               },
               "deterministic": true
             },
@@ -24810,7 +24950,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954238+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015836+00:00"
           },
           "start_time": {
             "type": "string",
@@ -24835,7 +24975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237437+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24862,7 +25002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237473+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24917,7 +25057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:12.237514+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24944,7 +25084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237550+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25036,7 +25176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237604+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25048,7 +25188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954348+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015898+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25103,7 +25243,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954386+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015920+00:00"
           }
         },
         "x-f5xc-description-short": "CDN Metrics response series. Each series instance has data for a combination of group-by tag values.",
@@ -25150,7 +25290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.237683+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222411+00:00"
               },
               "deterministic": true
             },
@@ -25174,7 +25314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237719+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25186,7 +25326,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954424+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015943+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25272,7 +25412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:12.237766+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25335,7 +25475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:12.237829+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25347,7 +25487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954484+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.015979+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -25397,23 +25537,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.237868+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222495+00:00"
               },
               "deterministic": true
             },
@@ -25426,7 +25566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954547+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016015+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25441,16 +25581,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.237901+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222511+00:00"
               },
               "deterministic": true
             },
@@ -25463,7 +25608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954573+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016031+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -25502,7 +25647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237955+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25515,7 +25660,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954624+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016062+00:00"
           },
           "uid": {
             "type": "string",
@@ -25533,7 +25678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.237984+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25547,7 +25692,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954652+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016079+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26016,7 +26161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238174+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26062,7 +26207,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238216+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26086,7 +26231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238251+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26143,23 +26288,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.238291+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222695+00:00"
               },
               "deterministic": true
             },
@@ -26172,7 +26317,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954965+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016267+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26195,16 +26340,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.238335+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222712+00:00"
               },
               "deterministic": true
             },
@@ -26217,7 +26367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.954994+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016283+00:00"
           },
           "service_op_id": {
             "type": "integer",
@@ -26287,7 +26437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:12.238391+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26351,7 +26501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.238460+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222773+00:00"
               },
               "deterministic": true
             },
@@ -26397,7 +26547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.238528+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26442,7 +26592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:06:12.238566+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222828+00:00"
               },
               "deterministic": true
             },
@@ -26551,23 +26701,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.238629+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222856+00:00"
               },
               "deterministic": true
             },
@@ -26580,7 +26730,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.955123+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016358+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26603,16 +26753,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.238663+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.222873+00:00"
               },
               "deterministic": true
             },
@@ -26625,7 +26780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.955149+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016374+00:00"
           },
           "time_range": {
             "$ref": "#/components/schemas/common_cdnServiceOperationsTimeRange"
@@ -26675,7 +26830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:12.238701+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26722,7 +26877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238751+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26748,7 +26903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238798+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26780,7 +26935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238848+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26825,7 +26980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238899+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26850,7 +27005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238940+00:00"
+                "validatedAt": "2026-05-05T18:40:57.222997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26874,7 +27029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.238974+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26905,7 +27060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.239022+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26978,7 +27133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.239081+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26990,7 +27145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.955296+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016459+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27033,7 +27188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.239133+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27062,7 +27217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.239184+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27150,7 +27305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.239264+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27185,7 +27340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.239311+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27261,7 +27416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.239393+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223199+00:00"
               },
               "deterministic": true
             },
@@ -27309,7 +27464,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.239449+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27362,7 +27517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.239513+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27465,7 +27620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.239580+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27523,7 +27678,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.239642+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27567,7 +27722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.239711+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223358+00:00"
               },
               "deterministic": true
             },
@@ -27712,23 +27867,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.239879+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.223437+00:00"
               },
               "deterministic": true
             },
@@ -27741,7 +27896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.955724+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.016716+00:00"
           }
         },
         "x-f5xc-description-short": "Response of DELETE DoS Auto-Mitigation Rule API.",
@@ -27992,7 +28147,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240053+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223519+00:00"
               },
               "deterministic": true
             },
@@ -28079,7 +28234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.240114+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28137,7 +28292,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240176+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28240,7 +28395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:06:12.240218+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223601+00:00"
               },
               "deterministic": true
             },
@@ -28364,7 +28519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240286+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28426,7 +28581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240351+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28470,7 +28625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240413+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223709+00:00"
               },
               "deterministic": true
             },
@@ -28610,7 +28765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.240575+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28635,7 +28790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.240618+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28668,7 +28823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.240669+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28737,7 +28892,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240733+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28847,7 +29002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240826+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28895,7 +29050,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240880+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29070,7 +29225,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.240969+00:00"
+                "validatedAt": "2026-05-05T18:40:57.223973+00:00"
               },
               "deterministic": true
             },
@@ -29153,7 +29308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241032+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29269,7 +29424,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241403+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29333,7 +29488,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241459+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29401,7 +29556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241533+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29448,7 +29603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241614+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29514,7 +29669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241670+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29602,7 +29757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241734+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224356+00:00"
               },
               "deterministic": true
             },
@@ -29696,7 +29851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.241855+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29789,7 +29944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.242172+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29894,7 +30049,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.242239+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29991,7 +30146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.242681+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30067,7 +30222,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.242763+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30105,7 +30260,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.242835+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30151,7 +30306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.242922+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30226,7 +30381,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.242983+00:00"
+                "validatedAt": "2026-05-05T18:40:57.224986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30284,7 +30439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.243388+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225174+00:00"
               },
               "deterministic": true
             },
@@ -30406,7 +30561,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.243460+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30498,7 +30653,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.243541+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225244+00:00"
               },
               "deterministic": true
             },
@@ -30591,7 +30746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.243614+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30627,23 +30782,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.243653+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.225292+00:00"
               },
               "deterministic": true
             },
@@ -30656,7 +30811,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.957665+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.017891+00:00"
           },
           "uid": {
             "type": "string",
@@ -30675,7 +30830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.243686+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30689,7 +30844,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.957695+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.017908+00:00"
           }
         },
         "x-f5xc-description-short": "DoS Mitigation Object to auto-configure rules to block attackers.",
@@ -30758,7 +30913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.243727+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225325+00:00"
               },
               "deterministic": true
             },
@@ -30804,7 +30959,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.243814+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31155,7 +31310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.244311+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225605+00:00"
               },
               "deterministic": true
             },
@@ -31195,7 +31350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.244392+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31236,7 +31391,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.244472+00:00"
+                "validatedAt": "2026-05-05T18:40:57.225688+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -31303,7 +31458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.245282+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31378,7 +31533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.245368+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226100+00:00"
               },
               "deterministic": true
             },
@@ -31467,7 +31622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.245448+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31572,7 +31727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.245530+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31663,7 +31818,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.245617+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31748,23 +31903,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.246184+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226503+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31780,7 +31935,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.958851+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.018594+00:00"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -31891,7 +32046,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.246542+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31931,7 +32086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.246622+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31988,7 +32143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.246704+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32178,23 +32333,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.246832+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226810+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -32210,7 +32365,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.959205+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.018813+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -32247,23 +32402,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.246864+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.226825+00:00"
               },
               "deterministic": true
             },
@@ -32276,7 +32431,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.959236+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.018831+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Name of the cookie field\" Specifies the name of the cookie field.",
@@ -32309,23 +32464,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.246896+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.226841+00:00"
               },
               "deterministic": true
             },
@@ -32338,7 +32493,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.959267+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.018848+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Name of the field\" Specifies the name of the field.",
@@ -32373,7 +32528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.246986+00:00"
+                "validatedAt": "2026-05-05T18:40:57.226885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32385,7 +32540,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.959316+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.018877+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Key name of the query parameter\" Specifies the key name of the query parameter.",
@@ -32484,7 +32639,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.247417+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32530,7 +32685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.247469+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32590,7 +32745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.247830+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32684,7 +32839,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.247919+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32725,7 +32880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.247995+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32815,7 +32970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.248032+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32884,7 +33039,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.248114+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32938,7 +33093,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.248194+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32989,7 +33144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.248837+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33012,7 +33167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.248877+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33024,7 +33179,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.959883+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019214+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -33385,7 +33540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249055+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33461,7 +33616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249110+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33499,7 +33654,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249181+00:00"
+                "validatedAt": "2026-05-05T18:40:57.227983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33511,7 +33666,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960082+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019331+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -33530,7 +33685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249230+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33923,23 +34078,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249355+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228056+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -33955,7 +34110,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960459+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019550+00:00"
           },
           "regex_values": {
             "type": "array",
@@ -33993,7 +34148,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249410+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34056,7 +34211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249469+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34092,7 +34247,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249531+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34169,7 +34324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249578+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34181,7 +34336,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960525+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019589+00:00"
           },
           "url": {
             "type": "string",
@@ -34219,7 +34374,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.249653+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228205+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34276,7 +34431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.249693+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228224+00:00"
               },
               "deterministic": true
             },
@@ -34302,7 +34457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249744+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34329,7 +34484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249785+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34341,7 +34496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960581+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019628+00:00"
           },
           "service_name": {
             "type": "string",
@@ -34358,7 +34513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249833+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34391,7 +34546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249876+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34403,7 +34558,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960615+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019649+00:00"
           },
           "type": {
             "type": "string",
@@ -34428,7 +34583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.249917+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34541,23 +34696,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250013+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228377+00:00"
               },
               "deterministic": true
             },
@@ -34570,7 +34725,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960730+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019716+00:00"
           },
           "samesite_lax": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -34644,7 +34799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.250071+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34676,7 +34831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.250121+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34722,7 +34877,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250181+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34770,7 +34925,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250238+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34812,7 +34967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.250290+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34849,7 +35004,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250368+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34966,7 +35121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250445+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228594+00:00"
               },
               "deterministic": true
             },
@@ -35029,7 +35184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250527+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35072,7 +35227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250600+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35117,7 +35272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250677+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228717+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35204,7 +35359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.250724+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35295,7 +35450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250788+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35364,23 +35519,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250856+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228807+00:00"
               },
               "deterministic": true
             },
@@ -35393,7 +35548,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960965+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019857+00:00"
           },
           "secret_value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -35419,7 +35574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.250921+00:00"
+                "validatedAt": "2026-05-05T18:40:57.228842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35431,7 +35586,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.960999+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:01.019878+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -35576,23 +35731,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.250956+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.228860+00:00"
               },
               "deterministic": true
             },
@@ -35605,7 +35760,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961029+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019896+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -35747,7 +35902,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.251259+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229016+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -35763,7 +35918,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961157+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019969+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -35817,23 +35972,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.251304+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229037+00:00"
               },
               "deterministic": true
             },
@@ -35846,7 +36001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961204+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.019996+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35863,16 +36018,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.251347+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229054+00:00"
               },
               "deterministic": true
             },
@@ -35885,7 +36045,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961229+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020012+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -35967,7 +36127,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.251442+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229100+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -35983,7 +36143,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961268+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020035+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -36039,23 +36199,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.251485+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229121+00:00"
               },
               "deterministic": true
             },
@@ -36068,7 +36228,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961313+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020062+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36085,16 +36245,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.251516+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229137+00:00"
               },
               "deterministic": true
             },
@@ -36107,7 +36272,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961349+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020078+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -36189,7 +36354,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.251609+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229183+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -36205,7 +36370,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961387+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020100+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -36259,23 +36424,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.251652+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229204+00:00"
               },
               "deterministic": true
             },
@@ -36288,7 +36453,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961433+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020127+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36305,16 +36470,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.251683+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229221+00:00"
               },
               "deterministic": true
             },
@@ -36327,7 +36497,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961460+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020142+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -36422,7 +36592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.251741+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36450,7 +36620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.251790+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36478,7 +36648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.251836+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36507,7 +36677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.251883+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36534,7 +36704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.251916+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36548,7 +36718,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961553+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020198+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -36564,7 +36734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.251960+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36673,7 +36843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252018+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36685,7 +36855,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961612+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020231+00:00"
           },
           "status": {
             "type": "string",
@@ -36703,7 +36873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252060+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36715,7 +36885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961638+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020247+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -36757,7 +36927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252114+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36784,7 +36954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252164+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36811,7 +36981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252210+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36839,7 +37009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252262+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36904,7 +37074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252342+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36953,7 +37123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252399+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36966,7 +37136,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961754+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020316+00:00"
           },
           "uid": {
             "type": "string",
@@ -36985,7 +37155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252429+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36999,7 +37169,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961781+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020332+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -37072,7 +37242,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.252516+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37104,7 +37274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:12.252574+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37116,7 +37286,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961825+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020359+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -37190,7 +37360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252763+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37202,7 +37372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961954+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020435+00:00"
           },
           "name": {
             "type": "string",
@@ -37219,23 +37389,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.252797+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229740+00:00"
               },
               "deterministic": true
             },
@@ -37248,7 +37418,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.961979+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020451+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37265,16 +37435,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.252831+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.229758+00:00"
               },
               "deterministic": true
             },
@@ -37287,7 +37462,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.962004+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020467+00:00"
           },
           "uid": {
             "type": "string",
@@ -37304,7 +37479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.252861+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37318,7 +37493,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.962033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.020483+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -37405,7 +37580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.252919+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37441,7 +37616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.252971+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37473,7 +37648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.253025+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37546,7 +37721,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253101+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37589,7 +37764,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253156+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37629,7 +37804,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253218+00:00"
+                "validatedAt": "2026-05-05T18:40:57.229979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37730,7 +37905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253420+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37789,7 +37964,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253481+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37835,7 +38010,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253538+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37879,7 +38054,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253592+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37917,7 +38092,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253648+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37990,7 +38165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.253778+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38066,7 +38241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254033+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38111,7 +38286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254089+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38149,7 +38324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.254146+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38184,7 +38359,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254212+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230515+00:00"
               },
               "deterministic": true
             },
@@ -38230,7 +38405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254271+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38308,7 +38483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254336+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38378,7 +38553,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254400+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38479,7 +38654,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254492+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38556,7 +38731,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254547+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38709,7 +38884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.254638+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38842,7 +39017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.254749+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38926,7 +39101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.254791+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230799+00:00"
               },
               "deterministic": true
             },
@@ -39021,23 +39196,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.254833+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.230818+00:00"
               },
               "deterministic": true
             },
@@ -39050,7 +39225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.962953+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.021041+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/viewscdn_loadbalancerCacheOperator"
@@ -39158,7 +39333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.254887+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39181,7 +39356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.254937+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39204,7 +39379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.254986+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39227,7 +39402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255032+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39250,7 +39425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255084+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39273,7 +39448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255129+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39296,7 +39471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255171+00:00"
+                "validatedAt": "2026-05-05T18:40:57.230981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39319,7 +39494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255219+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39342,7 +39517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255266+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39393,7 +39568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255302+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39405,7 +39580,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.963137+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.021152+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/viewscdn_loadbalancerCacheOperator"
@@ -39459,7 +39634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255363+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39539,7 +39714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.255428+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39582,7 +39757,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255496+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39677,7 +39852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255559+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39732,7 +39907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255618+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39768,7 +39943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255676+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39853,7 +40028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255753+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231278+00:00"
               },
               "deterministic": true
             },
@@ -39906,7 +40081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255809+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39983,7 +40158,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255878+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40034,7 +40209,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.255942+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40221,7 +40396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256023+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40279,7 +40454,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256088+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40315,7 +40490,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256147+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40414,7 +40589,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256229+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231521+00:00"
               },
               "deterministic": true
             },
@@ -40467,7 +40642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256290+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40492,7 +40667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.256345+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40569,7 +40744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256414+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40637,7 +40812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256489+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40763,7 +40938,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256552+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40810,7 +40985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256613+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40848,7 +41023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256668+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40889,7 +41064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256725+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40974,7 +41149,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256783+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41181,7 +41356,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256862+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41236,7 +41411,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256919+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41272,7 +41447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.256973+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41357,7 +41532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257045+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231957+00:00"
               },
               "deterministic": true
             },
@@ -41410,7 +41585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257105+00:00"
+                "validatedAt": "2026-05-05T18:40:57.231987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41487,7 +41662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257176+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41538,7 +41713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257233+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41655,7 +41830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257291+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41689,7 +41864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257358+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41824,7 +41999,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257432+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41837,7 +42012,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.964770+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.022147+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/common_wafSimpleLogin"
@@ -41895,7 +42070,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257494+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42013,7 +42188,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257560+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42036,7 +42211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257612+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42062,7 +42237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257668+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42166,7 +42341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.257785+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42250,23 +42425,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:12.257825+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:57.232336+00:00"
               },
               "deterministic": true
             },
@@ -42279,7 +42454,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.964985+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.022275+00:00"
           },
           "type": {
             "type": "string",
@@ -42296,7 +42471,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257864+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42319,7 +42494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257904+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42331,7 +42506,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.965022+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.022296+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42371,7 +42546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.257960+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42396,7 +42571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.258022+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42427,7 +42602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.258076+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42513,7 +42688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.258179+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42583,7 +42758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.258244+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42596,7 +42771,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:05.965123+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.022357+00:00"
           },
           "service_domain": {
             "type": "string",
@@ -42613,7 +42788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:12.258295+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42751,7 +42926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.258428+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42837,7 +43012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:12.258505+00:00"
+                "validatedAt": "2026-05-05T18:40:57.232658+00:00"
               },
               "deterministic": true
             },
@@ -42913,7 +43088,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.634781+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42948,7 +43123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.634878+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43009,7 +43184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.634944+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43047,7 +43222,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635005+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43086,7 +43261,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635068+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43154,7 +43329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635136+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43190,7 +43365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635215+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43268,23 +43443,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635296+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370679+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -43300,7 +43475,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135013+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138151+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/cdn_cache_ruleCacheOperator"
@@ -43400,7 +43575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635361+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43435,7 +43610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635410+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43470,7 +43645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635457+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43505,7 +43680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635503+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43540,7 +43715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635553+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43575,7 +43750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635597+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43610,7 +43785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635638+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43658,7 +43833,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635720+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43693,7 +43868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635766+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43775,7 +43950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:14.635834+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43786,7 +43961,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135174+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138243+00:00"
           },
           "operator": {
             "$ref": "#/components/schemas/cdn_cache_ruleCacheOperator"
@@ -43853,7 +44028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.635885+00:00"
+                "validatedAt": "2026-05-05T18:40:58.370941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43982,23 +44157,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:14.635933+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:58.370963+00:00"
               },
               "deterministic": true
             },
@@ -44011,7 +44186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135295+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138318+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44027,16 +44202,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:14.635968+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:58.370979+00:00"
               },
               "deterministic": true
             },
@@ -44049,7 +44229,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135331+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138334+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -44223,7 +44403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:14.636074+00:00"
+                "validatedAt": "2026-05-05T18:40:58.371024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44286,7 +44466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:14.636139+00:00"
+                "validatedAt": "2026-05-05T18:40:58.371054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44298,7 +44478,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135466+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138412+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -44348,23 +44528,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:14.636179+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:58.371072+00:00"
               },
               "deterministic": true
             },
@@ -44377,7 +44557,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135527+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138449+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44392,16 +44572,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:14.636212+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:58.371089+00:00"
               },
               "deterministic": true
             },
@@ -44414,7 +44599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138465+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -44437,7 +44622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.636255+00:00"
+                "validatedAt": "2026-05-05T18:40:58.371108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44450,7 +44635,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135596+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138491+00:00"
           },
           "uid": {
             "type": "string",
@@ -44467,7 +44652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:14.636285+00:00"
+                "validatedAt": "2026-05-05T18:40:58.371123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44481,7 +44666,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.135624+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.138507+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_cache_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -44755,23 +44940,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:25.964609+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:08.776095+00:00"
               },
               "deterministic": true
             },
@@ -44784,7 +44969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475131+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329542+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44800,16 +44985,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:25.964672+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:08.776116+00:00"
               },
               "deterministic": true
             },
@@ -44822,7 +45012,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475160+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329559+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -44922,7 +45112,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329607+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -44989,7 +45179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:25.964819+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45052,7 +45242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:25.964890+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45064,7 +45254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475314+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329654+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -45114,23 +45304,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:25.964931+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:08.776217+00:00"
               },
               "deterministic": true
             },
@@ -45143,7 +45333,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475390+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329692+00:00"
           },
           "namespace": {
             "type": "string",
@@ -45158,16 +45348,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:25.964967+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:08.776238+00:00"
               },
               "deterministic": true
             },
@@ -45180,7 +45375,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475417+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329708+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -45219,7 +45414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965026+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45232,7 +45427,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475469+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329739+00:00"
           },
           "uid": {
             "type": "string",
@@ -45250,7 +45445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965056+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45264,7 +45459,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.475500+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.329755+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cdn_purge_command is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -45313,7 +45508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965109+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45339,7 +45534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965160+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45371,7 +45566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965215+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45410,7 +45605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965256+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45441,7 +45636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965304+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45466,7 +45661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965358+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45491,7 +45686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965396+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45522,7 +45717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.965444+00:00"
+                "validatedAt": "2026-05-05T18:41:08.776451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45648,7 +45843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:25.967387+00:00"
+                "validatedAt": "2026-05-05T18:41:08.777359+00:00"
               },
               "deterministic": true
             },
@@ -45691,7 +45886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:25.967463+00:00"
+                "validatedAt": "2026-05-05T18:41:08.777396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45733,7 +45928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.967512+00:00"
+                "validatedAt": "2026-05-05T18:41:08.777417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45810,7 +46005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:25.967583+00:00"
+                "validatedAt": "2026-05-05T18:41:08.777453+00:00"
               },
               "deterministic": true
             },
@@ -45853,7 +46048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:25.967655+00:00"
+                "validatedAt": "2026-05-05T18:41:08.777488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45895,7 +46090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:25.967703+00:00"
+                "validatedAt": "2026-05-05T18:41:08.777510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45955,7 +46150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773405+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45990,7 +46185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773453+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46025,7 +46220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773499+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46060,7 +46255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773546+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46095,7 +46290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773594+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46130,7 +46325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773635+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46165,7 +46360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773676+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46211,7 +46406,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:29.773751+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46246,7 +46441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773798+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46309,7 +46504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.773977+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46344,7 +46539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774024+00:00"
+                "validatedAt": "2026-05-05T18:41:10.677988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46379,7 +46574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774071+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46414,7 +46609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774118+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46449,7 +46644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774167+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46484,7 +46679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774208+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46519,7 +46714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774246+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46565,7 +46760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:29.774332+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46600,7 +46795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774377+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46663,7 +46858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774685+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46698,7 +46893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774734+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46733,7 +46928,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774781+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46768,7 +46963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774829+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46803,7 +46998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774878+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46838,7 +47033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774921+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46873,7 +47068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.774959+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46919,7 +47114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:29.775040+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46954,7 +47149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:29.775087+00:00"
+                "validatedAt": "2026-05-05T18:41:10.678474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47011,7 +47206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.665167+00:00"
+                "validatedAt": "2026-05-05T18:42:14.632123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47036,7 +47231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.665226+00:00"
+                "validatedAt": "2026-05-05T18:42:14.632155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47304,7 +47499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.665923+00:00"
+                "validatedAt": "2026-05-05T18:42:14.632468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47395,7 +47590,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.665986+00:00"
+                "validatedAt": "2026-05-05T18:42:14.632501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47584,7 +47779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:08:38.666092+00:00"
+                "validatedAt": "2026-05-05T18:42:14.632548+00:00"
               },
               "deterministic": true
             },
@@ -47779,7 +47974,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.668081+00:00"
+                "validatedAt": "2026-05-05T18:42:14.633495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47840,7 +48035,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.668132+00:00"
+                "validatedAt": "2026-05-05T18:42:14.633522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47919,7 +48114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.672084+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48391,7 +48586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672228+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48434,7 +48629,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672287+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48472,7 +48667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672354+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48517,7 +48712,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672413+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48555,7 +48750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672471+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48599,7 +48794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672530+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48637,7 +48832,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672586+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48682,7 +48877,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672647+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49310,7 +49505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672709+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49322,7 +49517,7 @@
             "x-original-maxLength": 128,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.478650+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.022931+00:00"
           },
           "value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -49642,7 +49837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672791+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49680,7 +49875,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672851+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635825+00:00"
               },
               "deterministic": true
             },
@@ -50024,23 +50219,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.672893+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.635844+00:00"
               },
               "deterministic": true
             },
@@ -50053,7 +50248,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.478749+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.022990+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50068,16 +50263,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.672925+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.635860+00:00"
               },
               "deterministic": true
             },
@@ -50090,7 +50290,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.478774+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023006+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50709,7 +50909,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.672990+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635892+00:00"
               },
               "deterministic": true
             },
@@ -52250,7 +52450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.673143+00:00"
+                "validatedAt": "2026-05-05T18:42:14.635964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52588,23 +52788,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673185+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.635985+00:00"
               },
               "deterministic": true
             },
@@ -52617,7 +52817,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.478976+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023129+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52633,16 +52833,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673216+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636001+00:00"
               },
               "deterministic": true
             },
@@ -52655,7 +52860,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479006+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023146+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52965,23 +53170,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673251+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636017+00:00"
               },
               "deterministic": true
             },
@@ -52994,7 +53199,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479036+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023171+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53010,16 +53215,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673282+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636032+00:00"
               },
               "deterministic": true
             },
@@ -53032,7 +53242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023187+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints For Groups.",
@@ -53363,7 +53573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.673359+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53693,7 +53903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.673421+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53717,23 +53927,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673455+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636106+00:00"
               },
               "deterministic": true
             },
@@ -53746,7 +53956,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023234+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53762,16 +53972,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673486+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636122+00:00"
               },
               "deterministic": true
             },
@@ -53784,7 +53999,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479148+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023266+00:00"
           },
           "query_type": {
             "$ref": "#/components/schemas/http_loadbalancerApiInventorySchemaQueryType"
@@ -54789,7 +55004,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479277+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023411+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -55109,16 +55324,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673629+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636182+00:00"
               },
               "deterministic": true
             },
@@ -55131,7 +55351,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479339+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023464+00:00"
           }
         },
         "x-f5xc-description-short": "Request of GET Security Config Spec API.",
@@ -55465,7 +55685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.673692+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55800,7 +56020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.673750+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56798,7 +57018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:38.673846+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57134,7 +57354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.673906+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57146,7 +57366,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479519+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023600+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -57196,23 +57416,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673948+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636327+00:00"
               },
               "deterministic": true
             },
@@ -57225,7 +57445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479583+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023644+00:00"
           },
           "namespace": {
             "type": "string",
@@ -57240,16 +57460,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.673980+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.636343+00:00"
               },
               "deterministic": true
             },
@@ -57262,7 +57487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479611+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023661+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -57301,7 +57526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.674034+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57314,7 +57539,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479666+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023692+00:00"
           },
           "uid": {
             "type": "string",
@@ -57332,7 +57557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.674064+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57346,7 +57571,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.479695+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.023708+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of http_loadbalancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -57676,7 +57901,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674146+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636419+00:00"
               },
               "deterministic": true
             },
@@ -57708,7 +57933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.674196+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58040,7 +58265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674252+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58387,7 +58612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674463+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58489,7 +58714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674529+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636598+00:00"
               },
               "deterministic": true
             },
@@ -58535,7 +58760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674611+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58571,7 +58796,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674684+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58930,7 +59155,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674772+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59034,7 +59259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674842+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636755+00:00"
               },
               "deterministic": true
             },
@@ -59080,7 +59305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674916+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59116,7 +59341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.674989+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60154,7 +60379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675100+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60202,7 +60427,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675160+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60245,7 +60470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675221+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60282,7 +60507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675276+00:00"
+                "validatedAt": "2026-05-05T18:42:14.636971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60327,7 +60552,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675340+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60365,7 +60590,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675397+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60409,7 +60634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675452+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60446,7 +60671,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675511+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60491,7 +60716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675571+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60537,7 +60762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:08:38.675614+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637145+00:00"
               },
               "deterministic": true
             },
@@ -61175,7 +61400,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675692+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637183+00:00"
               },
               "deterministic": true
             },
@@ -61522,7 +61747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675762+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637218+00:00"
               },
               "deterministic": true
             },
@@ -61879,7 +62104,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675834+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637255+00:00"
               },
               "deterministic": true
             },
@@ -61915,7 +62140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675905+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61969,7 +62194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.675964+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62310,7 +62535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.676033+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62637,23 +62862,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.676080+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.637372+00:00"
               },
               "deterministic": true
             },
@@ -62666,7 +62891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.480671+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.024309+00:00"
           },
           "namespace": {
             "type": "string",
@@ -62689,16 +62914,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.676117+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.637390+00:00"
               },
               "deterministic": true
             },
@@ -62711,7 +62941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.480698+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.024326+00:00"
           },
           "rps_threshold": {
             "type": "integer",
@@ -64005,7 +64235,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.676242+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64029,23 +64259,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.676274+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.637466+00:00"
               },
               "deterministic": true
             },
@@ -64058,7 +64288,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.480832+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.024407+00:00"
           },
           "namespace": {
             "type": "string",
@@ -64074,16 +64304,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.676306+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.637481+00:00"
               },
               "deterministic": true
             },
@@ -64096,7 +64331,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.480857+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.024423+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for Update API Endpoints Schemas.",
@@ -64736,7 +64971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.677021+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637837+00:00"
               },
               "deterministic": true
             },
@@ -64780,7 +65015,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.677098+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65051,7 +65286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.677241+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65112,7 +65347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.677295+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65178,7 +65413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.677359+00:00"
+                "validatedAt": "2026-05-05T18:42:14.637989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65281,7 +65516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.677421+00:00"
+                "validatedAt": "2026-05-05T18:42:14.638015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65353,7 +65588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.677483+00:00"
+                "validatedAt": "2026-05-05T18:42:14.638047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65434,7 +65669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.677534+00:00"
+                "validatedAt": "2026-05-05T18:42:14.638069+00:00"
               },
               "deterministic": true
             },
@@ -65602,7 +65837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.677774+00:00"
+                "validatedAt": "2026-05-05T18:42:14.638188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65673,7 +65908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.677816+00:00"
+                "validatedAt": "2026-05-05T18:42:14.638209+00:00"
               },
               "deterministic": true
             },
@@ -65785,7 +66020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.679847+00:00"
+                "validatedAt": "2026-05-05T18:42:14.639224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65870,7 +66105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.679915+00:00"
+                "validatedAt": "2026-05-05T18:42:14.639257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65951,7 +66186,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.681598+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66028,23 +66263,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.681667+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640104+00:00"
               },
               "deterministic": true
             },
@@ -66056,7 +66291,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.483271+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.025905+00:00"
           },
           "path": {
             "type": "string",
@@ -66077,7 +66312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.681712+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66177,7 +66412,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.681800+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66283,7 +66518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.681886+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66320,7 +66555,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.681946+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66380,7 +66615,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.682033+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66450,7 +66685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.682121+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66524,7 +66759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.682191+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66559,7 +66794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.682272+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66598,7 +66833,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.682355+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66634,7 +66869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.682410+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66672,7 +66907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.682489+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66767,7 +67002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.682588+00:00"
+                "validatedAt": "2026-05-05T18:42:14.640544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66953,23 +67188,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.683667+00:00"
+                "validatedAt": "2026-05-05T18:42:14.641056+00:00"
               },
               "deterministic": true
             },
@@ -66982,7 +67217,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.484362+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.026517+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -67023,7 +67258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.683734+00:00"
+                "validatedAt": "2026-05-05T18:42:14.641090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67035,7 +67270,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.484405+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:03.026543+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -67233,7 +67468,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.685536+00:00"
+                "validatedAt": "2026-05-05T18:42:14.641978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67267,7 +67502,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.685609+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67441,7 +67676,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.685740+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67490,7 +67725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.685804+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67585,7 +67820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.685884+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67619,7 +67854,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.685958+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67661,7 +67896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.686031+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67752,23 +67987,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.686118+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642268+00:00"
               },
               "deterministic": true
             },
@@ -67781,7 +68016,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.485469+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.027184+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -67831,7 +68066,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.686186+00:00"
+                "validatedAt": "2026-05-05T18:42:14.642303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67843,7 +68078,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.485535+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:03.027226+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -68054,7 +68289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.688407+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68137,7 +68372,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.688784+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68225,7 +68460,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.688863+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68292,7 +68527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.688950+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643702+00:00"
               },
               "byteLength": {
                 "max": 1024,
@@ -68344,7 +68579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689216+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68394,7 +68629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.689261+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68422,7 +68657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.689296+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643870+00:00"
               },
               "deterministic": true
             },
@@ -68446,7 +68681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689347+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68469,7 +68704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689390+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68481,7 +68716,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.486954+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028108+00:00"
           },
           "status": {
             "type": "string",
@@ -68497,7 +68732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689432+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68509,7 +68744,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.486981+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028130+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -68550,7 +68785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.689473+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68572,23 +68807,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.689508+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.643972+00:00"
               },
               "deterministic": true
             },
@@ -68601,7 +68836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.487018+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028153+00:00"
           },
           "nlb_cname": {
             "type": "string",
@@ -68617,7 +68852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689552+00:00"
+                "validatedAt": "2026-05-05T18:42:14.643993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68640,7 +68875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689597+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68663,7 +68898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689638+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68675,7 +68910,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.487065+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028180+00:00"
           },
           "target_group_status": {
             "type": "array",
@@ -68729,7 +68964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.689696+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68766,23 +69001,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:38.689748+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:14.644090+00:00"
               },
               "deterministic": true
             },
@@ -68795,7 +69030,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.487120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028214+00:00"
           },
           "protocol": {
             "type": "string",
@@ -68810,7 +69045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689790+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68833,7 +69068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689831+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68845,7 +69080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.487156+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028236+00:00"
           },
           "status": {
             "type": "string",
@@ -68861,7 +69096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.689875+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68873,7 +69108,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.487182+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.028252+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -68926,7 +69161,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.689940+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644193+00:00"
               },
               "deterministic": true
             },
@@ -69011,7 +69246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.689991+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69039,7 +69274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:38.690029+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69207,7 +69442,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690158+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69280,7 +69515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690201+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644323+00:00"
               },
               "deterministic": true
             },
@@ -69327,7 +69562,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690283+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69450,7 +69685,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690379+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69485,7 +69720,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690452+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69580,7 +69815,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690517+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69711,7 +69946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690880+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69772,7 +70007,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.690944+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69808,7 +70043,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691005+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69850,7 +70085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691065+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69948,7 +70183,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691141+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644810+00:00"
               },
               "deterministic": true
             },
@@ -70004,7 +70239,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691202+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70093,7 +70328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691278+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70142,7 +70377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691341+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70199,7 +70434,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691406+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70579,7 +70814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691499+00:00"
+                "validatedAt": "2026-05-05T18:42:14.644988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70592,7 +70827,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.488495+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.029040+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -70982,7 +71217,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691574+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71046,7 +71281,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691640+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71082,7 +71317,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691699+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71124,7 +71359,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691762+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71236,7 +71471,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691858+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645164+00:00"
               },
               "deterministic": true
             },
@@ -71292,7 +71527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.691917+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71317,7 +71552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:38.691964+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71420,7 +71655,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692057+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71469,7 +71704,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692112+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71529,7 +71764,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692175+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72236,7 +72471,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692248+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72297,7 +72532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692310+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72333,7 +72568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692378+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72375,7 +72610,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692439+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72473,7 +72708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692516+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645490+00:00"
               },
               "deterministic": true
             },
@@ -72529,7 +72764,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692578+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72618,7 +72853,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692656+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72667,7 +72902,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692714+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72724,7 +72959,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692778+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73405,7 +73640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692865+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73460,7 +73695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692925+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73498,7 +73733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.692963+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645718+00:00"
               },
               "deterministic": true
             },
@@ -73605,7 +73840,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.693311+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73693,7 +73928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:38.693394+00:00"
+                "validatedAt": "2026-05-05T18:42:14.645922+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/ce_management.json
+++ b/docs/specifications/api/ce_management.json
@@ -7474,23 +7474,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.892127+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.715194+00:00"
               },
               "deterministic": true
             },
@@ -7503,7 +7503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.800203+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433436+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7519,16 +7519,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.892182+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.715215+00:00"
               },
               "deterministic": true
             },
@@ -7541,7 +7546,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.800233+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433453+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7581,23 +7586,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.892234+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.715232+00:00"
               },
               "deterministic": true
             },
@@ -7610,7 +7615,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.800262+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433471+00:00"
           },
           "network_device": {
             "$ref": "#/components/schemas/fleetNetworkingDeviceInstanceType"
@@ -7675,7 +7680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892410+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7712,7 +7717,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892507+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7831,7 +7836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892604+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7868,7 +7873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892675+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7932,7 +7937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892759+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7967,7 +7972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.892813+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8006,7 +8011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892876+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8063,7 +8068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.892942+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8125,7 +8130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.893008+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8223,7 +8228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893094+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8260,7 +8265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893161+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8300,7 +8305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893248+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8337,7 +8342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893334+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8415,7 +8420,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893421+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8459,7 +8464,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893479+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8535,7 +8540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893537+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8625,23 +8630,23 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893641+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715876+00:00"
               },
               "deterministic": true
             },
@@ -8654,7 +8659,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.800609+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433664+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8714,7 +8719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893703+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8772,7 +8777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893757+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8837,7 +8842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893815+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8882,7 +8887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.893874+00:00"
+                "validatedAt": "2026-05-05T18:43:45.715992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8938,7 +8943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.893929+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9053,7 +9058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894026+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716071+00:00"
               },
               "deterministic": true
             },
@@ -9066,7 +9071,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.800730+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433763+00:00"
           },
           "hpe_storage": {
             "$ref": "#/components/schemas/fleetStorageClassHpeStorageType"
@@ -9100,7 +9105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894103+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9135,7 +9140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.894157+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9179,7 +9184,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894241+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9245,7 +9250,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894297+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9343,7 +9348,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894389+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9412,7 +9417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894446+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9521,7 +9526,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.800949+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433897+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9589,7 +9594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:40.894560+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9651,7 +9656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:40.894622+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9663,7 +9668,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.801018+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433938+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9713,23 +9718,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.894663+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.716371+00:00"
               },
               "deterministic": true
             },
@@ -9742,7 +9747,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.801083+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433976+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9757,16 +9762,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.894695+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.716388+00:00"
               },
               "deterministic": true
             },
@@ -9779,7 +9789,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.801110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.433991+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9818,7 +9828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.894749+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9831,7 +9841,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.801167+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434026+00:00"
           },
           "uid": {
             "type": "string",
@@ -9848,7 +9858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.894778+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9862,7 +9872,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.801196+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434042+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fleet is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9926,7 +9936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894837+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10034,7 +10044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.894879+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10092,7 +10102,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.894961+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10137,7 +10147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895013+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10175,7 +10185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895087+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10204,7 +10214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895135+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10243,7 +10253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895187+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10269,7 +10279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895239+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10301,7 +10311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895291+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10343,7 +10353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895356+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10493,7 +10503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895432+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10589,7 +10599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895522+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10709,7 +10719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895637+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716831+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -10766,7 +10776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895715+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10798,7 +10808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895790+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10851,7 +10861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895874+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716950+00:00"
               },
               "deterministic": true
             },
@@ -10864,7 +10874,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.801550+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434251+00:00"
           },
           "destroy_on_delete": {
             "type": "boolean",
@@ -10922,7 +10932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.895945+00:00"
+                "validatedAt": "2026-05-05T18:43:45.716985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10949,7 +10959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.895990+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10976,7 +10986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.896035+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11009,7 +11019,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896116+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11042,7 +11052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896175+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11075,7 +11085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896256+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11109,7 +11119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896340+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11142,7 +11152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896414+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11261,7 +11271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896499+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11316,7 +11326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.896544+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11350,7 +11360,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896616+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11455,7 +11465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896727+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11491,7 +11501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896811+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11524,7 +11534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896885+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11568,7 +11578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.896952+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717470+00:00"
               },
               "deterministic": true
             },
@@ -11651,7 +11661,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897032+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11684,7 +11694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897109+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11724,7 +11734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897189+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11762,7 +11772,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897260+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11820,7 +11830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.897327+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11846,7 +11856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.897377+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11883,7 +11893,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897464+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11921,7 +11931,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897541+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11950,7 +11960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.897594+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11978,7 +11988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.897633+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12016,7 +12026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897685+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12051,7 +12061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.897739+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12077,7 +12087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.897787+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12114,7 +12124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897844+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12148,7 +12158,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897923+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12192,7 +12202,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.897988+00:00"
+                "validatedAt": "2026-05-05T18:43:45.717979+00:00"
               },
               "deterministic": true
             },
@@ -12274,7 +12284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898068+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12314,7 +12324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898148+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12352,7 +12362,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898217+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12392,7 +12402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898292+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12498,7 +12508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898425+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12536,7 +12546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898506+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12570,7 +12580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.898547+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12608,7 +12618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898601+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12643,7 +12653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.898660+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12680,7 +12690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898737+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12717,7 +12727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898799+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12751,7 +12761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898879+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718403+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12798,7 +12808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.898945+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718436+00:00"
               },
               "deterministic": true
             },
@@ -12919,7 +12929,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.899037+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13006,7 +13016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899094+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13136,7 +13146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899150+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13149,7 +13159,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802249+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434676+00:00"
           },
           "name": {
             "type": "string",
@@ -13166,23 +13176,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.899184+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.718551+00:00"
               },
               "deterministic": true
             },
@@ -13195,7 +13205,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802277+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434692+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13212,16 +13222,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.899220+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.718567+00:00"
               },
               "deterministic": true
             },
@@ -13234,7 +13249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802302+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434709+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13253,7 +13268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899260+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13267,7 +13282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802337+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434724+00:00"
           },
           "uid": {
             "type": "string",
@@ -13286,7 +13301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899289+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13301,7 +13316,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802366+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434741+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13339,7 +13354,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899341+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13362,7 +13377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899378+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13374,7 +13389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802407+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434766+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -13417,7 +13432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899431+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13455,7 +13470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.899499+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13467,7 +13482,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802446+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434789+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -13486,7 +13501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899549+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13537,7 +13552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899590+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13549,7 +13564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802485+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434811+00:00"
           },
           "url": {
             "type": "string",
@@ -13587,7 +13602,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.899661+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718789+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13644,7 +13659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.899697+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718807+00:00"
               },
               "deterministic": true
             },
@@ -13670,7 +13685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899747+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13697,7 +13712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899787+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13709,7 +13724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802540+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434844+00:00"
           },
           "service_name": {
             "type": "string",
@@ -13726,7 +13741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899833+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13759,7 +13774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899874+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13771,7 +13786,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802576+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434865+00:00"
           },
           "type": {
             "type": "string",
@@ -13796,7 +13811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899911+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13884,7 +13899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.899956+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13930,23 +13945,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.899992+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.718940+00:00"
               },
               "deterministic": true
             },
@@ -13959,7 +13974,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802640+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.434904+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -14108,7 +14123,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900077+00:00"
+                "validatedAt": "2026-05-05T18:43:45.718979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14184,7 +14199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900159+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14240,7 +14255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900223+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14318,7 +14333,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900304+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14374,7 +14389,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900371+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14489,7 +14504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900460+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719165+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14505,7 +14520,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435012+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14559,23 +14574,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.900501+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719184+00:00"
               },
               "deterministic": true
             },
@@ -14588,7 +14603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802866+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435040+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14605,16 +14620,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.900533+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719200+00:00"
               },
               "deterministic": true
             },
@@ -14627,7 +14647,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802892+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435056+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -14709,7 +14729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900619+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719243+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14725,7 +14745,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802933+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435079+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -14781,23 +14801,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.900660+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719263+00:00"
               },
               "deterministic": true
             },
@@ -14810,7 +14830,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.802978+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435106+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14827,16 +14847,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.900690+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719278+00:00"
               },
               "deterministic": true
             },
@@ -14849,7 +14874,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803004+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435122+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -14931,7 +14956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900779+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719322+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -14947,7 +14972,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803041+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435145+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15001,23 +15026,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.900821+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719343+00:00"
               },
               "deterministic": true
             },
@@ -15030,7 +15055,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435172+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15047,16 +15072,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.900851+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719358+00:00"
               },
               "deterministic": true
             },
@@ -15069,7 +15099,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435187+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15198,7 +15228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900908+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15252,7 +15282,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.900964+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15303,7 +15333,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901016+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15331,7 +15361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901063+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15359,7 +15389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901106+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15388,7 +15418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901149+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15415,7 +15445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901178+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15429,7 +15459,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803242+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435265+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15445,7 +15475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901226+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15554,7 +15584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901288+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15566,7 +15596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435298+00:00"
           },
           "status": {
             "type": "string",
@@ -15584,7 +15614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901340+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15596,7 +15626,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803331+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435313+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -15638,7 +15668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901396+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15665,7 +15695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901446+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15692,7 +15722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901492+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15720,7 +15750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901543+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15785,7 +15815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901614+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15834,7 +15864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901680+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15847,7 +15877,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803451+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435383+00:00"
           },
           "uid": {
             "type": "string",
@@ -15866,7 +15896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901713+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15880,7 +15910,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803480+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435399+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -15930,7 +15960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901755+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15942,7 +15972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803507+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435416+00:00"
           },
           "name": {
             "type": "string",
@@ -15959,23 +15989,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.901790+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719793+00:00"
               },
               "deterministic": true
             },
@@ -15988,7 +16018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803532+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435432+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16005,16 +16035,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:40.901824+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:45.719810+00:00"
               },
               "deterministic": true
             },
@@ -16027,7 +16062,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803557+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435448+00:00"
           },
           "uid": {
             "type": "string",
@@ -16044,7 +16079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901854+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16058,7 +16093,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.803583+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.435465+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16157,7 +16192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.901914+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16244,7 +16279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.901982+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16277,7 +16312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902043+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16323,7 +16358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902100+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16357,7 +16392,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902151+00:00"
+                "validatedAt": "2026-05-05T18:43:45.719977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16405,7 +16440,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902236+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16438,7 +16473,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902295+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16492,7 +16527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902397+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16600,7 +16635,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902458+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16687,7 +16722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:40.902523+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16720,7 +16755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902584+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16766,7 +16801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902641+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16800,7 +16835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902696+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16848,7 +16883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902780+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16881,7 +16916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902835+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16935,7 +16970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902921+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17043,7 +17078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.902980+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17128,7 +17163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903047+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17174,7 +17209,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903108+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17208,7 +17243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903163+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17256,7 +17291,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903249+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17289,7 +17324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903305+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17343,7 +17378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903403+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17438,23 +17473,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903469+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720644+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17470,7 +17505,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.804573+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.436072+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17493,16 +17528,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903530+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720677+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -17518,7 +17558,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.804602+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.436089+00:00"
           },
           "tenant": {
             "type": "string",
@@ -17547,7 +17587,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903593+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17561,7 +17601,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.804631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.436105+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -17790,7 +17830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:40.903707+00:00"
+                "validatedAt": "2026-05-05T18:43:45.720764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18019,7 +18059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:36.876238+00:00"
+                "validatedAt": "2026-05-05T18:45:40.148769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18059,7 +18099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876317+00:00"
+                "validatedAt": "2026-05-05T18:45:40.148816+00:00"
               },
               "deterministic": true
             },
@@ -18117,7 +18157,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876408+00:00"
+                "validatedAt": "2026-05-05T18:45:40.148853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18152,7 +18192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876477+00:00"
+                "validatedAt": "2026-05-05T18:45:40.148888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18224,7 +18264,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876544+00:00"
+                "validatedAt": "2026-05-05T18:45:40.148922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18412,7 +18452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876640+00:00"
+                "validatedAt": "2026-05-05T18:45:40.148967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18451,7 +18491,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876716+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18492,7 +18532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:36.876768+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18532,7 +18572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876837+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149069+00:00"
               },
               "deterministic": true
             },
@@ -18620,7 +18660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876909+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18654,7 +18694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.876981+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18726,7 +18766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877046+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18826,7 +18866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877128+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18893,7 +18933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877213+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18936,7 +18976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:36.877260+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19008,7 +19048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877342+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19066,7 +19106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877421+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19129,23 +19169,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.877462+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:40.149373+00:00"
               },
               "deterministic": true
             },
@@ -19158,7 +19198,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.100305+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.764550+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19174,16 +19214,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.877496+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:40.149390+00:00"
               },
               "deterministic": true
             },
@@ -19196,7 +19241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.100349+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.764565+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19260,7 +19305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877571+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19339,7 +19384,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877651+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19382,7 +19427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:36.877694+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19436,7 +19481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.877733+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149516+00:00"
               },
               "deterministic": true
             },
@@ -19569,7 +19614,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.100609+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.764727+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19634,7 +19679,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.877856+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19676,7 +19721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:36.877907+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19789,7 +19834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:36.877971+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19825,7 +19870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878032+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19867,7 +19912,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878089+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19978,7 +20023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878202+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20107,7 +20152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878271+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20162,7 +20207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878360+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20266,7 +20311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.878407+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149847+00:00"
               },
               "deterministic": true
             },
@@ -20330,7 +20375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878477+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20371,7 +20416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.878514+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149902+00:00"
               },
               "deterministic": true
             },
@@ -20438,7 +20483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878588+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20478,7 +20523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.878623+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149964+00:00"
               },
               "deterministic": true
             },
@@ -20543,7 +20588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878683+00:00"
+                "validatedAt": "2026-05-05T18:45:40.149995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20580,7 +20625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:36.878735+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20649,7 +20694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:36.878790+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20705,7 +20750,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.878858+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20830,7 +20875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:36.878922+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20893,7 +20938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:36.878984+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20905,7 +20950,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.101203+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.765078+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20955,23 +21000,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.879024+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:40.150164+00:00"
               },
               "deterministic": true
             },
@@ -20984,7 +21029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.101264+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.765114+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20999,16 +21044,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:36.879056+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:40.150189+00:00"
               },
               "deterministic": true
             },
@@ -21021,7 +21071,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.101290+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.765130+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21060,7 +21110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:36.879109+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21073,7 +21123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.101356+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.765161+00:00"
           },
           "uid": {
             "type": "string",
@@ -21091,7 +21141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:36.879138+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21105,7 +21155,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.101385+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.765177+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_interface is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21353,7 +21403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.879212+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21638,7 +21688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.879298+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21677,7 +21727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.879380+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150363+00:00"
               },
               "deterministic": true
             },
@@ -21821,7 +21871,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:36.879486+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21858,7 +21908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:36.879527+00:00"
+                "validatedAt": "2026-05-05T18:45:40.150436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21939,7 +21989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.883821+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21951,7 +22001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.307922+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292458+00:00"
           },
           "status": {
             "type": "string",
@@ -21969,7 +22019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.883862+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21981,7 +22031,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.307952+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292475+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -22037,7 +22087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884006+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22064,7 +22114,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884056+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22111,23 +22161,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.884102+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.543198+00:00"
               },
               "deterministic": true
             },
@@ -22140,7 +22190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308061+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292560+00:00"
           },
           "passport": {
             "$ref": "#/components/schemas/registrationPassport"
@@ -22161,7 +22211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884154+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22221,23 +22271,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.884197+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.543240+00:00"
               },
               "deterministic": true
             },
@@ -22250,7 +22300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308118+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292600+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22272,16 +22322,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.884236+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.543260+00:00"
               },
               "deterministic": true
             },
@@ -22294,7 +22349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308146+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292628+00:00"
           },
           "token": {
             "type": "string",
@@ -22320,7 +22375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:17:31.884284+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22366,7 +22421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884342+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22488,7 +22543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884402+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22500,7 +22555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292706+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22535,7 +22590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884457+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22558,7 +22613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884513+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22611,7 +22666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884564+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22790,7 +22845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884686+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22816,7 +22871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884733+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22843,7 +22898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884772+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22856,7 +22911,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308440+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292829+00:00"
           },
           "hostname": {
             "type": "string",
@@ -22888,7 +22943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.884814+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543515+00:00"
               },
               "deterministic": true
             },
@@ -22918,7 +22973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884862+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22981,7 +23036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884913+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23021,7 +23076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.884963+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543583+00:00"
               },
               "deterministic": true
             },
@@ -23048,7 +23103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.884997+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23109,7 +23164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885042+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23135,7 +23190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885089+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23162,7 +23217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885131+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23189,7 +23244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885181+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23258,7 +23313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:31.885235+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23321,7 +23376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:31.885296+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23333,7 +23388,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308640+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.292984+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23383,23 +23438,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.885345+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.543768+00:00"
               },
               "deterministic": true
             },
@@ -23412,7 +23467,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308705+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293027+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23427,16 +23482,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.885377+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.543784+00:00"
               },
               "deterministic": true
             },
@@ -23449,7 +23509,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308732+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293046+00:00"
           },
           "object": {
             "$ref": "#/components/schemas/registrationObject"
@@ -23475,7 +23535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885417+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23488,7 +23548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308786+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293086+00:00"
           },
           "uid": {
             "type": "string",
@@ -23505,7 +23565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885446+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23519,7 +23579,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308815+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293111+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of registration is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23576,16 +23636,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.885483+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.543838+00:00"
               },
               "deterministic": true
             },
@@ -23598,7 +23663,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.308844+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293133+00:00"
           },
           "state": {
             "$ref": "#/components/schemas/registrationObjectState"
@@ -23743,7 +23808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885539+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23798,7 +23863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885611+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23892,7 +23957,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.885735+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23932,7 +23997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.885825+00:00"
+                "validatedAt": "2026-05-05T18:46:38.543999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23966,7 +24031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.885913+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24137,7 +24202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.885965+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24215,7 +24280,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.886045+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24249,7 +24314,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.886119+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24273,16 +24338,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.886152+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.544164+00:00"
               },
               "deterministic": true
             },
@@ -24295,7 +24365,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.309112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293323+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -24377,7 +24447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.886683+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544415+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24393,7 +24463,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.309475+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293574+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24449,23 +24519,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.886722+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.544434+00:00"
               },
               "deterministic": true
             },
@@ -24478,7 +24548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.309522+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293609+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24495,16 +24565,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.886752+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.544449+00:00"
               },
               "deterministic": true
             },
@@ -24517,7 +24592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.309551+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293640+00:00"
           },
           "uid": {
             "type": "string",
@@ -24536,7 +24611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.886782+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24551,7 +24626,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.309580+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293661+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -24622,7 +24697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887346+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24650,7 +24725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887392+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24679,7 +24754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887440+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24706,7 +24781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887483+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24735,7 +24810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887531+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24760,7 +24835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887581+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24825,7 +24900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887652+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24863,7 +24938,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.887707+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24875,7 +24950,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.309958+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293935+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -24916,7 +24991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887762+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24960,7 +25035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887804+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24974,7 +25049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310018+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.293978+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -24993,7 +25068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887848+00:00"
+                "validatedAt": "2026-05-05T18:46:38.544990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25020,7 +25095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887876+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25035,7 +25110,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310054+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294005+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -25050,7 +25125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.887916+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25146,7 +25221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:17:31.888095+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25209,7 +25284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:17:31.888143+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25322,7 +25397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:17:31.888225+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25402,7 +25477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888282+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25453,7 +25528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:31.888316+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25502,7 +25577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:31.888384+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25514,7 +25589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310389+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294241+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -25532,7 +25607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888427+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25591,7 +25666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.888665+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545404+00:00"
               },
               "deterministic": true
             },
@@ -25618,7 +25693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888703+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25644,7 +25719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888745+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25656,7 +25731,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310538+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294351+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25696,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888789+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25720,23 +25795,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.888822+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.545476+00:00"
               },
               "deterministic": true
             },
@@ -25749,7 +25824,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310577+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294377+00:00"
           },
           "serial": {
             "type": "string",
@@ -25767,7 +25842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888859+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25793,7 +25868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888897+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25819,7 +25894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888936+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25831,7 +25906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310619+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294414+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25873,7 +25948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.888981+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25899,7 +25974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889019+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25941,7 +26016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889066+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25967,7 +26042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889106+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25979,7 +26054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310682+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294464+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26065,7 +26140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889173+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26120,7 +26195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889231+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26171,7 +26246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889277+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26196,7 +26271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889335+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26259,7 +26334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889378+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26284,7 +26359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889420+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26309,7 +26384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889464+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26356,7 +26431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889512+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26381,7 +26456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889551+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26406,7 +26481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889590+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26418,7 +26493,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310852+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294578+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26540,7 +26615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889649+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26587,7 +26662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889688+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26639,7 +26714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.889747+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545923+00:00"
               },
               "deterministic": true
             },
@@ -26663,23 +26738,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.889779+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.545938+00:00"
               },
               "deterministic": true
             },
@@ -26692,7 +26767,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.310957+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294656+00:00"
           },
           "port": {
             "type": "string",
@@ -26711,7 +26786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889814+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26778,7 +26853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889871+00:00"
+                "validatedAt": "2026-05-05T18:46:38.545982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26801,23 +26876,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.889903+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.545998+00:00"
               },
               "deterministic": true
             },
@@ -26830,7 +26905,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.311014+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294692+00:00"
           },
           "release": {
             "type": "string",
@@ -26847,7 +26922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889941+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26872,7 +26947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.889979+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26897,7 +26972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890018+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26909,7 +26984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.311059+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294722+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26974,7 +27049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:31.890061+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27007,7 +27082,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.890119+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27099,23 +27174,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.890179+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.546131+00:00"
               },
               "deterministic": true
             },
@@ -27128,7 +27203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.311202+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294845+00:00"
           },
           "serial": {
             "type": "string",
@@ -27147,7 +27222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890217+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27172,7 +27247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890256+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27198,7 +27273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890294+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27210,7 +27285,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.311248+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294882+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27295,7 +27370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890387+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27320,7 +27395,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890425+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27343,23 +27418,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:31.890459+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:38.546245+00:00"
               },
               "deterministic": true
             },
@@ -27372,7 +27447,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.311294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.294916+00:00"
           },
           "serial": {
             "type": "string",
@@ -27389,7 +27464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890499+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27429,7 +27504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890549+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546286+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27495,7 +27570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890623+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27521,7 +27596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890679+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27547,7 +27622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890735+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27587,7 +27662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890800+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27612,7 +27687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890843+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27657,7 +27732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:31.890909+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27669,7 +27744,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.311429+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.295006+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -27686,7 +27761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.890956+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27711,7 +27786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891005+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27737,7 +27812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891052+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27763,7 +27838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891101+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27788,7 +27863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891147+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27818,7 +27893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:31.891187+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546593+00:00"
               },
               "deterministic": true
             },
@@ -27845,7 +27920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891238+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27871,7 +27946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891276+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27900,7 +27975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:31.891335+00:00"
+                "validatedAt": "2026-05-05T18:46:38.546669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28060,7 +28135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:04.167131+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28117,23 +28192,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:04.167173+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:58.955304+00:00"
               },
               "deterministic": true
             },
@@ -28146,7 +28221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400425+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348692+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28162,16 +28237,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:04.167206+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:58.955320+00:00"
               },
               "deterministic": true
             },
@@ -28184,7 +28264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400452+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348708+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28287,7 +28367,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400542+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348760+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -28352,7 +28432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:04.167345+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28417,7 +28497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:04.167401+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28480,7 +28560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:04.167462+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28492,7 +28572,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400620+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348806+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -28542,23 +28622,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:04.167501+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:58.955446+00:00"
               },
               "deterministic": true
             },
@@ -28571,7 +28651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400685+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348843+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28586,16 +28666,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:04.167536+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:58.955461+00:00"
               },
               "deterministic": true
             },
@@ -28608,7 +28693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400711+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348859+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -28647,7 +28732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167591+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28660,7 +28745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400762+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348889+00:00"
           },
           "uid": {
             "type": "string",
@@ -28677,7 +28762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167621+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28691,7 +28776,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.400791+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.348905+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of usb_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -28799,7 +28884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:04.167687+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28845,7 +28930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167740+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28871,7 +28956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167789+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28897,7 +28982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167879+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28923,7 +29008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167948+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28949,7 +29034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.167994+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28974,7 +29059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:04.168040+00:00"
+                "validatedAt": "2026-05-05T18:45:58.955662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29113,7 +29198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017158+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29136,7 +29221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017232+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29158,7 +29243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017271+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29170,7 +29255,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532452+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418660+00:00"
           },
           "name": {
             "type": "string",
@@ -29183,23 +29268,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:12.017316+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:02.764224+00:00"
               },
               "deterministic": true
             },
@@ -29212,7 +29297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532482+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418681+00:00"
           }
         },
         "x-f5xc-description-short": "ApplicationObj shows the upgrade status of each object in a application in either site/node level upgrades.",
@@ -29252,7 +29337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017373+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29264,7 +29349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 15,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532512+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418702+00:00"
           },
           "reason": {
             "type": "string",
@@ -29281,7 +29366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017415+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29293,7 +29378,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532537+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418720+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/upgrade_statusChecklistStatus"
@@ -29355,7 +29440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017460+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29376,7 +29461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017500+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29398,7 +29483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017538+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29518,7 +29603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017621+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29565,7 +29650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017664+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29586,23 +29671,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:12.017702+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:02.764391+00:00"
               },
               "deterministic": true
             },
@@ -29615,7 +29700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532673+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418804+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/upgrade_statusStatus"
@@ -29632,7 +29717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017740+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29693,7 +29778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017804+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29736,23 +29821,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:12.017843+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:02.764457+00:00"
               },
               "deterministic": true
             },
@@ -29765,7 +29850,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532747+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418850+00:00"
           },
           "progress": {
             "$ref": "#/components/schemas/upgrade_statusUpgradeProgressCount"
@@ -29820,23 +29905,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:12.017893+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:02.764481+00:00"
               },
               "deterministic": true
             },
@@ -29849,7 +29934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532803+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418882+00:00"
           },
           "results": {
             "type": "array",
@@ -29916,7 +30001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.017968+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29998,7 +30083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.018035+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30030,7 +30115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.018082+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30052,7 +30137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.018117+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30083,7 +30168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.018159+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30095,7 +30180,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.532968+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.418977+00:00"
           }
         },
         "x-f5xc-description-short": "SWStatus stores information about CE Site upgrade status.",
@@ -30157,7 +30242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.018223+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30204,23 +30289,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:12.018259+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:02.764667+00:00"
               },
               "deterministic": true
             },
@@ -30233,7 +30318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.533035+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.419016+00:00"
           },
           "objects": {
             "type": "array",
@@ -30300,23 +30385,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:12.018328+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:02.764694+00:00"
               },
               "deterministic": true
             },
@@ -30329,7 +30414,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.533092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.419048+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/upgrade_statusStatus"
@@ -30457,7 +30542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:12.018418+00:00"
+                "validatedAt": "2026-05-05T18:46:02.764732+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/certificates.json
+++ b/docs/specifications/api/certificates.json
@@ -4811,7 +4811,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.850872+00:00"
+                "validatedAt": "2026-05-05T18:41:01.027802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4867,7 +4867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:06:18.850947+00:00"
+                "validatedAt": "2026-05-05T18:41:01.027852+00:00"
               },
               "deterministic": true
             },
@@ -4929,23 +4929,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.850994+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.027877+00:00"
               },
               "deterministic": true
             },
@@ -4958,7 +4958,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214531+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182631+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4974,16 +4974,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.851029+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.027898+00:00"
               },
               "deterministic": true
             },
@@ -4996,7 +5001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214561+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182648+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -5099,7 +5104,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214652+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182701+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -5185,7 +5190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.851196+00:00"
+                "validatedAt": "2026-05-05T18:41:01.027982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5241,7 +5246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:06:18.851258+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028019+00:00"
               },
               "deterministic": true
             },
@@ -5300,7 +5305,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.851357+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028066+00:00"
               },
               "deterministic": true
             },
@@ -5366,7 +5371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:18.851409+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5428,7 +5433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:18.851473+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5440,7 +5445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214780+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182779+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5489,23 +5494,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.851517+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028149+00:00"
               },
               "deterministic": true
             },
@@ -5518,7 +5523,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214846+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182817+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5533,16 +5538,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.851549+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028166+00:00"
               },
               "deterministic": true
             },
@@ -5555,7 +5565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214872+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182833+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5594,7 +5604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.851608+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5607,7 +5617,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214924+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182864+00:00"
           },
           "uid": {
             "type": "string",
@@ -5624,7 +5634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.851640+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5638,7 +5648,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.214955+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182882+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of CRL is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5767,7 +5777,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.851743+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5823,7 +5833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:06:18.851801+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028294+00:00"
               },
               "deterministic": true
             },
@@ -5924,7 +5934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.851870+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5947,7 +5957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.851909+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5959,7 +5969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215084+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182962+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -6005,7 +6015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.851950+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028367+00:00"
               },
               "deterministic": true
             },
@@ -6031,7 +6041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852000+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6058,7 +6068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852042+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6070,7 +6080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215131+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.182990+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6087,7 +6097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852090+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6120,7 +6130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852134+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6132,7 +6142,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215167+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183011+00:00"
           },
           "type": {
             "type": "string",
@@ -6157,7 +6167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852171+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6245,7 +6255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852214+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6291,23 +6301,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852251+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028508+00:00"
               },
               "deterministic": true
             },
@@ -6320,7 +6330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215233+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183050+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -6438,7 +6448,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.852373+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028564+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6454,7 +6464,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215292+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183084+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6508,23 +6518,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852419+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028585+00:00"
               },
               "deterministic": true
             },
@@ -6537,7 +6547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215347+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183111+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6554,16 +6564,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852451+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028601+00:00"
               },
               "deterministic": true
             },
@@ -6576,7 +6591,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215373+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183127+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6658,7 +6673,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.852542+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028661+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6674,7 +6689,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215414+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183150+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6730,23 +6745,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852584+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028684+00:00"
               },
               "deterministic": true
             },
@@ -6759,7 +6774,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215459+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183177+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6776,16 +6791,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852617+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028701+00:00"
               },
               "deterministic": true
             },
@@ -6798,7 +6818,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215486+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183195+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -6843,7 +6863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852653+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6856,7 +6876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215516+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183213+00:00"
           },
           "name": {
             "type": "string",
@@ -6873,23 +6893,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852685+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028736+00:00"
               },
               "deterministic": true
             },
@@ -6902,7 +6922,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215542+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183229+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6919,16 +6939,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852718+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028754+00:00"
               },
               "deterministic": true
             },
@@ -6941,7 +6966,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215568+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183245+00:00"
           },
           "tenant": {
             "type": "string",
@@ -6960,7 +6985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852757+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6974,7 +6999,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215594+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183260+00:00"
           },
           "uid": {
             "type": "string",
@@ -6993,7 +7018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.852786+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7008,7 +7033,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215621+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183276+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7090,7 +7115,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:18.852878+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028833+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7106,7 +7131,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215662+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183300+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7160,23 +7185,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852919+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028852+00:00"
               },
               "deterministic": true
             },
@@ -7189,7 +7214,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215709+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183327+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7206,16 +7231,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.852949+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.028874+00:00"
               },
               "deterministic": true
             },
@@ -7228,7 +7258,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215736+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183342+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -7273,7 +7303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853001+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7301,7 +7331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853048+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7329,7 +7359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853094+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7358,7 +7388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853140+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7385,7 +7415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853170+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7399,7 +7429,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215809+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183385+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7415,7 +7445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853211+00:00"
+                "validatedAt": "2026-05-05T18:41:01.028999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7524,7 +7554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853265+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7536,7 +7566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215864+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183418+00:00"
           },
           "status": {
             "type": "string",
@@ -7554,7 +7584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853304+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7566,7 +7596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.215890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183433+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7608,7 +7638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853365+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7635,7 +7665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853413+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7662,7 +7692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853458+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7690,7 +7720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853508+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7755,7 +7785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853578+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7804,7 +7834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853633+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7817,7 +7847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.216006+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183503+00:00"
           },
           "uid": {
             "type": "string",
@@ -7836,7 +7866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853665+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7850,7 +7880,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.216034+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183519+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7900,7 +7930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853701+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7912,7 +7942,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.216061+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183536+00:00"
           },
           "name": {
             "type": "string",
@@ -7929,23 +7959,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.853736+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.029263+00:00"
               },
               "deterministic": true
             },
@@ -7958,7 +7988,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.216086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183551+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7975,16 +8005,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:18.853769+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:01.029280+00:00"
               },
               "deterministic": true
             },
@@ -7997,7 +8032,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.216111+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183567+00:00"
           },
           "uid": {
             "type": "string",
@@ -8014,7 +8049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:18.853799+00:00"
+                "validatedAt": "2026-05-05T18:41:01.029295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8028,7 +8063,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.216137+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.183583+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -8150,7 +8185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.865702+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8221,23 +8256,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:37.865763+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:14.617455+00:00"
               },
               "deterministic": true
             },
@@ -8250,7 +8285,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649413+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424130+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8266,16 +8301,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:37.865799+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:14.617472+00:00"
               },
               "deterministic": true
             },
@@ -8288,7 +8328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649444+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424146+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8391,7 +8431,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649533+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424198+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8458,7 +8498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.865953+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8581,7 +8621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:37.866052+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8645,7 +8685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:37.866118+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8657,7 +8697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649680+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424284+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8707,23 +8747,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:37.866159+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:14.617648+00:00"
               },
               "deterministic": true
             },
@@ -8736,7 +8776,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649744+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424321+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8751,16 +8791,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:37.866192+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:14.617664+00:00"
               },
               "deterministic": true
             },
@@ -8773,7 +8818,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649770+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424337+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8812,7 +8857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866248+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8825,7 +8870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649821+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424368+00:00"
           },
           "uid": {
             "type": "string",
@@ -8842,7 +8887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866279+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8856,7 +8901,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649849+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424384+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certificate is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8967,7 +9012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.866381+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9101,7 +9146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866452+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9114,7 +9159,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.649978+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424461+00:00"
           },
           "name": {
             "type": "string",
@@ -9131,23 +9176,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:37.866487+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:14.617797+00:00"
               },
               "deterministic": true
             },
@@ -9160,7 +9205,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.650005+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424476+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9177,16 +9222,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:37.866519+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:14.617814+00:00"
               },
               "deterministic": true
             },
@@ -9199,7 +9249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.650033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424492+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9218,7 +9268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866559+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9232,7 +9282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.650059+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424508+00:00"
           },
           "uid": {
             "type": "string",
@@ -9251,7 +9301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866588+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9266,7 +9316,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.650087+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424524+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9312,7 +9362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866729+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9350,7 +9400,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.866800+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9362,7 +9412,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.650164+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424569+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -9381,7 +9431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866850+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617969+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9428,7 +9478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866898+00:00"
+                "validatedAt": "2026-05-05T18:41:14.617990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9453,7 +9503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866938+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9476,7 +9526,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.866978+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9499,7 +9549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.867024+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9523,7 +9573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.867079+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9593,7 +9643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:37.867139+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9605,7 +9655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.650255+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.424630+00:00"
           },
           "url": {
             "type": "string",
@@ -9643,7 +9693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.867212+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618136+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9737,7 +9787,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.867590+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9845,23 +9895,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.869061+00:00"
+                "validatedAt": "2026-05-05T18:41:14.618991+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9877,7 +9927,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.651253+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.425206+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9900,16 +9950,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.869121+00:00"
+                "validatedAt": "2026-05-05T18:41:14.619022+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -9925,7 +9980,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.651278+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.425221+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9954,7 +10009,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:37.869187+00:00"
+                "validatedAt": "2026-05-05T18:41:14.619056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9968,7 +10023,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.651305+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.425237+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -10086,7 +10141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:41.575220+00:00"
+                "validatedAt": "2026-05-05T18:41:16.430320+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10146,23 +10201,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:41.575279+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:16.430346+00:00"
               },
               "deterministic": true
             },
@@ -10175,7 +10230,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.450788+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10191,16 +10246,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:41.575314+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:16.430363+00:00"
               },
               "deterministic": true
             },
@@ -10213,7 +10273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698589+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.450805+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10316,7 +10376,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698676+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.450861+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -10379,7 +10439,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:41.575492+00:00"
+                "validatedAt": "2026-05-05T18:41:16.430433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10461,7 +10521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:41.575558+00:00"
+                "validatedAt": "2026-05-05T18:41:16.430463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10525,7 +10585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:41.575623+00:00"
+                "validatedAt": "2026-05-05T18:41:16.430494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10537,7 +10597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698764+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.450971+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10587,23 +10647,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:41.575664+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:16.430512+00:00"
               },
               "deterministic": true
             },
@@ -10616,7 +10676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698830+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.451012+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10631,16 +10691,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:41.575697+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:16.430528+00:00"
               },
               "deterministic": true
             },
@@ -10653,7 +10718,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698856+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.451028+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10692,7 +10757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:41.575753+00:00"
+                "validatedAt": "2026-05-05T18:41:16.430552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10705,7 +10770,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698908+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.451060+00:00"
           },
           "uid": {
             "type": "string",
@@ -10723,7 +10788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:41.575786+00:00"
+                "validatedAt": "2026-05-05T18:41:16.430567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10737,7 +10802,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.698936+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.451077+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certificate_chain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10965,7 +11030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:22.374565+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11023,23 +11088,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:22.374601+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.921297+00:00"
               },
               "deterministic": true
             },
@@ -11052,7 +11117,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120225+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039075+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11068,16 +11133,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:22.374633+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.921313+00:00"
               },
               "deterministic": true
             },
@@ -11090,7 +11160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120252+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039091+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11193,7 +11263,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120348+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039145+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -11265,7 +11335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:22.374781+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11332,7 +11402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:22.374832+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11395,7 +11465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:22.374893+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11407,7 +11477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120434+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039202+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11457,23 +11527,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:22.374931+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.921451+00:00"
               },
               "deterministic": true
             },
@@ -11486,7 +11556,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120496+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039239+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11501,16 +11571,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:22.374962+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:33.921466+00:00"
               },
               "deterministic": true
             },
@@ -11523,7 +11598,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120522+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039255+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -11562,7 +11637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:22.375015+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11575,7 +11650,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120577+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039285+00:00"
           },
           "uid": {
             "type": "string",
@@ -11592,7 +11667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:22.375044+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11606,7 +11681,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.120606+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.039301+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of trusted_ca_list is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11706,7 +11781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:22.375127+00:00"
+                "validatedAt": "2026-05-05T18:46:33.921544+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/cloud_infrastructure.json
+++ b/docs/specifications/api/cloud_infrastructure.json
@@ -7990,7 +7990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268487+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8015,7 +8015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268552+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8084,7 +8084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268602+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8129,7 +8129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268654+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8220,23 +8220,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.268748+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.059577+00:00"
               },
               "deterministic": true
             },
@@ -8249,7 +8249,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.743776+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475397+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/certified_hardwareHardwareDeviceType"
@@ -8317,7 +8317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268799+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8421,7 +8421,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.743893+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475462+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8550,7 +8550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268902+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8574,7 +8574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.268943+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8629,23 +8629,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.268984+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.059743+00:00"
               },
               "deterministic": true
             },
@@ -8658,7 +8658,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.743980+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475512+00:00"
           },
           "provider": {
             "type": "string",
@@ -8676,7 +8676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269027+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8688,7 +8688,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744009+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475528+00:00"
           }
         },
         "x-f5xc-description-short": "Describes the image to be used for this certified hardware.",
@@ -8750,7 +8750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:45.269080+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8813,7 +8813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:45.269145+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059830+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8825,7 +8825,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744072+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475563+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8875,23 +8875,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.269186+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.059849+00:00"
               },
               "deterministic": true
             },
@@ -8904,7 +8904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744136+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475599+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8919,16 +8919,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.269218+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.059867+00:00"
               },
               "deterministic": true
             },
@@ -8941,7 +8946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744163+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475621+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8980,7 +8985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269271+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8993,7 +8998,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744215+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475653+00:00"
           },
           "uid": {
             "type": "string",
@@ -9011,7 +9016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269301+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9025,7 +9030,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744243+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475669+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of certified_hardware is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9073,23 +9078,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.269347+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.059925+00:00"
               },
               "deterministic": true
             },
@@ -9102,7 +9107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744272+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475687+00:00"
           },
           "offer": {
             "type": "string",
@@ -9117,7 +9122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269385+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9140,7 +9145,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269430+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9163,7 +9168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269460+00:00"
+                "validatedAt": "2026-05-05T18:41:19.059981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9187,7 +9192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269501+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9199,7 +9204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744334+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475718+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9381,7 +9386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269590+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9394,7 +9399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744419+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475768+00:00"
           },
           "name": {
             "type": "string",
@@ -9411,23 +9416,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.269626+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060061+00:00"
               },
               "deterministic": true
             },
@@ -9440,7 +9445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744448+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475783+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9457,16 +9462,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.269658+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060083+00:00"
               },
               "deterministic": true
             },
@@ -9479,7 +9489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744476+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475799+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9498,7 +9508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269696+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9512,7 +9522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744501+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475815+00:00"
           },
           "uid": {
             "type": "string",
@@ -9531,7 +9541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269728+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9546,7 +9556,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744531+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475831+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9584,7 +9594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269771+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9607,7 +9617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269808+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9619,7 +9629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744570+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475854+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -9665,7 +9675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.269847+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060187+00:00"
               },
               "deterministic": true
             },
@@ -9691,7 +9701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269895+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9718,7 +9728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269935+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9730,7 +9740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744618+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475880+00:00"
           },
           "service_name": {
             "type": "string",
@@ -9747,7 +9757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.269981+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9780,7 +9790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270030+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9792,7 +9802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744654+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475901+00:00"
           },
           "type": {
             "type": "string",
@@ -9817,7 +9827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270069+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9905,7 +9915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270111+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9951,23 +9961,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.270146+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060348+00:00"
               },
               "deterministic": true
             },
@@ -9980,7 +9990,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744724+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475944+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -10099,7 +10109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:45.270260+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060410+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10115,7 +10125,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744784+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.475979+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10171,23 +10181,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.270302+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060433+00:00"
               },
               "deterministic": true
             },
@@ -10200,7 +10210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744832+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476006+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10217,16 +10227,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.270343+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060450+00:00"
               },
               "deterministic": true
             },
@@ -10239,7 +10254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744857+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476022+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -10284,7 +10299,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270394+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10312,7 +10327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270441+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10340,7 +10355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270487+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10369,7 +10384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270531+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10396,7 +10411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270562+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10410,7 +10425,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744930+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476065+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -10426,7 +10441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270601+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10535,7 +10550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270655+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10547,7 +10562,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.744986+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476097+00:00"
           },
           "status": {
             "type": "string",
@@ -10565,7 +10580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270695+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10577,7 +10592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745011+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476113+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -10619,7 +10634,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270747+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10646,7 +10661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270795+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10673,7 +10688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270839+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10701,7 +10716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270888+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10766,7 +10781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.270955+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10815,7 +10830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271010+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10828,7 +10843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745125+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476181+00:00"
           },
           "uid": {
             "type": "string",
@@ -10847,7 +10862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271042+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10861,7 +10876,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745152+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476197+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -10911,7 +10926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271079+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10923,7 +10938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745179+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476214+00:00"
           },
           "name": {
             "type": "string",
@@ -10940,23 +10955,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.271110+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060924+00:00"
               },
               "deterministic": true
             },
@@ -10969,7 +10984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745204+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476229+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10986,16 +11001,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:45.271140+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:19.060942+00:00"
               },
               "deterministic": true
             },
@@ -11008,7 +11028,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476245+00:00"
           },
           "uid": {
             "type": "string",
@@ -11025,7 +11045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271170+00:00"
+                "validatedAt": "2026-05-05T18:41:19.060962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11039,7 +11059,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.745257+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.476261+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -11222,7 +11242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271314+00:00"
+                "validatedAt": "2026-05-05T18:41:19.061032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11248,7 +11268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271373+00:00"
+                "validatedAt": "2026-05-05T18:41:19.061055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11274,7 +11294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271424+00:00"
+                "validatedAt": "2026-05-05T18:41:19.061079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11300,7 +11320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271464+00:00"
+                "validatedAt": "2026-05-05T18:41:19.061100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11326,7 +11346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271507+00:00"
+                "validatedAt": "2026-05-05T18:41:19.061122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11351,7 +11371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:45.271551+00:00"
+                "validatedAt": "2026-05-05T18:41:19.061149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11424,7 +11444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.433216+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11458,7 +11478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.433307+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11503,7 +11523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433417+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11528,7 +11548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433501+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11553,7 +11573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433567+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11578,7 +11598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433619+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11643,7 +11663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433690+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11668,7 +11688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433744+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11691,7 +11711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433787+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11717,7 +11737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433831+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11742,7 +11762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433874+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11765,7 +11785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433922+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11822,7 +11842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.433980+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11847,7 +11867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434031+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11875,7 +11895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434081+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11913,7 +11933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434135+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11959,7 +11979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434190+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11982,7 +12002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434248+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12007,7 +12027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434306+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12030,7 +12050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434374+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12054,7 +12074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434428+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12109,7 +12129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434482+00:00"
+                "validatedAt": "2026-05-05T18:41:36.305987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12136,7 +12156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434531+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12162,7 +12182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434583+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12184,23 +12204,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.434626+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.306053+00:00"
               },
               "deterministic": true
             },
@@ -12213,7 +12233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.545113+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.908747+00:00"
           },
           "tags": {
             "type": "object",
@@ -12292,7 +12312,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.434695+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12356,7 +12376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.434763+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12411,7 +12431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.434867+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12459,7 +12479,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.434925+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12503,7 +12523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.434972+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12529,7 +12549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435022+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12554,7 +12574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:21.435072+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12578,7 +12598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435121+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12646,7 +12666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435189+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12710,7 +12730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435258+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12734,7 +12754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435317+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12759,7 +12779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435388+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12866,7 +12886,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.435464+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12950,7 +12970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.435557+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13035,7 +13055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435624+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13058,7 +13078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435679+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13082,7 +13102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435730+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306558+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13105,7 +13125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435784+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13131,7 +13151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435834+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13154,7 +13174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435886+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13177,7 +13197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435937+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13200,7 +13220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.435989+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13224,7 +13244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.436037+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13287,7 +13307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.436108+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13311,7 +13331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.436154+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13408,7 +13428,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436257+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13456,7 +13476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436317+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13521,7 +13541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436385+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13580,7 +13600,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436441+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13660,7 +13680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436528+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13696,7 +13716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436598+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13781,7 +13801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.436656+00:00"
+                "validatedAt": "2026-05-05T18:41:36.306997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13824,7 +13844,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.436709+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13847,7 +13867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.436757+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13871,7 +13891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.436802+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13921,7 +13941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:07:21.436845+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307082+00:00"
               },
               "deterministic": true
             },
@@ -14318,23 +14338,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.436947+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.307127+00:00"
               },
               "deterministic": true
             },
@@ -14347,7 +14367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.545894+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909201+00:00"
           }
         },
         "x-f5xc-description-short": "Customer Edge uniquely identifies customer edge i.e. Site.",
@@ -14425,23 +14445,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.436986+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.307145+00:00"
               },
               "deterministic": true
             },
@@ -14454,7 +14474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.545950+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909236+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14470,16 +14490,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.437018+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.307161+00:00"
               },
               "deterministic": true
             },
@@ -14492,7 +14517,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.545978+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909253+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14539,7 +14564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437061+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14629,7 +14654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437125+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14652,7 +14677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437166+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14677,7 +14702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437208+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14810,7 +14835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437280+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14877,7 +14902,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546179+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909377+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -14951,7 +14976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437350+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14987,7 +15012,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.437402+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15032,23 +15057,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.437442+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.307348+00:00"
               },
               "deterministic": true
             },
@@ -15061,7 +15086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546237+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909410+00:00"
           },
           "start_time": {
             "type": "string",
@@ -15086,7 +15111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437491+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15119,7 +15144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437528+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15194,7 +15219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437577+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15304,7 +15329,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546388+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909483+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15358,7 +15383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437678+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15370,7 +15395,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546445+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909514+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the cloud connect are tagged with labels listed in the enum Label.",
@@ -15419,7 +15444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437726+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15455,7 +15480,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.437784+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15490,7 +15515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.437840+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15523,7 +15548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437889+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15596,7 +15621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.437940+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15664,7 +15689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:21.437993+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15727,7 +15752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:21.438050+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15739,7 +15764,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546559+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909582+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15789,23 +15814,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.438090+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.307652+00:00"
               },
               "deterministic": true
             },
@@ -15818,7 +15843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546621+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909624+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15833,16 +15858,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.438122+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.307667+00:00"
               },
               "deterministic": true
             },
@@ -15855,7 +15885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546648+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909639+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15894,7 +15924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438175+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15907,7 +15937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546703+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909670+00:00"
           },
           "uid": {
             "type": "string",
@@ -15924,7 +15954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438204+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15938,7 +15968,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.546733+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909686+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_connect is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -15997,7 +16027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438250+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16033,7 +16063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.438305+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16083,7 +16113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.438374+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16116,7 +16146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438422+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16149,7 +16179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438460+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16237,7 +16267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438520+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16330,7 +16360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438589+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16358,7 +16388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438632+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16381,7 +16411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438679+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16434,7 +16464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438722+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16712,7 +16742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438821+00:00"
+                "validatedAt": "2026-05-05T18:41:36.307988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16735,7 +16765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438870+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16758,7 +16788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438921+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308033+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16782,7 +16812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.438974+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16806,7 +16836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.439016+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16818,7 +16848,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547069+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909887+00:00"
           },
           "subnet_id": {
             "type": "string",
@@ -16833,7 +16863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.439059+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308095+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16932,7 +16962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.439117+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16968,7 +16998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.439173+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16995,7 +17025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.439213+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17034,7 +17064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:07:21.439261+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17067,7 +17097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.439307+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17140,7 +17170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.439367+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17211,23 +17241,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.439406+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.308253+00:00"
               },
               "deterministic": true
             },
@@ -17240,7 +17270,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547201+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.909964+00:00"
           },
           "site": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -17337,7 +17367,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.440119+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17391,7 +17421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.440185+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17477,7 +17507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.440241+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17489,7 +17519,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547655+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910228+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -17567,7 +17597,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.440349+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308694+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17583,7 +17613,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547693+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910251+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17637,23 +17667,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.440394+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.308715+00:00"
               },
               "deterministic": true
             },
@@ -17666,7 +17696,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547738+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910278+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17683,16 +17713,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.440428+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.308732+00:00"
               },
               "deterministic": true
             },
@@ -17705,7 +17740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547765+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910293+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -17787,7 +17822,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.440694+00:00"
+                "validatedAt": "2026-05-05T18:41:36.308856+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17803,7 +17838,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547918+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910381+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17857,23 +17892,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.440735+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.308876+00:00"
               },
               "deterministic": true
             },
@@ -17886,7 +17921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547965+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910407+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17903,16 +17938,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:21.440767+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:36.308891+00:00"
               },
               "deterministic": true
             },
@@ -17925,7 +17965,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.547992+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910423+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -17996,7 +18036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:21.441570+00:00"
+                "validatedAt": "2026-05-05T18:41:36.309243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18008,7 +18048,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.548314+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910618+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -18026,7 +18066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.441617+00:00"
+                "validatedAt": "2026-05-05T18:41:36.309264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18054,7 +18094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:21.441656+00:00"
+                "validatedAt": "2026-05-05T18:41:36.309282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18066,7 +18106,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.548368+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910644+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -18290,23 +18330,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.441870+00:00"
+                "validatedAt": "2026-05-05T18:41:36.309385+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18322,7 +18362,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.548585+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910773+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18345,16 +18385,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.441935+00:00"
+                "validatedAt": "2026-05-05T18:41:36.309417+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -18370,7 +18415,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.548614+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910789+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18399,7 +18444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:21.442000+00:00"
+                "validatedAt": "2026-05-05T18:41:36.309452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18413,7 +18458,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.548639+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.910804+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -18515,7 +18560,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.677951+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18593,7 +18638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678153+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18637,7 +18682,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678252+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18726,7 +18771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678350+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18792,7 +18837,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678436+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18828,7 +18873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678516+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18868,7 +18913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678596+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18905,7 +18950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678672+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18968,7 +19013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678747+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19008,7 +19053,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678822+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19045,7 +19090,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.678893+00:00"
+                "validatedAt": "2026-05-05T18:41:38.421885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19201,23 +19246,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:25.678949+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:38.421928+00:00"
               },
               "deterministic": true
             },
@@ -19230,7 +19275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.654670+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968367+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19246,16 +19291,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:25.678983+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:38.421952+00:00"
               },
               "deterministic": true
             },
@@ -19268,7 +19318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.654699+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968384+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19394,7 +19444,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.654800+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968443+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19502,7 +19552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:25.679107+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19565,7 +19615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:25.679166+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19577,7 +19627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.654912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968508+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19627,23 +19677,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:25.679204+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:38.422145+00:00"
               },
               "deterministic": true
             },
@@ -19656,7 +19706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.654975+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968546+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19671,16 +19721,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:25.679236+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:38.422163+00:00"
               },
               "deterministic": true
             },
@@ -19693,7 +19748,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655000+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968562+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19732,7 +19787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.679292+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19745,7 +19800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655054+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968593+00:00"
           },
           "uid": {
             "type": "string",
@@ -19763,7 +19818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.679332+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19777,7 +19832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655083+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968609+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_credentials is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19968,7 +20023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.679505+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20006,7 +20061,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.679574+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20018,7 +20073,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968717+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -20037,7 +20092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.679623+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20088,7 +20143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.679665+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422606+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20100,7 +20155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655291+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968740+00:00"
           },
           "url": {
             "type": "string",
@@ -20138,7 +20193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:25.679741+00:00"
+                "validatedAt": "2026-05-05T18:41:38.422671+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20191,7 +20246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.680471+00:00"
+                "validatedAt": "2026-05-05T18:41:38.423125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20204,7 +20259,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655719+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.968996+00:00"
           },
           "name": {
             "type": "string",
@@ -20221,23 +20276,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:25.680505+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:38.423149+00:00"
               },
               "deterministic": true
             },
@@ -20250,7 +20305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655745+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.969012+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20267,16 +20322,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:25.680536+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:38.423169+00:00"
               },
               "deterministic": true
             },
@@ -20289,7 +20349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655769+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.969027+00:00"
           },
           "tenant": {
             "type": "string",
@@ -20308,7 +20368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.680574+00:00"
+                "validatedAt": "2026-05-05T18:41:38.423193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20322,7 +20382,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655795+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.969043+00:00"
           },
           "uid": {
             "type": "string",
@@ -20341,7 +20401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:25.680604+00:00"
+                "validatedAt": "2026-05-05T18:41:38.423216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20356,7 +20416,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.655821+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.969059+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -20514,7 +20574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:29.802341+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20550,7 +20610,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:29.802418+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20609,23 +20669,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:29.802468+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:41.279473+00:00"
               },
               "deterministic": true
             },
@@ -20638,7 +20698,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.727859+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.016904+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20654,16 +20714,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:29.802504+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:41.279490+00:00"
               },
               "deterministic": true
             },
@@ -20676,7 +20741,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.727888+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.016927+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20716,7 +20781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:29.802538+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20739,7 +20804,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:29.802592+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20762,7 +20827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:29.802637+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20774,7 +20839,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.727935+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.016971+00:00"
           },
           "public_ip_address": {
             "type": "string",
@@ -20789,7 +20854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:29.802689+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20850,23 +20915,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:29.802745+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:41.279600+00:00"
               },
               "deterministic": true
             },
@@ -20879,7 +20944,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.727981+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017015+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20916,23 +20981,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:29.802782+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:41.279626+00:00"
               },
               "deterministic": true
             },
@@ -20945,7 +21010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728010+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017044+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21062,7 +21127,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728100+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017121+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -21120,7 +21185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:29.802891+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21156,7 +21221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:29.802950+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21223,7 +21288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:29.803003+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21286,7 +21351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:29.803066+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21298,7 +21363,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017196+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21348,23 +21413,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:29.803105+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:41.279774+00:00"
               },
               "deterministic": true
             },
@@ -21377,7 +21442,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728257+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017248+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21392,16 +21457,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:29.803137+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:41.279790+00:00"
               },
               "deterministic": true
             },
@@ -21414,7 +21484,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728283+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017270+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21453,7 +21523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:29.803190+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21466,7 +21536,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728344+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017305+00:00"
           },
           "uid": {
             "type": "string",
@@ -21484,7 +21554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:29.803221+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21498,7 +21568,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.728373+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.017332+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_elastic_ip is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21599,7 +21669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:29.803271+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21635,7 +21705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:29.803336+00:00"
+                "validatedAt": "2026-05-05T18:41:41.279890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21789,7 +21859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.186472+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21812,7 +21882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.186522+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21852,7 +21922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.186591+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21876,7 +21946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.186643+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21900,7 +21970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.186683+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21912,7 +21982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.789559+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.056097+00:00"
           },
           "tags": {
             "type": "object",
@@ -21940,7 +22010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.186737+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21993,7 +22063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.187057+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22017,7 +22087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:34.187098+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391767+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22056,7 +22126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.187137+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22079,7 +22149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.187183+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22102,7 +22172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.187224+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22125,7 +22195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.187263+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22148,7 +22218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:34.187308+00:00"
+                "validatedAt": "2026-05-05T18:41:43.391869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22323,7 +22393,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.867255+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.106810+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22418,7 +22488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:36.271807+00:00"
+                "validatedAt": "2026-05-05T18:41:44.383233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22481,7 +22551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:36.271884+00:00"
+                "validatedAt": "2026-05-05T18:41:44.383267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22493,7 +22563,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.867358+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.106865+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22543,23 +22613,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:36.271927+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:44.383287+00:00"
               },
               "deterministic": true
             },
@@ -22572,7 +22642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.867427+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.106904+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22587,16 +22657,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:36.271961+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:44.383304+00:00"
               },
               "deterministic": true
             },
@@ -22609,7 +22684,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.867454+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.106920+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22648,7 +22723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:36.272016+00:00"
+                "validatedAt": "2026-05-05T18:41:44.383329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22661,7 +22736,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.867507+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.106951+00:00"
           },
           "uid": {
             "type": "string",
@@ -22678,7 +22753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:36.272048+00:00"
+                "validatedAt": "2026-05-05T18:41:44.383344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22692,7 +22767,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.867536+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.106968+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_region is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22885,7 +22960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.868750+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655554+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22977,7 +23052,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.868893+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23019,7 +23094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.868941+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23084,7 +23159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.869028+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23196,7 +23271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869113+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655743+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23221,7 +23296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869163+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23345,7 +23420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869238+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23382,7 +23457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869296+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23412,7 +23487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869364+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655856+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23441,7 +23516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869415+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23465,7 +23540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869471+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23489,7 +23564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869523+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23634,23 +23709,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.869578+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.655949+00:00"
               },
               "deterministic": true
             },
@@ -23663,7 +23738,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.967563+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.172524+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23679,16 +23754,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.869615+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.655967+00:00"
               },
               "deterministic": true
             },
@@ -23701,7 +23781,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.967592+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.172541+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23739,7 +23819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869659+00:00"
+                "validatedAt": "2026-05-05T18:41:46.655987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23762,7 +23842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869704+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23786,7 +23866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869753+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23811,7 +23891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869802+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23841,7 +23921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869854+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23874,7 +23954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869911+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23911,7 +23991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.869956+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23923,7 +24003,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.967694+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.172600+00:00"
           },
           "owner_account": {
             "type": "string",
@@ -23939,7 +24019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870005+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23964,7 +24044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870053+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23989,7 +24069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870101+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24013,7 +24093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870140+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24110,7 +24190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870203+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656231+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24134,7 +24214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870245+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24157,7 +24237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870301+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24182,7 +24262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870370+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24212,7 +24292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870430+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24236,7 +24316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870479+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24260,7 +24340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870531+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24330,7 +24410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.870599+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24390,7 +24470,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.870690+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24428,7 +24508,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.870765+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24465,7 +24545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870809+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24536,7 +24616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870866+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24560,7 +24640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870916+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24584,7 +24664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.870961+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24624,7 +24704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871023+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24648,7 +24728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871074+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24693,7 +24773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871144+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24717,7 +24797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871186+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24741,7 +24821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871233+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24799,23 +24879,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.871287+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.656716+00:00"
               },
               "deterministic": true
             },
@@ -24828,7 +24908,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.172809+00:00"
           },
           "operational_status": {
             "type": "string",
@@ -24844,7 +24924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871347+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24885,7 +24965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871402+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24910,7 +24990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871441+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24934,7 +25014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871481+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24958,7 +25038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871526+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24991,7 +25071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871564+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25038,7 +25118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871623+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25107,7 +25187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871672+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25130,23 +25210,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.871708+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.656906+00:00"
               },
               "deterministic": true
             },
@@ -25159,7 +25239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968143+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.172883+00:00"
           },
           "portal_url": {
             "type": "string",
@@ -25176,7 +25256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871752+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25357,7 +25437,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968273+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.172963+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -25419,7 +25499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871896+00:00"
+                "validatedAt": "2026-05-05T18:41:46.656985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25458,7 +25538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.871952+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25525,7 +25605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:07:40.872002+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25588,7 +25668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:07:40.872064+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25600,7 +25680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173015+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -25650,23 +25730,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.872104+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.657079+00:00"
               },
               "deterministic": true
             },
@@ -25679,7 +25759,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968435+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173052+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25694,16 +25774,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.872136+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.657095+00:00"
               },
               "deterministic": true
             },
@@ -25716,7 +25801,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968463+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173067+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -25755,7 +25840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872191+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25768,7 +25853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173098+00:00"
           },
           "uid": {
             "type": "string",
@@ -25785,7 +25870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872221+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25799,7 +25884,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968540+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173114+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cloud_link is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25848,23 +25933,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:07:40.872258+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:46.657149+00:00"
               },
               "deterministic": true
             },
@@ -25877,7 +25962,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968568+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173131+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26046,7 +26131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872356+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26070,7 +26155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872406+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26096,7 +26181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872452+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26120,7 +26205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872508+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26144,7 +26229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872551+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26198,7 +26283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872624+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26228,7 +26313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872686+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26251,7 +26336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872740+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26276,7 +26361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872796+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26314,7 +26399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872841+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26326,7 +26411,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.968770+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173256+00:00"
           },
           "mtu": {
             "type": "integer",
@@ -26356,7 +26441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872898+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26381,7 +26466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872938+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26420,7 +26505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.872992+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26445,7 +26530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.873048+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26474,7 +26559,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.873104+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26503,7 +26588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:40.873159+00:00"
+                "validatedAt": "2026-05-05T18:41:46.657556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26643,7 +26728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.874141+00:00"
+                "validatedAt": "2026-05-05T18:41:46.658039+00:00"
               },
               "deterministic": true
             },
@@ -26656,7 +26741,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.969299+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173569+00:00"
           },
           "name": {
             "type": "string",
@@ -26684,23 +26769,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.874198+00:00"
+                "validatedAt": "2026-05-05T18:41:46.658070+00:00"
               },
               "deterministic": true
             },
@@ -26712,7 +26797,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.969333+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.173585+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -26812,7 +26897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.875605+00:00"
+                "validatedAt": "2026-05-05T18:41:46.658714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26918,7 +27003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:07:40.875909+00:00"
+                "validatedAt": "2026-05-05T18:41:46.658865+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/container_services.json
+++ b/docs/specifications/api/container_services.json
@@ -3834,7 +3834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105164+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3847,7 +3847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976491+00:00"
           },
           "name": {
             "type": "string",
@@ -3864,23 +3864,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.105234+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448357+00:00"
               },
               "deterministic": true
             },
@@ -3893,7 +3893,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384065+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976508+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3910,16 +3910,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.105273+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448376+00:00"
               },
               "deterministic": true
             },
@@ -3932,7 +3937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384093+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976524+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3951,7 +3956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105316+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3965,7 +3970,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384121+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976540+00:00"
           },
           "uid": {
             "type": "string",
@@ -3984,7 +3989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105365+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3999,7 +4004,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384151+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976557+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -4037,7 +4042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105413+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4060,7 +4065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105454+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4072,7 +4077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976580+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4118,7 +4123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.105498+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448468+00:00"
               },
               "deterministic": true
             },
@@ -4144,7 +4149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105548+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4171,7 +4176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105591+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4183,7 +4188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976607+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4200,7 +4205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105638+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4233,7 +4238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105691+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4245,7 +4250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384280+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976635+00:00"
           },
           "type": {
             "type": "string",
@@ -4270,7 +4275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105730+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4358,7 +4363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105775+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448590+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4404,23 +4409,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.105815+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448608+00:00"
               },
               "deterministic": true
             },
@@ -4433,7 +4438,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384357+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976674+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4531,7 +4536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.105892+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4543,7 +4548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384425+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976712+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -4621,7 +4626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.105999+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448700+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4637,7 +4642,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384464+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976735+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4691,23 +4696,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.106046+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448721+00:00"
               },
               "deterministic": true
             },
@@ -4720,7 +4725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384511+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976762+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4737,16 +4742,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.106079+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448737+00:00"
               },
               "deterministic": true
             },
@@ -4759,7 +4769,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384538+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976778+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -4841,7 +4851,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.106169+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448784+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4857,7 +4867,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384576+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976801+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4913,23 +4923,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.106212+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448805+00:00"
               },
               "deterministic": true
             },
@@ -4942,7 +4952,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384621+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976828+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4959,16 +4969,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.106243+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448820+00:00"
               },
               "deterministic": true
             },
@@ -4981,7 +4996,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384649+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976843+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5063,7 +5078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.106346+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448865+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5079,7 +5094,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384686+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976866+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5133,23 +5148,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.106388+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448884+00:00"
               },
               "deterministic": true
             },
@@ -5162,7 +5177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384730+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976893+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5179,16 +5194,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.106421+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.448900+00:00"
               },
               "deterministic": true
             },
@@ -5201,7 +5221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384756+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976908+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5246,7 +5266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106473+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5274,7 +5294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106523+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5302,7 +5322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106569+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5331,7 +5351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106615+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5358,7 +5378,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106646+00:00"
+                "validatedAt": "2026-05-05T18:46:25.448997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5372,7 +5392,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384829+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976951+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -5388,7 +5408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106686+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5497,7 +5517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106741+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5509,7 +5529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384889+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.976984+00:00"
           },
           "status": {
             "type": "string",
@@ -5527,7 +5547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106780+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5539,7 +5559,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.384915+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977000+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -5581,7 +5601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106835+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5608,7 +5628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106883+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5635,7 +5655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106928+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5663,7 +5683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.106979+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5728,7 +5748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107049+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5777,7 +5797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107104+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5790,7 +5810,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385031+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977068+00:00"
           },
           "uid": {
             "type": "string",
@@ -5809,7 +5829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107133+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5823,7 +5843,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385058+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977084+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -5901,7 +5921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:58.107191+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5913,7 +5933,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385088+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977101+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -5931,7 +5951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107239+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5959,7 +5979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107277+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5971,7 +5991,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385131+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977127+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -6060,7 +6080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107313+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6072,7 +6092,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385159+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977144+00:00"
           },
           "name": {
             "type": "string",
@@ -6089,23 +6109,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.107361+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449314+00:00"
               },
               "deterministic": true
             },
@@ -6118,7 +6138,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385186+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977159+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6135,16 +6155,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.107394+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449331+00:00"
               },
               "deterministic": true
             },
@@ -6157,7 +6182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385214+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977175+00:00"
           },
           "uid": {
             "type": "string",
@@ -6174,7 +6199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.107423+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6188,7 +6213,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385243+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977191+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6241,23 +6266,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.107491+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449380+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6273,7 +6298,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385273+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977207+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6296,16 +6321,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.107553+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449413+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6321,7 +6351,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385298+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977223+00:00"
           },
           "tenant": {
             "type": "string",
@@ -6350,7 +6380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.107620+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6364,7 +6394,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385332+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977239+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -6479,7 +6509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.107689+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6540,23 +6570,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.107728+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449499+00:00"
               },
               "deterministic": true
             },
@@ -6569,7 +6599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977309+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6585,16 +6615,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.107760+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449516+00:00"
               },
               "deterministic": true
             },
@@ -6607,7 +6642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385476+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977325+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6710,7 +6745,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385566+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977376+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6777,7 +6812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.107882+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6846,7 +6881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:58.107931+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6909,7 +6944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:58.107995+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6921,7 +6956,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385671+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977437+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6971,23 +7006,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.108035+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449650+00:00"
               },
               "deterministic": true
             },
@@ -7000,7 +7035,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385735+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977473+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7015,16 +7050,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.108069+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449666+00:00"
               },
               "deterministic": true
             },
@@ -7037,7 +7077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385762+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977489+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7076,7 +7116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108122+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7089,7 +7129,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385812+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977520+00:00"
           },
           "uid": {
             "type": "string",
@@ -7106,7 +7146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108152+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7120,7 +7160,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385840+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977535+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_k8s is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7261,7 +7301,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385900+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977569+00:00"
           },
           "value": {
             "type": "array",
@@ -7280,7 +7320,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385927+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977586+00:00"
           }
         },
         "x-f5xc-description-short": "PVC Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -7328,7 +7368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108227+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7373,7 +7413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.108292+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7400,7 +7440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108341+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7439,16 +7479,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:58.108387+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.449808+00:00"
               },
               "deterministic": true
             },
@@ -7461,7 +7506,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.385991+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.977629+00:00"
           },
           "range": {
             "type": "string",
@@ -7486,7 +7531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108428+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7519,7 +7564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108478+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7552,7 +7597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108518+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7629,7 +7674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:58.108570+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7734,7 +7779,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:58.108633+00:00"
+                "validatedAt": "2026-05-05T18:46:25.449923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7868,7 +7913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.432885+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896527+00:00"
               },
               "deterministic": true
             },
@@ -7914,7 +7959,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433007+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8264,7 +8309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433097+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8366,7 +8411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433169+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896681+00:00"
               },
               "deterministic": true
             },
@@ -8412,7 +8457,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433251+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8448,7 +8493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433348+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8807,7 +8852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433433+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8911,7 +8956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433501+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896852+00:00"
               },
               "deterministic": true
             },
@@ -8957,7 +9002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433579+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8993,7 +9038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433657+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9635,7 +9680,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433745+00:00"
+                "validatedAt": "2026-05-05T18:46:45.896987+00:00"
               },
               "deterministic": true
             },
@@ -9982,7 +10027,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433823+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897061+00:00"
               },
               "deterministic": true
             },
@@ -10334,7 +10379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433901+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10679,7 +10724,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.433976+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10734,23 +10779,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434051+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897192+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -10766,7 +10811,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.121910+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392025+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -10811,7 +10856,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434133+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897233+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -10883,7 +10928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434398+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897371+00:00"
               },
               "deterministic": true
             },
@@ -10923,7 +10968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434465+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10964,7 +11009,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434548+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897455+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -11037,7 +11082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434589+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897475+00:00"
               },
               "deterministic": true
             },
@@ -11081,7 +11126,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434671+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11148,7 +11193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434844+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11222,7 +11267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.434913+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11257,7 +11302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.434991+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11296,7 +11341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.435066+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11332,7 +11377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.435116+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11370,7 +11415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.435199+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11455,7 +11500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.435273+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11493,7 +11538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.435352+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11505,7 +11550,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.122308+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392260+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -11524,7 +11569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.435401+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11575,7 +11620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.435442+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11587,7 +11632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.122360+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392283+00:00"
           },
           "url": {
             "type": "string",
@@ -11625,7 +11670,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.435515+00:00"
+                "validatedAt": "2026-05-05T18:46:45.897965+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11719,7 +11764,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.435885+00:00"
+                "validatedAt": "2026-05-05T18:46:45.898144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11834,7 +11879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.435977+00:00"
+                "validatedAt": "2026-05-05T18:46:45.898191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11846,7 +11891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.122616+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392433+00:00"
           },
           "name": {
             "type": "string",
@@ -11861,23 +11906,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.436008+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.898207+00:00"
               },
               "deterministic": true
             },
@@ -11890,7 +11935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.122645+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392449+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11905,16 +11950,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.436040+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.898222+00:00"
               },
               "deterministic": true
             },
@@ -11927,7 +11977,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.122670+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392464+00:00"
           }
         },
         "x-f5xc-description-short": "KubeRefType represents a reference to a Kubernetes (K8s) object.",
@@ -12069,7 +12119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.437386+00:00"
+                "validatedAt": "2026-05-05T18:46:45.898891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12101,7 +12151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:22:35.437444+00:00"
+                "validatedAt": "2026-05-05T18:46:45.898918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12113,7 +12163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.123446+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.392950+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -12235,7 +12285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.437778+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12329,7 +12379,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438028+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12399,7 +12449,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438088+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12500,7 +12550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438179+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12637,7 +12687,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438241+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12943,7 +12993,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438347+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13008,7 +13058,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438404+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13048,7 +13098,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438477+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13087,7 +13137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438536+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13193,7 +13243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438604+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13229,7 +13279,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438656+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13316,7 +13366,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438713+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13489,7 +13539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438792+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899567+00:00"
               },
               "deterministic": true
             },
@@ -13638,7 +13688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438885+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13673,23 +13723,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.438947+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899647+00:00"
               },
               "deterministic": true
             },
@@ -13702,7 +13752,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124467+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393573+00:00"
           },
           "volume_name": {
             "type": "string",
@@ -13729,7 +13779,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439019+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13817,7 +13867,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439081+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13899,7 +13949,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439135+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13935,7 +13985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439188+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13996,23 +14046,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439258+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899799+00:00"
               },
               "deterministic": true
             },
@@ -14025,7 +14075,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124600+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393660+00:00"
           },
           "readiness_check": {
             "$ref": "#/components/schemas/workloadHealthCheckType"
@@ -14142,23 +14192,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.439304+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.899822+00:00"
               },
               "deterministic": true
             },
@@ -14171,7 +14221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124694+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393714+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14187,16 +14237,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.439348+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.899840+00:00"
               },
               "deterministic": true
             },
@@ -14209,7 +14264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124720+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393731+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14267,7 +14322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439408+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14332,7 +14387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439465+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14442,7 +14497,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439530+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14507,7 +14562,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439590+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14606,23 +14661,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439673+00:00"
+                "validatedAt": "2026-05-05T18:46:45.899999+00:00"
               },
               "deterministic": true
             },
@@ -14635,7 +14690,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124858+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393817+00:00"
           },
           "value": {
             "type": "string",
@@ -14659,7 +14714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439734+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14671,7 +14726,7 @@
             "x-original-maxLength": 256,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124884+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393836+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14720,23 +14775,23 @@
               "category": "discovery",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439795+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900060+00:00"
               },
               "deterministic": true
             },
@@ -14749,7 +14804,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.124930+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393873+00:00"
           }
         },
         "x-f5xc-description-short": "Ephemeral storage volume configuration for the workload.",
@@ -14813,7 +14868,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439851+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14942,7 +14997,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125028+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.393946+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15030,7 +15085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.439994+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15069,7 +15124,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440070+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900190+00:00"
               },
               "deterministic": true
             },
@@ -15171,7 +15226,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440139+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900224+00:00"
               },
               "deterministic": true
             },
@@ -15305,7 +15360,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:22:35.440224+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900261+00:00"
               },
               "deterministic": true
             },
@@ -15349,7 +15404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:22:35.440263+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900280+00:00"
               },
               "deterministic": true
             },
@@ -15460,7 +15515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440391+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900337+00:00"
               },
               "deterministic": true
             },
@@ -15546,23 +15601,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440453+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900369+00:00"
               },
               "deterministic": true
             },
@@ -15575,7 +15630,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125249+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394122+00:00"
           },
           "public": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -15638,7 +15693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440511+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15674,7 +15729,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440569+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15707,7 +15762,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440621+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15778,7 +15833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:22:35.440669+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15840,7 +15895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:22:35.440731+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15852,7 +15907,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125378+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394217+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15902,23 +15957,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.440773+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.900525+00:00"
               },
               "deterministic": true
             },
@@ -15931,7 +15986,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125439+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394266+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15946,16 +16001,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.440807+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.900542+00:00"
               },
               "deterministic": true
             },
@@ -15968,7 +16028,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125465+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394290+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -16007,7 +16067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.440861+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16020,7 +16080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125517+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394331+00:00"
           },
           "uid": {
             "type": "string",
@@ -16037,7 +16097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.440891+00:00"
+                "validatedAt": "2026-05-05T18:46:45.900580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16051,7 +16111,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125544+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394355+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of workload is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16119,7 +16179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.440971+00:00"
+                "validatedAt": "2026-05-05T18:46:45.905821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16181,7 +16241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441025+00:00"
+                "validatedAt": "2026-05-05T18:46:45.905859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16262,7 +16322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441101+00:00"
+                "validatedAt": "2026-05-05T18:46:45.905901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16379,23 +16439,23 @@
               "category": "discovery",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441187+00:00"
+                "validatedAt": "2026-05-05T18:46:45.905948+00:00"
               },
               "deterministic": true
             },
@@ -16408,7 +16468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125663+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394455+00:00"
           },
           "persistent_volume": {
             "$ref": "#/components/schemas/workloadPersistentStorageVolumeType"
@@ -16454,23 +16514,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.441226+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.905969+00:00"
               },
               "deterministic": true
             },
@@ -16483,7 +16543,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125699+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:14.394481+00:00",
             "x-f5xc-conflicts-with": [
               "num"
             ]
@@ -16566,7 +16626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441276+00:00"
+                "validatedAt": "2026-05-05T18:46:45.905998+00:00"
               },
               "deterministic": true
             },
@@ -16657,23 +16717,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.441341+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.906027+00:00"
               },
               "deterministic": true
             },
@@ -16686,7 +16746,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.125782+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394531+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16905,7 +16965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441419+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16945,7 +17005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441486+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16985,7 +17045,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441546+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17021,7 +17081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441602+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17158,23 +17218,23 @@
               "category": "discovery",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441713+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906237+00:00"
               },
               "deterministic": true
             },
@@ -17187,7 +17247,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.126054+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394728+00:00"
           },
           "persistent_volume": {
             "$ref": "#/components/schemas/workloadPersistentStorageVolumeType"
@@ -17290,7 +17350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441781+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906272+00:00"
               },
               "deterministic": true
             },
@@ -17430,7 +17490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.441845+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17475,7 +17535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.441908+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17502,7 +17562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.441950+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17557,16 +17617,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:35.442000+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:45.906382+00:00"
               },
               "deterministic": true
             },
@@ -17579,7 +17644,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.126192+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394812+00:00"
           },
           "range": {
             "type": "string",
@@ -17604,7 +17669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.442042+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17637,7 +17702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.442094+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17670,7 +17735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.442137+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17749,7 +17814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:35.442192+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17821,7 +17886,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.126267+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394858+00:00"
           },
           "value": {
             "type": "array",
@@ -17840,7 +17905,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.126297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.394875+00:00"
           }
         },
         "x-f5xc-description-short": "Usage Type Data contains key/value pair that uniquely identifies a workload in the response and the corresponding metric data.",
@@ -17921,7 +17986,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.442311+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17955,7 +18020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:35.442413+00:00"
+                "validatedAt": "2026-05-05T18:46:45.906576+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18005,7 +18070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.594244+00:00"
+                "validatedAt": "2026-05-05T18:46:49.020725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18018,7 +18083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.271870+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.474839+00:00"
           },
           "name": {
             "type": "string",
@@ -18035,23 +18100,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:41.594278+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:49.020742+00:00"
               },
               "deterministic": true
             },
@@ -18064,7 +18129,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.271896+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.474855+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18081,16 +18146,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:41.594309+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:49.020758+00:00"
               },
               "deterministic": true
             },
@@ -18103,7 +18173,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.271923+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.474871+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18122,7 +18192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.594359+00:00"
+                "validatedAt": "2026-05-05T18:46:49.020776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18136,7 +18206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.271950+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.474886+00:00"
           },
           "uid": {
             "type": "string",
@@ -18155,7 +18225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.594389+00:00"
+                "validatedAt": "2026-05-05T18:46:49.020790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18170,7 +18240,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.271980+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.474903+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -18276,7 +18346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.595451+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18309,7 +18379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.595497+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18391,23 +18461,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:41.595556+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:49.021327+00:00"
               },
               "deterministic": true
             },
@@ -18420,7 +18490,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272624+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475275+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18436,16 +18506,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:41.595589+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:49.021343+00:00"
               },
               "deterministic": true
             },
@@ -18458,7 +18533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272649+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475291+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18561,7 +18636,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272741+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475343+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18617,7 +18692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.595702+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18650,7 +18725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.595746+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18740,7 +18815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:22:41.595812+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18803,7 +18878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:22:41.595870+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18815,7 +18890,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272838+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475399+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18865,23 +18940,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:41.595907+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:49.021490+00:00"
               },
               "deterministic": true
             },
@@ -18894,7 +18969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272904+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475435+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18909,16 +18984,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:41.595939+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:49.021506+00:00"
               },
               "deterministic": true
             },
@@ -18931,7 +19011,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272935+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475451+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18970,7 +19050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.595992+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18983,7 +19063,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.272985+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475482+00:00"
           },
           "uid": {
             "type": "string",
@@ -19000,7 +19080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.596021+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19014,7 +19094,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.273011+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.475498+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of workload_flavor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19113,7 +19193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.596076+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19146,7 +19226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:41.596117+00:00"
+                "validatedAt": "2026-05-05T18:46:49.021589+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/data_and_privacy_security.json
+++ b/docs/specifications/api/data_and_privacy_security.json
@@ -3240,7 +3240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.051559+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3313,7 +3313,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.051655+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571268+00:00"
               },
               "deterministic": true
             },
@@ -3375,23 +3375,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.051703+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.571289+00:00"
               },
               "deterministic": true
             },
@@ -3404,7 +3404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342521+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619066+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3420,16 +3420,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.051739+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.571307+00:00"
               },
               "deterministic": true
             },
@@ -3442,7 +3447,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619082+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -3530,7 +3535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.051802+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3639,7 +3644,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342682+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619156+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -3703,7 +3708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.051931+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3776,7 +3781,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.052008+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571434+00:00"
               },
               "deterministic": true
             },
@@ -3878,7 +3883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:26.052059+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3940,7 +3945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:26.052127+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3952,7 +3957,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342815+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619234+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -4002,23 +4007,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.052172+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.571509+00:00"
               },
               "deterministic": true
             },
@@ -4031,7 +4036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342876+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619271+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4046,16 +4051,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.052205+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.571526+00:00"
               },
               "deterministic": true
             },
@@ -4068,7 +4078,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342902+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619287+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -4107,7 +4117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052260+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4120,7 +4130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342955+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619318+00:00"
           },
           "uid": {
             "type": "string",
@@ -4137,7 +4147,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052293+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4151,7 +4161,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.342981+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619334+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of data_type is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4283,7 +4293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.052370+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4356,7 +4366,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.052443+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571642+00:00"
               },
               "deterministic": true
             },
@@ -4423,7 +4433,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.052527+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4463,7 +4473,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.052610+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4580,7 +4590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052688+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4603,7 +4613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052728+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4615,7 +4625,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343153+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619433+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4661,7 +4671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.052769+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571799+00:00"
               },
               "deterministic": true
             },
@@ -4687,7 +4697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052819+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4714,7 +4724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052860+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4726,7 +4736,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343200+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619461+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4743,7 +4753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052907+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4776,7 +4786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052951+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4788,7 +4798,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343234+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619482+00:00"
           },
           "type": {
             "type": "string",
@@ -4813,7 +4823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.052990+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4901,7 +4911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053035+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4947,23 +4957,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053072+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.571938+00:00"
               },
               "deterministic": true
             },
@@ -4976,7 +4986,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343300+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619521+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5094,7 +5104,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.053180+00:00"
+                "validatedAt": "2026-05-05T18:43:07.571992+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5110,7 +5120,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343371+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619555+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5164,23 +5174,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053221+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572012+00:00"
               },
               "deterministic": true
             },
@@ -5193,7 +5203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343417+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619582+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5210,16 +5220,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053253+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572027+00:00"
               },
               "deterministic": true
             },
@@ -5232,7 +5247,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343443+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619598+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5314,7 +5329,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.053353+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572071+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5330,7 +5345,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343483+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619627+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5386,23 +5401,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053394+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572090+00:00"
               },
               "deterministic": true
             },
@@ -5415,7 +5430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343527+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619654+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5432,16 +5447,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053425+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572106+00:00"
               },
               "deterministic": true
             },
@@ -5454,7 +5474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619670+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5499,7 +5519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053464+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5512,7 +5532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343581+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619687+00:00"
           },
           "name": {
             "type": "string",
@@ -5529,23 +5549,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053498+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572140+00:00"
               },
               "deterministic": true
             },
@@ -5558,7 +5578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343606+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619703+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5575,16 +5595,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053529+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572156+00:00"
               },
               "deterministic": true
             },
@@ -5597,7 +5622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619719+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5616,7 +5641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053569+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5630,7 +5655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343656+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619735+00:00"
           },
           "uid": {
             "type": "string",
@@ -5649,7 +5674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053598+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5664,7 +5689,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343682+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619751+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -5746,7 +5771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:26.053691+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572232+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5762,7 +5787,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343721+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619774+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5816,23 +5841,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053732+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572251+00:00"
               },
               "deterministic": true
             },
@@ -5845,7 +5870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343766+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619802+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5862,16 +5887,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.053763+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572267+00:00"
               },
               "deterministic": true
             },
@@ -5884,7 +5914,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343791+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619819+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5929,7 +5959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053817+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5957,7 +5987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053865+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5985,7 +6015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053910+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6014,7 +6044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053955+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6041,7 +6071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.053986+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6055,7 +6085,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343867+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619863+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6071,7 +6101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054027+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6180,7 +6210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054084+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6192,7 +6222,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343924+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619895+00:00"
           },
           "status": {
             "type": "string",
@@ -6210,7 +6240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054125+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6222,7 +6252,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.343948+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619911+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6264,7 +6294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054175+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6291,7 +6321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054224+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6318,7 +6348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054268+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6346,7 +6376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054317+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6411,7 +6441,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054398+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6460,7 +6490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054453+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6473,7 +6503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.344068+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619980+00:00"
           },
           "uid": {
             "type": "string",
@@ -6492,7 +6522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054482+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6506,7 +6536,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.344096+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.619996+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6556,7 +6586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054519+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6568,7 +6598,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.344126+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.620014+00:00"
           },
           "name": {
             "type": "string",
@@ -6585,23 +6615,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.054553+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572620+00:00"
               },
               "deterministic": true
             },
@@ -6614,7 +6644,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.344152+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.620029+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6631,16 +6661,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:26.054586+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:07.572639+00:00"
               },
               "deterministic": true
             },
@@ -6653,7 +6688,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.344179+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.620044+00:00"
           },
           "uid": {
             "type": "string",
@@ -6670,7 +6705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:26.054615+00:00"
+                "validatedAt": "2026-05-05T18:43:07.572652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6684,7 +6719,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.344206+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.620060+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6783,7 +6818,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.129012+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.614514+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6838,7 +6873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:00.381301+00:00"
+                "validatedAt": "2026-05-05T18:43:55.210189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6942,7 +6977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:00.381442+00:00"
+                "validatedAt": "2026-05-05T18:43:55.210225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6955,7 +6990,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.129095+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.614560+00:00"
           },
           "name": {
             "type": "string",
@@ -6972,23 +7007,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:00.381504+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:55.210245+00:00"
               },
               "deterministic": true
             },
@@ -7001,7 +7036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.129121+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.614576+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7018,16 +7053,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:00.381560+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:55.210263+00:00"
               },
               "deterministic": true
             },
@@ -7040,7 +7080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.129148+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.614592+00:00"
           },
           "tenant": {
             "type": "string",
@@ -7059,7 +7099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:00.381601+00:00"
+                "validatedAt": "2026-05-05T18:43:55.210281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7073,7 +7113,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.129175+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.614607+00:00"
           },
           "uid": {
             "type": "string",
@@ -7092,7 +7132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:00.381634+00:00"
+                "validatedAt": "2026-05-05T18:43:55.210297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7107,7 +7147,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.129203+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.614630+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -7156,7 +7196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.775783+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7194,7 +7234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:01.775856+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618520+00:00"
               },
               "deterministic": true
             },
@@ -7231,7 +7271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.775902+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7382,7 +7422,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393185+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.819909+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7540,7 +7580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:01.776065+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7603,7 +7643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:01.776130+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7615,7 +7655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393305+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.819979+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7665,23 +7705,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:01.776170+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:53.618667+00:00"
               },
               "deterministic": true
             },
@@ -7694,7 +7734,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393380+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.820017+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7709,16 +7749,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:01.776204+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:53.618685+00:00"
               },
               "deterministic": true
             },
@@ -7731,7 +7776,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393409+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.820033+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7770,7 +7815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.776260+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7783,7 +7828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393461+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.820065+00:00"
           },
           "uid": {
             "type": "string",
@@ -7800,7 +7845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.776290+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7814,7 +7859,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393488+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.820082+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of lma_region is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7925,7 +7970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.776478+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7963,7 +8008,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:01.776553+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7975,7 +8020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393597+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.820145+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -7994,7 +8039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.776604+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8045,7 +8090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:01.776648+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8057,7 +8102,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.393634+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.820168+00:00"
           },
           "url": {
             "type": "string",
@@ -8095,7 +8140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:01.776729+00:00"
+                "validatedAt": "2026-05-05T18:44:53.618920+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8201,7 +8246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:27.690366+00:00"
+                "validatedAt": "2026-05-05T18:45:05.916523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8233,7 +8278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:27.690411+00:00"
+                "validatedAt": "2026-05-05T18:45:05.916544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8299,7 +8344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237337+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8332,7 +8377,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237394+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8373,7 +8418,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237457+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8437,7 +8482,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237515+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8470,7 +8515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237565+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8511,7 +8556,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237622+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8575,7 +8620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237679+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8608,7 +8653,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237733+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8649,7 +8694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237795+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8767,23 +8812,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237900+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134351+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8799,7 +8844,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121625+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.542922+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8822,16 +8867,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.237964+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134383+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8847,7 +8897,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121654+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.542943+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8876,7 +8926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:07.238031+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8890,7 +8940,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121682+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.542979+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -9021,23 +9071,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:07.238078+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:56.134437+00:00"
               },
               "deterministic": true
             },
@@ -9050,7 +9100,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121778+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543082+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9066,16 +9116,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:07.238110+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:56.134453+00:00"
               },
               "deterministic": true
             },
@@ -9088,7 +9143,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121804+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543111+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9191,7 +9246,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121891+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543172+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9259,7 +9314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:18:07.238224+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9322,7 +9377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:18:07.238285+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9334,7 +9389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.121959+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543215+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9384,23 +9439,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:07.238335+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:56.134547+00:00"
               },
               "deterministic": true
             },
@@ -9413,7 +9468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.122021+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543258+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9428,16 +9483,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:07.238367+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:56.134562+00:00"
               },
               "deterministic": true
             },
@@ -9450,7 +9510,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.122047+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543275+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9489,7 +9549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:07.238420+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9502,7 +9562,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.122098+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543308+00:00"
           },
           "uid": {
             "type": "string",
@@ -9520,7 +9580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:07.238448+00:00"
+                "validatedAt": "2026-05-05T18:46:56.134598+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9534,7 +9594,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.122126+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.543324+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of sensitive_data_policy is returned in 'List'.",

--- a/docs/specifications/api/data_intelligence.json
+++ b/docs/specifications/api/data_intelligence.json
@@ -3615,7 +3615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.437478+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3628,7 +3628,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041066+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457559+00:00"
           },
           "name": {
             "type": "string",
@@ -3645,23 +3645,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.437544+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.356743+00:00"
               },
               "deterministic": true
             },
@@ -3674,7 +3674,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041096+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457576+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3691,16 +3691,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.437580+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.356762+00:00"
               },
               "deterministic": true
             },
@@ -3713,7 +3718,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041123+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457593+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3732,7 +3737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.437622+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3746,7 +3751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041152+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457609+00:00"
           },
           "uid": {
             "type": "string",
@@ -3765,7 +3770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.437653+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3780,7 +3785,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041182+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457633+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3818,7 +3823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.437699+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3841,7 +3846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.437739+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3853,7 +3858,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041226+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457657+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -3943,7 +3948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.437850+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4069,7 +4074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.437948+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4222,7 +4227,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.438040+00:00"
+                "validatedAt": "2026-05-05T18:43:00.356985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4300,7 +4305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:10:11.438086+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357008+00:00"
               },
               "deterministic": true
             },
@@ -4339,7 +4344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.438127+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4408,23 +4413,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.438170+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.357050+00:00"
               },
               "deterministic": true
             },
@@ -4437,7 +4442,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041564+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457852+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4453,16 +4458,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.438204+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.357067+00:00"
               },
               "deterministic": true
             },
@@ -4475,7 +4485,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041592+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457868+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4534,7 +4544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.438295+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4653,7 +4663,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041719+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.457942+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -4717,7 +4727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.438444+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4751,7 +4761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.438493+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4778,7 +4788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.438546+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4811,7 +4821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.438590+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4845,7 +4855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.438641+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4938,7 +4948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.438703+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5003,7 +5013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.438774+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5070,7 +5080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:11.438825+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5132,7 +5142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:11.438888+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5144,7 +5154,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.041974+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458092+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5194,23 +5204,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.438929+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.357409+00:00"
               },
               "deterministic": true
             },
@@ -5223,7 +5233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042037+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458130+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5238,16 +5248,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.438962+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.357425+00:00"
               },
               "deterministic": true
             },
@@ -5260,7 +5275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458146+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5299,7 +5314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439015+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5312,7 +5327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458177+00:00"
           },
           "uid": {
             "type": "string",
@@ -5329,7 +5344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439045+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5343,7 +5358,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042139+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458194+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5450,7 +5465,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.439123+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357505+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5526,7 +5541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439175+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5571,7 +5586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.439257+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5641,7 +5656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:10:11.439302+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357594+00:00"
               },
               "deterministic": true
             },
@@ -5776,7 +5791,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.439430+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357662+00:00"
               },
               "deterministic": true
             },
@@ -5865,7 +5880,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.439512+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357703+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5924,7 +5939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439564+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5962,7 +5977,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.439633+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5974,7 +5989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042476+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458392+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -5993,7 +6008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439679+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6044,7 +6059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439721+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6056,7 +6071,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458414+00:00"
           },
           "url": {
             "type": "string",
@@ -6094,7 +6109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.439787+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357839+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -6151,7 +6166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.439824+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357857+00:00"
               },
               "deterministic": true
             },
@@ -6177,7 +6192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439872+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6204,7 +6219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439913+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6216,7 +6231,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042566+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458447+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6233,7 +6248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439959+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6266,7 +6281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.439999+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6278,7 +6293,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042600+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458468+00:00"
           },
           "type": {
             "type": "string",
@@ -6303,7 +6318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440038+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6391,7 +6406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440080+00:00"
+                "validatedAt": "2026-05-05T18:43:00.357978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6437,23 +6452,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440114+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.357995+00:00"
               },
               "deterministic": true
             },
@@ -6466,7 +6481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042666+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458507+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -6584,7 +6599,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.440220+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358047+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6600,7 +6615,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042725+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458541+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6654,23 +6669,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440261+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358067+00:00"
               },
               "deterministic": true
             },
@@ -6683,7 +6698,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042769+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458568+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6700,16 +6715,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440292+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358083+00:00"
               },
               "deterministic": true
             },
@@ -6722,7 +6742,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042794+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458584+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -6804,7 +6824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.440392+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358130+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -6820,7 +6840,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042832+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458608+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -6876,23 +6896,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440433+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358149+00:00"
               },
               "deterministic": true
             },
@@ -6905,7 +6925,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042878+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458640+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6922,16 +6942,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440464+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358165+00:00"
               },
               "deterministic": true
             },
@@ -6944,7 +6969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042904+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458657+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -7026,7 +7051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.440551+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358211+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7042,7 +7067,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042941+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458680+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7096,23 +7121,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440589+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358230+00:00"
               },
               "deterministic": true
             },
@@ -7125,7 +7150,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.042986+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458707+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7142,16 +7167,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.440620+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358246+00:00"
               },
               "deterministic": true
             },
@@ -7164,7 +7194,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043011+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458723+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -7259,7 +7289,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440673+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7287,7 +7317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440723+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7315,7 +7345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440767+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7344,7 +7374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440810+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358333+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7371,7 +7401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440840+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7385,7 +7415,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043105+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458778+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7401,7 +7431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440879+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7510,7 +7540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440932+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7522,7 +7552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043160+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458811+00:00"
           },
           "status": {
             "type": "string",
@@ -7540,7 +7570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.440969+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7552,7 +7582,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043188+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458827+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -7594,7 +7624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441019+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7621,7 +7651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441067+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7648,7 +7678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441109+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7676,7 +7706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441159+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7741,7 +7771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441227+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7790,7 +7820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441280+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7803,7 +7833,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043305+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458895+00:00"
           },
           "uid": {
             "type": "string",
@@ -7822,7 +7852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441308+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7836,7 +7866,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043345+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458912+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -7886,7 +7916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441352+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7898,7 +7928,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043375+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458928+00:00"
           },
           "name": {
             "type": "string",
@@ -7915,23 +7945,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.441384+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358598+00:00"
               },
               "deterministic": true
             },
@@ -7944,7 +7974,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043403+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458944+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7961,16 +7991,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:11.441416+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:00.358622+00:00"
               },
               "deterministic": true
             },
@@ -7983,7 +8018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043430+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458960+00:00"
           },
           "uid": {
             "type": "string",
@@ -8000,7 +8035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:11.441444+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8014,7 +8049,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043456+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458975+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -8067,23 +8102,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.441507+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358674+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8099,7 +8134,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043484+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.458992+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8122,16 +8157,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.441567+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358707+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8147,7 +8187,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043512+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.459008+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8176,7 +8216,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:11.441632+00:00"
+                "validatedAt": "2026-05-05T18:43:00.358741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8190,7 +8230,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.043537+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.459024+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -8238,7 +8278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.885897+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666007+00:00"
               },
               "deterministic": true
             },
@@ -8264,7 +8304,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177111+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526314+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8304,7 +8344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:15.885982+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8316,7 +8356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177146+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526334+00:00"
           },
           "id": {
             "type": "string",
@@ -8335,7 +8375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886014+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8358,23 +8398,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.886051+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:02.666083+00:00"
               },
               "deterministic": true
             },
@@ -8387,7 +8427,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526356+00:00"
           },
           "status": {
             "type": "string",
@@ -8405,7 +8445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886090+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8417,7 +8457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177210+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526372+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8457,7 +8497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886134+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8510,7 +8550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886204+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8522,7 +8562,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177268+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526405+00:00"
           }
         },
         "x-f5xc-description-short": "Message object representing events reason.",
@@ -8563,7 +8603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886251+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8590,7 +8630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:15.886307+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8602,7 +8642,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177309+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526427+00:00"
           },
           "feature_name": {
             "type": "string",
@@ -8618,7 +8658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886373+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8656,7 +8696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886414+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8721,7 +8761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886459+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8744,7 +8784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886500+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8865,7 +8905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886580+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9027,7 +9067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886697+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9051,16 +9091,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.886733+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:02.666402+00:00"
               },
               "deterministic": true
             },
@@ -9073,7 +9118,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177492+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526532+00:00"
           },
           "platform": {
             "type": "string",
@@ -9091,7 +9136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886775+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9116,7 +9161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.886821+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9148,7 +9193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.886872+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666466+00:00"
               },
               "deterministic": true
             },
@@ -9263,23 +9308,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.886935+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:02.666494+00:00"
               },
               "deterministic": true
             },
@@ -9292,7 +9337,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177585+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526587+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9504,7 +9549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887115+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9535,16 +9580,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.887153+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:02.666594+00:00"
               },
               "deterministic": true
             },
@@ -9557,7 +9607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177709+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526676+00:00"
           }
         },
         "x-f5xc-description-short": "Request to test receiver & destination sink.",
@@ -9597,7 +9647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887194+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9679,7 +9729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887227+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9703,16 +9753,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.887257+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:02.666657+00:00"
               },
               "deterministic": true
             },
@@ -9725,7 +9780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177770+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526711+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/shapedata_deliveryStatusType"
@@ -9769,7 +9824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887287+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9795,7 +9850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887342+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9821,7 +9876,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887382+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9833,7 +9888,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177823+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526744+00:00"
           }
         },
         "x-f5xc-description-short": "Payload about status of receiver status result.",
@@ -9881,7 +9936,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:15.887463+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9915,7 +9970,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:15.887537+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666791+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9939,16 +9994,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:15.887571+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:02.666808+00:00"
               },
               "deterministic": true
             },
@@ -9961,7 +10021,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177871+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526772+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -10007,7 +10067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:15.887611+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10056,7 +10116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:15.887668+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10068,7 +10128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177920+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526800+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -10086,7 +10146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887713+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10115,7 +10175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887752+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10127,7 +10187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177962+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526827+00:00"
           },
           "value": {
             "type": "string",
@@ -10143,7 +10203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:15.887788+00:00"
+                "validatedAt": "2026-05-05T18:43:02.666910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10155,7 +10215,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.177989+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.526843+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",

--- a/docs/specifications/api/ddos.json
+++ b/docs/specifications/api/ddos.json
@@ -15792,7 +15792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.623746+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15869,7 +15869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.623824+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15895,7 +15895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.623868+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15920,16 +15920,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.623910+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.271354+00:00"
               },
               "deterministic": true
             },
@@ -15942,7 +15947,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124224+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134531+00:00"
           }
         },
         "x-f5xc-description-short": "Request to add an alert to event (link them together).",
@@ -16017,7 +16022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.623988+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16029,7 +16034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124266+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134555+00:00"
           },
           "event_id": {
             "type": "string",
@@ -16047,7 +16052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624033+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16072,16 +16077,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.624066+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.271426+00:00"
               },
               "deterministic": true
             },
@@ -16094,7 +16104,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124303+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134576+00:00"
           },
           "time": {
             "type": "string",
@@ -16117,7 +16127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:53.624114+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271448+00:00"
               },
               "deterministic": true
             },
@@ -16143,7 +16153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624153+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16155,7 +16165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124347+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134598+00:00"
           }
         },
         "x-f5xc-description-short": "Request to add a single event detail to an event.",
@@ -16221,7 +16231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624202+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16250,7 +16260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624249+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16274,7 +16284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624290+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16303,7 +16313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624358+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16348,7 +16358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624400+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16374,7 +16384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624431+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16397,7 +16407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624475+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16429,7 +16439,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624522+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16454,7 +16464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624562+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16511,7 +16521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624602+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16548,23 +16558,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.624644+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.271685+00:00"
               },
               "deterministic": true
             },
@@ -16577,7 +16587,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124505+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134698+00:00"
           },
           "number": {
             "type": "integer",
@@ -16611,7 +16621,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624699+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271709+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16636,7 +16646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624740+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16691,7 +16701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:53.624781+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271747+00:00"
               },
               "deterministic": true
             },
@@ -16733,7 +16743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624830+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16760,7 +16770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624876+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16833,7 +16843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624926+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16864,7 +16874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.624968+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16890,7 +16900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625009+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16916,7 +16926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625054+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16939,23 +16949,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.625086+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.271890+00:00"
               },
               "deterministic": true
             },
@@ -16968,7 +16978,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124642+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134783+00:00"
           },
           "size_bytes": {
             "type": "string",
@@ -16987,7 +16997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625130+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17014,7 +17024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625173+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17117,7 +17127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625244+00:00"
+                "validatedAt": "2026-05-05T18:44:21.271964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17168,16 +17178,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.625283+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.271984+00:00"
               },
               "deterministic": true
             },
@@ -17190,7 +17205,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124735+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134841+00:00"
           },
           "time": {
             "type": "string",
@@ -17217,7 +17232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:53.625342+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272007+00:00"
               },
               "deterministic": true
             },
@@ -17269,7 +17284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:53.625384+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17390,23 +17405,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.625459+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272063+00:00"
               },
               "deterministic": true
             },
@@ -17419,7 +17434,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124797+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134879+00:00"
           },
           "zone1": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -17485,7 +17500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.625530+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17497,7 +17512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124856+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134912+00:00"
           },
           "event_detail_id": {
             "type": "string",
@@ -17514,7 +17529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625576+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17541,7 +17556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625617+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17566,16 +17581,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.625649+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272156+00:00"
               },
               "deterministic": true
             },
@@ -17588,7 +17608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124903+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134938+00:00"
           },
           "time": {
             "type": "string",
@@ -17611,7 +17631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:53.625694+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272178+00:00"
               },
               "deterministic": true
             },
@@ -17637,7 +17657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625731+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17649,7 +17669,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124938+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134960+00:00"
           }
         },
         "x-f5xc-description-short": "Request to update a single event detail.",
@@ -17720,7 +17740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.625792+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17732,7 +17752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.124977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.134983+00:00"
           },
           "end_time": {
             "type": "string",
@@ -17752,7 +17772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625833+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17793,7 +17813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.625889+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17817,23 +17837,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.625922+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272284+00:00"
               },
               "deterministic": true
             },
@@ -17846,7 +17866,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125029+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135014+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17862,16 +17882,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.625954+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272299+00:00"
               },
               "deterministic": true
             },
@@ -17884,7 +17909,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125055+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135030+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17965,7 +17990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626013+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17996,7 +18021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.626071+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18008,7 +18033,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135064+00:00"
           },
           "end_time": {
             "type": "string",
@@ -18027,7 +18052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626112+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18083,7 +18108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626144+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18108,7 +18133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626173+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18133,7 +18158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626221+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18157,23 +18182,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.626255+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272434+00:00"
               },
               "deterministic": true
             },
@@ -18186,7 +18211,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125192+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135111+00:00"
           },
           "network_id": {
             "type": "string",
@@ -18203,7 +18228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626299+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18231,7 +18256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626353+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18303,7 +18328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626409+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18334,7 +18359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.626463+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18346,7 +18371,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135149+00:00"
           },
           "id": {
             "type": "string",
@@ -18366,7 +18391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626491+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18398,7 +18423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:53.626536+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272557+00:00"
               },
               "deterministic": true
             },
@@ -18424,7 +18449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626575+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272575+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18436,7 +18461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135175+00:00"
           }
         },
         "x-f5xc-description-short": "Event detail represents a single occurrence of event detail, that tracks customer, SOC notes on a given event.",
@@ -18482,7 +18507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626604+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18506,23 +18531,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.626635+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272605+00:00"
               },
               "deterministic": true
             },
@@ -18535,7 +18560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125342+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135198+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -18650,7 +18675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626703+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18740,7 +18765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626762+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18767,7 +18792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626804+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18792,16 +18817,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.626837+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272708+00:00"
               },
               "deterministic": true
             },
@@ -18814,7 +18844,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135269+00:00"
           },
           "network_id": {
             "type": "string",
@@ -18833,7 +18863,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626881+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18863,7 +18893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.626924+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19099,7 +19129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627035+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19126,7 +19156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627083+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19151,16 +19181,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.627112+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272838+00:00"
               },
               "deterministic": true
             },
@@ -19173,7 +19208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125567+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135341+00:00"
           },
           "network_id": {
             "type": "string",
@@ -19191,7 +19226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627154+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19221,7 +19256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627198+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19385,7 +19420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627276+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19434,7 +19469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627331+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19461,7 +19496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627376+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19486,16 +19521,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.627407+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.272972+00:00"
               },
               "deterministic": true
             },
@@ -19508,7 +19548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125669+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135405+00:00"
           },
           "network_id": {
             "type": "string",
@@ -19527,7 +19567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627450+00:00"
+                "validatedAt": "2026-05-05T18:44:21.272991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19557,7 +19597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627495+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19644,7 +19684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.627553+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19694,7 +19734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627595+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19718,16 +19758,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.627629+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.273087+00:00"
               },
               "deterministic": true
             },
@@ -19740,7 +19785,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125746+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135449+00:00"
           },
           "start_time": {
             "type": "string",
@@ -19761,7 +19806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627673+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19845,7 +19890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627731+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19870,7 +19915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627769+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19899,7 +19944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627810+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19926,7 +19971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627836+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19963,23 +20008,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.627871+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.273200+00:00"
               },
               "deterministic": true
             },
@@ -19992,7 +20037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125839+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135503+00:00"
           },
           "network_id": {
             "type": "string",
@@ -20008,7 +20053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627912+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20035,7 +20080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627958+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20060,7 +20105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.627997+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20088,7 +20133,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628041+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20142,7 +20187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628085+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20167,7 +20212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628123+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20195,7 +20240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628150+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20226,7 +20271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:53.628192+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273351+00:00"
               },
               "deterministic": true
             },
@@ -20275,7 +20320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628221+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20303,7 +20348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628263+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20352,7 +20397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628291+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20375,23 +20420,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.628333+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.273414+00:00"
               },
               "deterministic": true
             },
@@ -20404,7 +20449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.125970+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135579+00:00"
           },
           "prefixes": {
             "$ref": "#/components/schemas/schemaPrefixListType"
@@ -20470,7 +20515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.628386+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273439+00:00"
               },
               "deterministic": true
             },
@@ -20497,7 +20542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628425+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20524,7 +20569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628450+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20547,23 +20592,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.628483+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.273485+00:00"
               },
               "deterministic": true
             },
@@ -20576,7 +20621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126042+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135627+00:00"
           },
           "scheduled": {
             "type": "boolean",
@@ -20607,7 +20652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628532+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20632,7 +20677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628566+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20658,7 +20703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628604+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20670,7 +20715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126096+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135659+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20722,7 +20767,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.628685+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20756,7 +20801,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.628758+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20780,16 +20825,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.628793+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.273645+00:00"
               },
               "deterministic": true
             },
@@ -20802,7 +20852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126145+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135687+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -20921,7 +20971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628852+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20966,7 +21016,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.628910+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20993,7 +21043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.628949+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21032,16 +21082,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:53.628993+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:21.273743+00:00"
               },
               "deterministic": true
             },
@@ -21054,7 +21109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126242+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135747+00:00"
           },
           "range": {
             "type": "string",
@@ -21079,7 +21134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629032+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21112,7 +21167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629079+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21145,7 +21200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629116+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21222,7 +21277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629165+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21293,7 +21348,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126318+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135795+00:00"
           },
           "value": {
             "type": "array",
@@ -21312,7 +21367,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126356+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135812+00:00"
           }
         },
         "x-f5xc-description-short": "Transit Usage Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -21347,7 +21402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629224+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21370,7 +21425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629261+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21382,7 +21437,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126396+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135835+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -21477,7 +21532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.629341+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21531,7 +21586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.629407+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21595,7 +21650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629461+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21607,7 +21662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126486+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135887+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -21660,7 +21715,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.629517+00:00"
+                "validatedAt": "2026-05-05T18:44:21.273990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21735,7 +21790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.629572+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21747,7 +21802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126528+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135910+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -21765,7 +21820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629622+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21793,7 +21848,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629670+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21805,7 +21860,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126570+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135936+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -21897,7 +21952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:53.629710+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21946,7 +22001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:53.629771+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21958,7 +22013,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126610+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135961+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -21976,7 +22031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629819+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22003,7 +22058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:53.629858+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22015,7 +22070,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126653+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.135987+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -22068,23 +22123,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.629928+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274228+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22100,7 +22155,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126680+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.136004+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22123,16 +22178,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.629991+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274261+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22148,7 +22208,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126706+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.136020+00:00"
           },
           "tenant": {
             "type": "string",
@@ -22177,7 +22237,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:53.630063+00:00"
+                "validatedAt": "2026-05-05T18:44:21.274297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22191,7 +22251,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.126732+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.136035+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -22354,23 +22414,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.791542+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.286695+00:00"
               },
               "deterministic": true
             },
@@ -22383,7 +22443,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203583+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181100+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22399,16 +22459,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.791584+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.286717+00:00"
               },
               "deterministic": true
             },
@@ -22421,7 +22486,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203613+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181117+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22524,7 +22589,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203701+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181171+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22660,7 +22725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:55.791722+00:00"
+                "validatedAt": "2026-05-05T18:44:22.286774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22723,7 +22788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:55.791790+00:00"
+                "validatedAt": "2026-05-05T18:44:22.286804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22735,7 +22800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181243+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22785,23 +22850,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.791831+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.286822+00:00"
               },
               "deterministic": true
             },
@@ -22814,7 +22879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203885+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181285+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22829,16 +22894,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.791865+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.286840+00:00"
               },
               "deterministic": true
             },
@@ -22851,7 +22921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203911+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181301+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22890,7 +22960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.791920+00:00"
+                "validatedAt": "2026-05-05T18:44:22.286864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22903,7 +22973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203960+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181332+00:00"
           },
           "uid": {
             "type": "string",
@@ -22921,7 +22991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.791950+00:00"
+                "validatedAt": "2026-05-05T18:44:22.286880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22935,7 +23005,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.203987+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181349+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_asn is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23097,23 +23167,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792018+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.286910+00:00"
               },
               "deterministic": true
             },
@@ -23126,7 +23196,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204064+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181395+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23149,16 +23219,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792058+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.286931+00:00"
               },
               "deterministic": true
             },
@@ -23171,7 +23246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204089+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181411+00:00"
           },
           "review_type_approved": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -23261,7 +23336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792182+00:00"
+                "validatedAt": "2026-05-05T18:44:22.286989+00:00"
               },
               "deterministic": true
             },
@@ -23287,7 +23362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792232+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23314,7 +23389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792271+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23326,7 +23401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204198+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181479+00:00"
           },
           "service_name": {
             "type": "string",
@@ -23343,7 +23418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792318+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23376,7 +23451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792374+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23388,7 +23463,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204233+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181501+00:00"
           },
           "type": {
             "type": "string",
@@ -23413,7 +23488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792415+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23501,7 +23576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792458+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23547,23 +23622,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792494+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287127+00:00"
               },
               "deterministic": true
             },
@@ -23576,7 +23651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204301+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181540+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -23694,7 +23769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:55.792605+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287186+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -23710,7 +23785,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181575+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -23764,23 +23839,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792648+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287205+00:00"
               },
               "deterministic": true
             },
@@ -23793,7 +23868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204416+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181608+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23810,16 +23885,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792679+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287221+00:00"
               },
               "deterministic": true
             },
@@ -23832,7 +23912,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204442+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181639+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -23914,7 +23994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:55.792771+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287266+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -23930,7 +24010,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204479+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181692+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -23986,23 +24066,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792814+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287285+00:00"
               },
               "deterministic": true
             },
@@ -24015,7 +24095,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204523+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181736+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24032,16 +24112,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792847+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287302+00:00"
               },
               "deterministic": true
             },
@@ -24054,7 +24139,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204551+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181759+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -24099,7 +24184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792884+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24112,7 +24197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204578+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181788+00:00"
           },
           "name": {
             "type": "string",
@@ -24129,23 +24214,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792918+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287334+00:00"
               },
               "deterministic": true
             },
@@ -24158,7 +24243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204605+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181822+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24175,16 +24260,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.792951+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287350+00:00"
               },
               "deterministic": true
             },
@@ -24197,7 +24287,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181857+00:00"
           },
           "tenant": {
             "type": "string",
@@ -24216,7 +24306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.792990+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24230,7 +24320,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204659+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181877+00:00"
           },
           "uid": {
             "type": "string",
@@ -24249,7 +24339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793020+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24264,7 +24354,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204686+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181912+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -24346,7 +24436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:55.793112+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287428+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24362,7 +24452,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204723+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181948+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24416,23 +24506,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.793153+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287447+00:00"
               },
               "deterministic": true
             },
@@ -24445,7 +24535,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204769+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.181993+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24462,16 +24552,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.793187+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287463+00:00"
               },
               "deterministic": true
             },
@@ -24484,7 +24579,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204797+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182014+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -24529,7 +24624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793240+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24557,7 +24652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793288+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24585,7 +24680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793342+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24614,7 +24709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793387+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24641,7 +24736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793417+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24655,7 +24750,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204870+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182072+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -24671,7 +24766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793458+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24780,7 +24875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793512+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24792,7 +24887,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204927+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182111+00:00"
           },
           "status": {
             "type": "string",
@@ -24810,7 +24905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793553+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24822,7 +24917,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.204954+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182128+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -24864,7 +24959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793605+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24891,7 +24986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793652+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24918,7 +25013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793696+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24946,7 +25041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793747+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25011,7 +25106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793816+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25060,7 +25155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793871+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25073,7 +25168,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.205068+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182246+00:00"
           },
           "uid": {
             "type": "string",
@@ -25092,7 +25187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793900+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25106,7 +25201,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.205094+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182275+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -25156,7 +25251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.793936+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25168,7 +25263,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.205122+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182298+00:00"
           },
           "name": {
             "type": "string",
@@ -25185,23 +25280,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.793970+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287826+00:00"
               },
               "deterministic": true
             },
@@ -25214,7 +25309,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.205148+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182331+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25231,16 +25326,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:55.794002+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:22.287842+00:00"
               },
               "deterministic": true
             },
@@ -25253,7 +25353,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.205173+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182362+00:00"
           },
           "uid": {
             "type": "string",
@@ -25270,7 +25370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:55.794031+00:00"
+                "validatedAt": "2026-05-05T18:44:22.287855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25284,7 +25384,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.205200+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.182383+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -25391,7 +25491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.241001+00:00"
+                "validatedAt": "2026-05-05T18:44:25.354851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25449,23 +25549,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241097+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.354885+00:00"
               },
               "deterministic": true
             },
@@ -25478,7 +25578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348384+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.253824+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25494,16 +25594,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241149+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.354903+00:00"
               },
               "deterministic": true
             },
@@ -25516,7 +25621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348414+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.253841+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25619,7 +25724,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348508+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.253894+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -25703,7 +25808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.241365+00:00"
+                "validatedAt": "2026-05-05T18:44:25.354960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25751,7 +25856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.241426+00:00"
+                "validatedAt": "2026-05-05T18:44:25.354986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25830,7 +25935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:02.241487+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25893,7 +25998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:02.241555+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25905,7 +26010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348711+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254012+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -25956,23 +26061,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241596+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355061+00:00"
               },
               "deterministic": true
             },
@@ -25985,7 +26090,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348774+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254050+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26000,16 +26105,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241631+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355077+00:00"
               },
               "deterministic": true
             },
@@ -26022,7 +26132,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348801+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254066+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26061,7 +26171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.241687+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26074,7 +26184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348852+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254098+00:00"
           },
           "uid": {
             "type": "string",
@@ -26092,7 +26202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.241718+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26106,7 +26216,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348882+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254114+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_asn_prefix is returned in 'List'.",
@@ -26268,23 +26378,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241792+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355146+00:00"
               },
               "deterministic": true
             },
@@ -26297,7 +26407,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348960+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254161+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26320,16 +26430,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241829+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355163+00:00"
               },
               "deterministic": true
             },
@@ -26342,7 +26457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.348986+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254177+00:00"
           }
         },
         "x-f5xc-description-short": "Request to update infraprotect ASN irr override status.",
@@ -26398,23 +26513,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241868+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355180+00:00"
               },
               "deterministic": true
             },
@@ -26427,7 +26542,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254195+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26450,16 +26565,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241904+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355197+00:00"
               },
               "deterministic": true
             },
@@ -26472,7 +26592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349045+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254211+00:00"
           },
           "review_type_approved": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -26542,7 +26662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.241944+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26555,7 +26675,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349103+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254245+00:00"
           },
           "name": {
             "type": "string",
@@ -26572,23 +26692,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.241977+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355230+00:00"
               },
               "deterministic": true
             },
@@ -26601,7 +26721,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349130+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254261+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26618,16 +26738,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:02.242009+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:25.355247+00:00"
               },
               "deterministic": true
             },
@@ -26640,7 +26765,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349156+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254277+00:00"
           },
           "tenant": {
             "type": "string",
@@ -26659,7 +26784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.242048+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26673,7 +26798,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349181+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254293+00:00"
           },
           "uid": {
             "type": "string",
@@ -26692,7 +26817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:02.242078+00:00"
+                "validatedAt": "2026-05-05T18:44:25.355279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26707,7 +26832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.349208+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.254309+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -26810,7 +26935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.321691+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26862,7 +26987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.321766+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26925,23 +27050,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:04.321816+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:26.335324+00:00"
               },
               "deterministic": true
             },
@@ -26954,7 +27079,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390237+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276449+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26970,16 +27095,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:04.321853+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:26.335342+00:00"
               },
               "deterministic": true
             },
@@ -26992,7 +27122,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390266+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276465+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27095,7 +27225,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390365+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276518+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -27148,7 +27278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.321973+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27184,7 +27314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.322020+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27251,7 +27381,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:04.322074+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27314,7 +27444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:04.322137+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27326,7 +27456,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390467+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276574+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27377,23 +27507,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:04.322178+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:26.335489+00:00"
               },
               "deterministic": true
             },
@@ -27406,7 +27536,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390531+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276611+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27421,16 +27551,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:04.322212+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:26.335506+00:00"
               },
               "deterministic": true
             },
@@ -27443,7 +27578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390558+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276633+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27482,7 +27617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.322266+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27495,7 +27630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390611+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276664+00:00"
           },
           "uid": {
             "type": "string",
@@ -27513,7 +27648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.322296+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27527,7 +27662,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.390643+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.276680+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_deny_list_rule is returned in 'List'.",
@@ -27623,7 +27758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.322377+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27675,7 +27810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:04.322424+00:00"
+                "validatedAt": "2026-05-05T18:44:26.335592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27856,7 +27991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.580824+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27924,7 +28059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.580941+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28016,23 +28151,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:08.581019+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:28.343511+00:00"
               },
               "deterministic": true
             },
@@ -28045,7 +28180,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.465403+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.320720+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28061,16 +28196,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:08.581070+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:28.343528+00:00"
               },
               "deterministic": true
             },
@@ -28083,7 +28223,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.465433+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.320737+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28186,7 +28326,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.465526+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.320789+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -28254,7 +28394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581213+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28322,7 +28462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581278+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28714,7 +28854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:08.581390+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28777,7 +28917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:08.581454+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28789,7 +28929,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.465932+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321024+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -28840,23 +28980,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:08.581496+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:28.343711+00:00"
               },
               "deterministic": true
             },
@@ -28869,7 +29009,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.465994+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321061+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28884,16 +29024,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:08.581530+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:28.343729+00:00"
               },
               "deterministic": true
             },
@@ -28906,7 +29051,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.466021+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321076+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -28945,7 +29090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581583+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28958,7 +29103,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.466073+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321107+00:00"
           },
           "uid": {
             "type": "string",
@@ -28976,7 +29121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581614+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28990,7 +29135,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.466101+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321123+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_rule is returned in 'List'.",
@@ -29101,7 +29246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581678+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29169,7 +29314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581739+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29308,7 +29453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:08.581826+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29320,7 +29465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.466367+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321283+00:00"
           },
           "destination_port_all": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -29346,7 +29491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581883+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29383,7 +29528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.581936+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29440,7 +29585,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:08.581993+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29452,7 +29597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.466432+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.321320+00:00"
           },
           "destination_port_all": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -29478,7 +29623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.582050+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29515,7 +29660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:08.582103+00:00"
+                "validatedAt": "2026-05-05T18:44:28.343997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29629,7 +29774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:14.424044+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107571+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29687,23 +29832,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:14.424118+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:31.107620+00:00"
               },
               "deterministic": true
             },
@@ -29716,7 +29861,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.549805+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367425+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29732,16 +29877,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:14.424156+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:31.107639+00:00"
               },
               "deterministic": true
             },
@@ -29754,7 +29904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.549835+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367442+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29857,7 +30007,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.549925+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367495+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -29911,7 +30061,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:14.424287+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29946,7 +30096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:14.424361+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30012,7 +30162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:14.424417+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30075,7 +30225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:14.424484+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30087,7 +30237,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.550013+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367551+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -30138,23 +30288,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:14.424528+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:31.107802+00:00"
               },
               "deterministic": true
             },
@@ -30167,7 +30317,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.550078+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367589+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30182,16 +30332,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:14.424562+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:31.107819+00:00"
               },
               "deterministic": true
             },
@@ -30204,7 +30359,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.550106+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367605+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -30243,7 +30398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:14.424618+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30256,7 +30411,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.550157+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367643+00:00"
           },
           "uid": {
             "type": "string",
@@ -30274,7 +30429,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:14.424650+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30288,7 +30443,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.550185+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.367684+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_rule_group is returned in 'List'.",
@@ -30385,7 +30540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:14.424713+00:00"
+                "validatedAt": "2026-05-05T18:44:31.107890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30488,7 +30643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.250806+00:00"
+                "validatedAt": "2026-05-05T18:44:32.437705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30516,7 +30671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.250846+00:00"
+                "validatedAt": "2026-05-05T18:44:32.437725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30541,7 +30696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.250881+00:00"
+                "validatedAt": "2026-05-05T18:44:32.437742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30592,7 +30747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.251239+00:00"
+                "validatedAt": "2026-05-05T18:44:32.437903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30636,7 +30791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.251292+00:00"
+                "validatedAt": "2026-05-05T18:44:32.437926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30713,7 +30868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.251847+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30760,7 +30915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.251888+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30807,7 +30962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.251931+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30854,7 +31009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.251972+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30901,7 +31056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252014+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30948,7 +31103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252056+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30995,7 +31150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252096+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31042,7 +31197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252137+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31088,7 +31243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252179+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31135,7 +31290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252221+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31182,7 +31337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252263+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31228,7 +31383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252305+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31275,7 +31430,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252357+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31322,7 +31477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252399+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31369,7 +31524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252441+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31416,7 +31571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252484+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31463,7 +31618,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252527+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438490+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31510,7 +31665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252569+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31557,7 +31712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252610+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31604,7 +31759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252652+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31651,7 +31806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252692+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31698,7 +31853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252733+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31745,7 +31900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252773+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31791,7 +31946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252815+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31838,7 +31993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252858+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31885,7 +32040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252899+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31932,7 +32087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252939+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31979,7 +32134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.252980+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32026,7 +32181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.253020+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32073,7 +32228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:17.253061+00:00"
+                "validatedAt": "2026-05-05T18:44:32.438745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32320,7 +32475,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.690192+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.444094+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -32378,7 +32533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:19.355855+00:00"
+                "validatedAt": "2026-05-05T18:44:33.458865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32451,7 +32606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:19.355923+00:00"
+                "validatedAt": "2026-05-05T18:44:33.458896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32514,7 +32669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:19.356001+00:00"
+                "validatedAt": "2026-05-05T18:44:33.458929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32526,7 +32681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.690298+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.444151+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32577,23 +32732,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:19.356050+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:33.458950+00:00"
               },
               "deterministic": true
             },
@@ -32606,7 +32761,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.690373+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.444189+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32621,16 +32776,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:19.356089+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:33.458968+00:00"
               },
               "deterministic": true
             },
@@ -32643,7 +32803,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.690400+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.444205+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32682,7 +32842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:19.356149+00:00"
+                "validatedAt": "2026-05-05T18:44:33.458994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32695,7 +32855,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.690451+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.444236+00:00"
           },
           "uid": {
             "type": "string",
@@ -32713,7 +32873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:19.356181+00:00"
+                "validatedAt": "2026-05-05T18:44:33.459010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32727,7 +32887,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.690481+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.444252+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_firewall_ruleset is returned in 'List'.",
@@ -32828,7 +32988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:19.356245+00:00"
+                "validatedAt": "2026-05-05T18:44:33.459041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32986,7 +33146,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.755917+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.480583+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33035,7 +33195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:23.363797+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33108,7 +33268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:23.363902+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33155,7 +33315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:23.363954+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336410+00:00"
               },
               "deterministic": true
             },
@@ -33315,7 +33475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:23.364064+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33353,7 +33513,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:23.364143+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33365,7 +33525,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.756149+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.480729+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -33384,7 +33544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:23.364195+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33435,7 +33595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:23.364238+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33447,7 +33607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.756188+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.480752+00:00"
           },
           "url": {
             "type": "string",
@@ -33485,7 +33645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:23.364340+00:00"
+                "validatedAt": "2026-05-05T18:44:35.336585+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -33653,7 +33813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.638982+00:00"
+                "validatedAt": "2026-05-05T18:44:37.350814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33690,7 +33850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.639056+00:00"
+                "validatedAt": "2026-05-05T18:44:37.350848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33751,23 +33911,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:27.639111+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:37.350872+00:00"
               },
               "deterministic": true
             },
@@ -33780,7 +33940,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.824830+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519242+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33796,16 +33956,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:27.639149+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:37.350889+00:00"
               },
               "deterministic": true
             },
@@ -33818,7 +33983,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.824859+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519259+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33921,7 +34086,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.824949+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519313+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33981,7 +34146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.639276+00:00"
+                "validatedAt": "2026-05-05T18:44:37.350941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34018,7 +34183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.639345+00:00"
+                "validatedAt": "2026-05-05T18:44:37.350964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34087,7 +34252,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:27.639405+00:00"
+                "validatedAt": "2026-05-05T18:44:37.350990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34150,7 +34315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:27.639471+00:00"
+                "validatedAt": "2026-05-05T18:44:37.351019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34162,7 +34327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519380+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34213,23 +34378,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:27.639514+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:37.351038+00:00"
               },
               "deterministic": true
             },
@@ -34242,7 +34407,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825124+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519417+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34257,16 +34422,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:27.639548+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:37.351055+00:00"
               },
               "deterministic": true
             },
@@ -34279,7 +34449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825152+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519433+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34318,7 +34488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.639603+00:00"
+                "validatedAt": "2026-05-05T18:44:37.351079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34331,7 +34501,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825202+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519464+00:00"
           },
           "uid": {
             "type": "string",
@@ -34349,7 +34519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.639635+00:00"
+                "validatedAt": "2026-05-05T18:44:37.351093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34363,7 +34533,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519480+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_internet_prefix_advertisement is returned in 'List'.",
@@ -34466,7 +34636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:27.639697+00:00"
+                "validatedAt": "2026-05-05T18:44:37.351119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34585,23 +34755,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:27.639771+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:37.351151+00:00"
               },
               "deterministic": true
             },
@@ -34614,7 +34784,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825368+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519557+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34637,16 +34807,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:27.639809+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:37.351169+00:00"
               },
               "deterministic": true
             },
@@ -34659,7 +34834,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.825394+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.519573+00:00"
           }
         },
         "x-f5xc-description-short": "Request to toggle Internet prefix advertisement announcement/withdrawal.",
@@ -34936,23 +35111,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:53.319283+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:53.917759+00:00"
               },
               "deterministic": true
             },
@@ -34965,7 +35140,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158265+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225440+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34981,16 +35156,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:53.319357+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:53.917780+00:00"
               },
               "deterministic": true
             },
@@ -35003,7 +35183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225456+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35106,7 +35286,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158397+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225508+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35176,7 +35356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319579+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35204,7 +35384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319642+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35228,7 +35408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319693+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35256,7 +35436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319753+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35284,7 +35464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319809+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35333,7 +35513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319857+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917962+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35435,7 +35615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319923+00:00"
+                "validatedAt": "2026-05-05T18:45:53.917990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35515,7 +35695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.319986+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35578,7 +35758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.320047+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35633,7 +35813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.320106+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35762,7 +35942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:53.320161+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35825,7 +36005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:53.320227+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35837,7 +36017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158754+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225728+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35887,23 +36067,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:53.320270+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:53.918144+00:00"
               },
               "deterministic": true
             },
@@ -35916,7 +36096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158817+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225766+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35931,16 +36111,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:53.320302+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:53.918161+00:00"
               },
               "deterministic": true
             },
@@ -35953,7 +36138,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158844+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225781+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -35992,7 +36177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.320374+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36005,7 +36190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158894+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225815+00:00"
           },
           "uid": {
             "type": "string",
@@ -36023,7 +36208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.320407+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36037,7 +36222,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.158922+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225832+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of infraprotect_tunnel is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36236,23 +36421,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:53.320521+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918251+00:00"
               },
               "deterministic": true
             },
@@ -36265,7 +36450,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.159046+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225907+00:00"
           },
           "zone1": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -36342,16 +36527,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:53.320559+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:53.918269+00:00"
               },
               "deterministic": true
             },
@@ -36364,7 +36554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.159092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.225935+00:00"
           },
           "tunnel_id": {
             "type": "string",
@@ -36389,7 +36579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:53.320609+00:00"
+                "validatedAt": "2026-05-05T18:45:53.918290+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/dns.json
+++ b/docs/specifications/api/dns.json
@@ -13238,7 +13238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.009444+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13273,7 +13273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.009526+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13316,7 +13316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.009585+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13425,23 +13425,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.009644+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.162363+00:00"
               },
               "deterministic": true
             },
@@ -13454,7 +13454,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.758813+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627717+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13470,16 +13470,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.009681+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.162381+00:00"
               },
               "deterministic": true
             },
@@ -13492,7 +13497,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.758845+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627738+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13725,7 +13730,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.758938+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627806+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -13783,7 +13788,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.009811+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13818,7 +13823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.009874+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13861,7 +13866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.009933+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13944,7 +13949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:13.010002+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14007,7 +14012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:13.010072+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14019,7 +14024,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759046+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627884+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14069,23 +14074,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.010113+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.162583+00:00"
               },
               "deterministic": true
             },
@@ -14098,7 +14103,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627930+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14113,16 +14118,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.010145+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.162600+00:00"
               },
               "deterministic": true
             },
@@ -14135,7 +14145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759136+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627948+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14174,7 +14184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010202+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14187,7 +14197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759187+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.627986+00:00"
           },
           "uid": {
             "type": "string",
@@ -14205,7 +14215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010234+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162648+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14219,7 +14229,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759218+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628005+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_compliance_checks is returned in 'List'.",
@@ -14320,7 +14330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.010301+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14355,7 +14365,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.010373+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14398,7 +14408,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.010433+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14509,7 +14519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010501+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14522,7 +14532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759356+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628086+00:00"
           },
           "name": {
             "type": "string",
@@ -14539,23 +14549,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.010537+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.162797+00:00"
               },
               "deterministic": true
             },
@@ -14568,7 +14578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628105+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14585,16 +14595,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.010569+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.162813+00:00"
               },
               "deterministic": true
             },
@@ -14607,7 +14622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759407+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628124+00:00"
           },
           "tenant": {
             "type": "string",
@@ -14626,7 +14641,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010609+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14640,7 +14655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759433+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628144+00:00"
           },
           "uid": {
             "type": "string",
@@ -14659,7 +14674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010639+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14674,7 +14689,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759460+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628164+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -14712,7 +14727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010684+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14735,7 +14750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010724+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14747,7 +14762,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759500+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628189+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -14793,7 +14808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.010763+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162905+00:00"
               },
               "deterministic": true
             },
@@ -14819,7 +14834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010814+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14846,7 +14861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010858+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14858,7 +14873,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759547+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628224+00:00"
           },
           "service_name": {
             "type": "string",
@@ -14875,7 +14890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010906+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162967+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14908,7 +14923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010954+00:00"
+                "validatedAt": "2026-05-05T18:42:02.162988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14920,7 +14935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759583+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628251+00:00"
           },
           "type": {
             "type": "string",
@@ -14945,7 +14960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.010993+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15033,7 +15048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011039+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15079,23 +15094,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011074+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163043+00:00"
               },
               "deterministic": true
             },
@@ -15108,7 +15123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759649+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628295+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -15226,7 +15241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.011182+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163097+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15242,7 +15257,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759707+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628336+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15296,23 +15311,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011229+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163121+00:00"
               },
               "deterministic": true
             },
@@ -15325,7 +15340,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759755+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628371+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15342,16 +15357,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011263+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163137+00:00"
               },
               "deterministic": true
             },
@@ -15364,7 +15384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759800+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628389+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -15446,7 +15466,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.011369+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163183+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15462,7 +15482,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759863+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628419+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15518,23 +15538,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011411+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163203+00:00"
               },
               "deterministic": true
             },
@@ -15547,7 +15567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759930+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628451+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15564,16 +15584,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011442+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163219+00:00"
               },
               "deterministic": true
             },
@@ -15586,7 +15611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759956+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628470+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -15668,7 +15693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.011534+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163263+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15684,7 +15709,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.759994+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628498+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -15738,23 +15763,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011573+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163282+00:00"
               },
               "deterministic": true
             },
@@ -15767,7 +15792,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760039+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628529+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15784,16 +15809,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.011604+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163299+00:00"
               },
               "deterministic": true
             },
@@ -15806,7 +15836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760064+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628553+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -15851,7 +15881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011657+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15879,7 +15909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011706+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15907,7 +15937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011751+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15936,7 +15966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011796+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15963,7 +15993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011826+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15977,7 +16007,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760135+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628608+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -15993,7 +16023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011865+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16102,7 +16132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011921+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16114,7 +16144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628654+00:00"
           },
           "status": {
             "type": "string",
@@ -16132,7 +16162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.011960+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16144,7 +16174,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760221+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628673+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -16186,7 +16216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012013+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16213,7 +16243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012060+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16240,7 +16270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012104+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16268,7 +16298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012154+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16333,7 +16363,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012227+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16382,7 +16412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012282+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16395,7 +16425,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760347+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628745+00:00"
           },
           "uid": {
             "type": "string",
@@ -16414,7 +16444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012312+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163622+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16428,7 +16458,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760376+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628762+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -16478,7 +16508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012359+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16490,7 +16520,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760403+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628779+00:00"
           },
           "name": {
             "type": "string",
@@ -16507,23 +16537,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.012394+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163657+00:00"
               },
               "deterministic": true
             },
@@ -16536,7 +16566,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760428+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628795+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16553,16 +16583,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:13.012428+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:02.163672+00:00"
               },
               "deterministic": true
             },
@@ -16575,7 +16610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760456+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628815+00:00"
           },
           "uid": {
             "type": "string",
@@ -16592,7 +16627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:13.012458+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16606,7 +16641,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760482+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628832+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -16659,23 +16694,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.012529+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163720+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16691,7 +16726,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760509+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628850+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16714,16 +16749,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.012590+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163755+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -16739,7 +16779,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760534+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628866+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16768,7 +16808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:13.012657+00:00"
+                "validatedAt": "2026-05-05T18:42:02.163789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16782,7 +16822,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:08.760560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.628882+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -16938,23 +16978,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:50.447045+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:20.550403+00:00"
               },
               "deterministic": true
             },
@@ -16967,7 +17007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952484+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.292851+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16983,16 +17023,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:50.447090+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:20.550426+00:00"
               },
               "deterministic": true
             },
@@ -17005,7 +17050,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952515+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.292867+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17108,7 +17153,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952607+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.292920+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -17222,7 +17267,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.447235+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17289,7 +17334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:08:50.447305+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550527+00:00"
               },
               "deterministic": true
             },
@@ -17330,7 +17375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:08:50.447360+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550565+00:00"
               },
               "deterministic": true
             },
@@ -17466,7 +17511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:50.447433+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17528,7 +17573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:50.447497+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17540,7 +17585,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952765+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.293009+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17590,23 +17635,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:50.447539+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:20.550685+00:00"
               },
               "deterministic": true
             },
@@ -17619,7 +17664,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952829+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.293046+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17634,16 +17679,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:50.447572+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:20.550702+00:00"
               },
               "deterministic": true
             },
@@ -17656,7 +17706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952855+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.293062+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17695,7 +17745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:50.447626+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17708,7 +17758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952909+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.293249+00:00"
           },
           "uid": {
             "type": "string",
@@ -17725,7 +17775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:50.447656+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17739,7 +17789,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.952936+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.293266+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_proxy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17812,7 +17862,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.447723+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18165,7 +18215,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.447842+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18205,7 +18255,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.447923+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18301,7 +18351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.448010+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18336,7 +18386,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.448081+00:00"
+                "validatedAt": "2026-05-05T18:42:20.550955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18437,7 +18487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:50.448312+00:00"
+                "validatedAt": "2026-05-05T18:42:20.551066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18505,7 +18555,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.448385+00:00"
+                "validatedAt": "2026-05-05T18:42:20.551098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18580,7 +18630,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.448461+00:00"
+                "validatedAt": "2026-05-05T18:42:20.551139+00:00"
               },
               "deterministic": true
             },
@@ -18698,7 +18748,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450311+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552062+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18784,7 +18834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450398+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18910,7 +18960,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450459+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18985,7 +19035,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450712+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19050,7 +19100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450773+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19137,7 +19187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450831+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19302,7 +19352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450889+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19375,7 +19425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.450932+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552385+00:00"
               },
               "deterministic": true
             },
@@ -19422,7 +19472,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.451013+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19545,7 +19595,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.451096+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19580,7 +19630,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.451168+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19675,7 +19725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:50.451228+00:00"
+                "validatedAt": "2026-05-05T18:42:20.552533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19984,7 +20034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.069499+00:00"
+                "validatedAt": "2026-05-05T18:42:46.756809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20007,7 +20057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.069564+00:00"
+                "validatedAt": "2026-05-05T18:42:46.756837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20030,7 +20080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.069612+00:00"
+                "validatedAt": "2026-05-05T18:42:46.756860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20053,7 +20103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.069651+00:00"
+                "validatedAt": "2026-05-05T18:42:46.756879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20076,7 +20126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.069691+00:00"
+                "validatedAt": "2026-05-05T18:42:46.756899+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20112,7 +20162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:09:44.069756+00:00"
+                "validatedAt": "2026-05-05T18:42:46.756930+00:00"
               },
               "deterministic": true
             },
@@ -20191,23 +20241,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:44.069813+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:46.756955+00:00"
               },
               "deterministic": true
             },
@@ -20220,7 +20270,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106367+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20236,16 +20286,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:44.069847+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:46.756972+00:00"
               },
               "deterministic": true
             },
@@ -20258,7 +20313,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436142+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106388+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20361,7 +20416,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436229+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106452+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20411,7 +20466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.069953+00:00"
+                "validatedAt": "2026-05-05T18:42:46.757017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20424,7 +20479,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436280+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106490+00:00"
           },
           "txt_record": {
             "type": "string",
@@ -20439,7 +20494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.070002+00:00"
+                "validatedAt": "2026-05-05T18:42:46.757040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20511,7 +20566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:44.070056+00:00"
+                "validatedAt": "2026-05-05T18:42:46.757065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20574,7 +20629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:44.070118+00:00"
+                "validatedAt": "2026-05-05T18:42:46.757094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20586,7 +20641,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436371+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106541+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20636,23 +20691,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:44.070156+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:46.757112+00:00"
               },
               "deterministic": true
             },
@@ -20665,7 +20720,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436433+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106598+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20680,16 +20735,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:44.070189+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:46.757128+00:00"
               },
               "deterministic": true
             },
@@ -20702,7 +20762,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436459+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106625+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -20741,7 +20801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.070243+00:00"
+                "validatedAt": "2026-05-05T18:42:46.757152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20754,7 +20814,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436511+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106662+00:00"
           },
           "uid": {
             "type": "string",
@@ -20771,7 +20831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:44.070271+00:00"
+                "validatedAt": "2026-05-05T18:42:46.757166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20785,7 +20845,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436541+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106680+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_domain is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -20965,23 +21025,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:44.070365+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:46.757198+00:00"
               },
               "deterministic": true
             },
@@ -20994,7 +21054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436646+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106746+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21010,16 +21070,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:44.070398+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:46.757214+00:00"
               },
               "deterministic": true
             },
@@ -21032,7 +21097,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.436673+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.106763+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21177,7 +21242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:46.454213+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21239,23 +21304,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.454311+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.869756+00:00"
               },
               "deterministic": true
             },
@@ -21268,7 +21333,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482219+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133175+00:00"
           },
           "status": {
             "type": "array",
@@ -21288,7 +21353,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482249+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133192+00:00"
           }
         },
         "x-f5xc-description-short": "Individual item in a collection of DNS Load Balancer.",
@@ -21346,7 +21411,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482287+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133215+00:00"
           }
         },
         "x-f5xc-description-short": "Response for DNS Load Balancer Health Status Request.",
@@ -21402,7 +21467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454437+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21425,23 +21490,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.454473+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.869821+00:00"
               },
               "deterministic": true
             },
@@ -21454,7 +21519,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482345+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133243+00:00"
           },
           "status": {
             "type": "array",
@@ -21475,7 +21540,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482372+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133260+00:00"
           }
         },
         "x-f5xc-description-short": "Individual item in a collection of DNS Load Balancer Pool.",
@@ -21536,7 +21601,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482413+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133282+00:00"
           }
         },
         "x-f5xc-description-short": "Response for DNS Load Balancer Pool Health Status Request.",
@@ -21579,7 +21644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454564+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21604,7 +21669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454617+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21632,7 +21697,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482469+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133315+00:00"
           }
         },
         "x-f5xc-description-short": "Pool member health status change event data.",
@@ -21677,7 +21742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:46.454667+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21724,7 +21789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454715+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21749,7 +21814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454765+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21778,7 +21843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454818+00:00"
+                "validatedAt": "2026-05-05T18:42:47.869978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21804,7 +21869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.454868+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21831,23 +21896,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.454904+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.870017+00:00"
               },
               "deterministic": true
             },
@@ -21860,7 +21925,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133371+00:00"
           },
           "ports": {
             "type": "array",
@@ -21889,7 +21954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.454965+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21918,7 +21983,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482597+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133392+00:00"
           },
           "unhealthy_ports": {
             "type": "array",
@@ -21946,7 +22011,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.455035+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22051,23 +22116,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.455094+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.870111+00:00"
               },
               "deterministic": true
             },
@@ -22080,7 +22145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482657+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133426+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22096,16 +22161,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.455128+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.870127+00:00"
               },
               "deterministic": true
             },
@@ -22118,7 +22188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482683+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133442+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22221,7 +22291,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482774+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133495+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22354,7 +22424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:46.455247+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22417,7 +22487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:46.455312+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22429,7 +22499,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482867+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133548+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22479,23 +22549,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.455364+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.870230+00:00"
               },
               "deterministic": true
             },
@@ -22508,7 +22578,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482935+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133586+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22523,16 +22593,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.455397+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.870246+00:00"
               },
               "deterministic": true
             },
@@ -22545,7 +22620,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.482963+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133632+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22584,7 +22659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.455450+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22597,7 +22672,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.483016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133668+00:00"
           },
           "uid": {
             "type": "string",
@@ -22615,7 +22690,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.455480+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22629,7 +22704,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.483044+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133686+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_load_balancer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22772,7 +22847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.455578+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870332+00:00"
               },
               "deterministic": true
             },
@@ -23013,7 +23088,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.455713+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23047,7 +23122,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.455790+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23071,16 +23146,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:46.455825+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:47.870451+00:00"
               },
               "deterministic": true
             },
@@ -23093,7 +23173,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.483252+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.133814+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -23189,7 +23269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.456049+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23248,7 +23328,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.456100+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23319,7 +23399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.456160+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23397,7 +23477,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.456217+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23544,7 +23624,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:46.456715+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23609,7 +23689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.456765+00:00"
+                "validatedAt": "2026-05-05T18:42:47.870913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23621,7 +23701,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.483726+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.134149+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -23689,7 +23769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:46.457996+00:00"
+                "validatedAt": "2026-05-05T18:42:47.871483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23701,7 +23781,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.484385+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.134552+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -23719,7 +23799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.458043+00:00"
+                "validatedAt": "2026-05-05T18:42:47.871503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23747,7 +23827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.458080+00:00"
+                "validatedAt": "2026-05-05T18:42:47.871521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23759,7 +23839,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.484429+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.134579+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -24021,7 +24101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:46.458294+00:00"
+                "validatedAt": "2026-05-05T18:42:47.871627+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24070,7 +24150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:46.458359+00:00"
+                "validatedAt": "2026-05-05T18:42:47.871652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24082,7 +24162,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.484725+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.134763+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -24100,7 +24180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:46.458401+00:00"
+                "validatedAt": "2026-05-05T18:42:47.871672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24264,23 +24344,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:52.700413+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:50.969087+00:00"
               },
               "deterministic": true
             },
@@ -24293,7 +24373,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606196+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210449+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24309,16 +24389,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:52.700457+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:50.969112+00:00"
               },
               "deterministic": true
             },
@@ -24331,7 +24416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606226+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210465+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24434,7 +24519,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606317+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210518+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -24606,7 +24691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.700673+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24638,7 +24723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.700736+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24721,7 +24806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:52.700789+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969268+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24784,7 +24869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:52.700855+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24796,7 +24881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606500+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210622+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24846,23 +24931,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:52.700897+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:50.969317+00:00"
               },
               "deterministic": true
             },
@@ -24875,7 +24960,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606565+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210660+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24890,16 +24975,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:52.700930+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:50.969333+00:00"
               },
               "deterministic": true
             },
@@ -24912,7 +25002,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606593+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210676+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -24951,7 +25041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:52.700985+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24964,7 +25054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606643+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210707+00:00"
           },
           "uid": {
             "type": "string",
@@ -24982,7 +25072,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:52.701017+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24996,7 +25086,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.606673+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.210723+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_lb_health_check is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25250,7 +25340,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.701166+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25283,7 +25373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.701232+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25409,7 +25499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.701356+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25445,7 +25535,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.701421+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25576,7 +25666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.701533+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25614,7 +25704,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:52.701598+00:00"
+                "validatedAt": "2026-05-05T18:42:50.969660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25720,7 +25810,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058296+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064055+00:00"
               },
               "deterministic": true
             },
@@ -25817,7 +25907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058419+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064107+00:00"
               },
               "deterministic": true
             },
@@ -25894,7 +25984,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058507+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25923,23 +26013,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058576+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064186+00:00"
               },
               "deterministic": true
             },
@@ -25952,7 +26042,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.686902+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254339+00:00"
           },
           "priority": {
             "type": "integer",
@@ -25980,7 +26070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:57.058622+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26066,7 +26156,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058708+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26079,7 +26169,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.686955+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254368+00:00"
           },
           "final_translation": {
             "type": "boolean",
@@ -26114,23 +26204,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058779+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064285+00:00"
               },
               "deterministic": true
             },
@@ -26143,7 +26233,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.686994+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254390+00:00"
           },
           "ratio": {
             "type": "integer",
@@ -26223,7 +26313,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.058870+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064329+00:00"
               },
               "deterministic": true
             },
@@ -26413,23 +26503,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:57.058932+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:53.064357+00:00"
               },
               "deterministic": true
             },
@@ -26442,7 +26532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687164+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254503+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26458,16 +26548,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:57.058965+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:53.064375+00:00"
               },
               "deterministic": true
             },
@@ -26480,7 +26575,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687192+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254522+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26583,7 +26678,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687282+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254574+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26743,7 +26838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:57.059106+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26806,7 +26901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:57.059168+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26818,7 +26913,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687443+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254667+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26868,23 +26963,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:57.059205+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:53.064481+00:00"
               },
               "deterministic": true
             },
@@ -26897,7 +26992,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687510+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254706+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26912,16 +27007,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:57.059236+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:53.064497+00:00"
               },
               "deterministic": true
             },
@@ -26934,7 +27034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687535+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254722+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26973,7 +27073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:57.059290+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26986,7 +27086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687586+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254755+00:00"
           },
           "uid": {
             "type": "string",
@@ -27003,7 +27103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:57.059333+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27017,7 +27117,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687614+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254771+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_lb_pool is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27105,7 +27205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059401+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27118,7 +27218,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687646+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254789+00:00"
           },
           "name": {
             "type": "string",
@@ -27139,23 +27239,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059465+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064604+00:00"
               },
               "deterministic": true
             },
@@ -27168,7 +27268,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687672+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254805+00:00"
           },
           "priority": {
             "type": "integer",
@@ -27195,7 +27295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:57.059505+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27310,7 +27410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059609+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064692+00:00"
               },
               "deterministic": true
             },
@@ -27493,23 +27593,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059693+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064734+00:00"
               },
               "deterministic": true
             },
@@ -27522,7 +27622,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.687837+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.254902+00:00"
           },
           "port": {
             "type": "integer",
@@ -27555,7 +27655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059727+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064752+00:00"
               },
               "deterministic": true
             },
@@ -27595,7 +27695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:57.059767+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27655,7 +27755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059865+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27694,7 +27794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:57.059905+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27789,7 +27889,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:57.059998+00:00"
+                "validatedAt": "2026-05-05T18:42:53.064887+00:00"
               },
               "deterministic": true
             },
@@ -27931,7 +28031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011242+00:00"
+                "validatedAt": "2026-05-05T18:42:58.068974+00:00"
               },
               "deterministic": true
             },
@@ -28066,7 +28166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011392+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069042+00:00"
               },
               "deterministic": true
             },
@@ -28126,18 +28226,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011477+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069092+00:00"
               },
               "deterministic": true
             },
@@ -28150,7 +28250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906431+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380145+00:00"
           },
           "values": {
             "type": "array",
@@ -28184,7 +28284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011539+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28291,7 +28391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.011591+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069150+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28327,7 +28427,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011664+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069187+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28338,7 +28438,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906490+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380178+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28376,7 +28476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.011709+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28389,7 +28489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906523+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380195+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28572,18 +28672,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011826+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069267+00:00"
               },
               "deterministic": true
             },
@@ -28596,7 +28696,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906640+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380261+00:00"
           },
           "values": {
             "type": "array",
@@ -28635,7 +28735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011886+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28692,18 +28792,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.011964+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069339+00:00"
               },
               "deterministic": true
             },
@@ -28716,7 +28816,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906678+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380283+00:00"
           },
           "values": {
             "type": "array",
@@ -28750,7 +28850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012013+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28806,18 +28906,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012083+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069407+00:00"
               },
               "deterministic": true
             },
@@ -28830,7 +28930,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906715+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380305+00:00"
           },
           "values": {
             "type": "array",
@@ -28869,7 +28969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012140+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28924,7 +29024,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012209+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28936,7 +29036,7 @@
             "x-original-maxLength": 255,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906753+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380327+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28982,18 +29082,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012287+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069514+00:00"
               },
               "deterministic": true
             },
@@ -29006,7 +29106,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906781+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380344+00:00"
           },
           "values": {
             "type": "array",
@@ -29031,7 +29131,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012346+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29087,18 +29187,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012420+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069585+00:00"
               },
               "deterministic": true
             },
@@ -29111,7 +29211,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906819+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380366+00:00"
           },
           "values": {
             "type": "array",
@@ -29143,7 +29243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012475+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29202,18 +29302,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012552+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069665+00:00"
               },
               "deterministic": true
             },
@@ -29226,7 +29326,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906856+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380388+00:00"
           },
           "value": {
             "type": "string",
@@ -29253,7 +29353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012617+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29265,7 +29365,7 @@
             "x-original-maxLength": 255,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906883+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380403+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29313,18 +29413,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012692+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069737+00:00"
               },
               "deterministic": true
             },
@@ -29337,7 +29437,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906911+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380420+00:00"
           },
           "values": {
             "type": "array",
@@ -29369,7 +29469,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012746+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29451,18 +29551,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012818+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069806+00:00"
               },
               "deterministic": true
             },
@@ -29475,7 +29575,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906951+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380442+00:00"
           },
           "value": {
             "type": "string",
@@ -29509,7 +29609,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012894+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29520,7 +29620,7 @@
             },
             "x-original-maxLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.906977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380458+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29569,18 +29669,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.012969+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069889+00:00"
               },
               "deterministic": true
             },
@@ -29593,7 +29693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907005+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380474+00:00"
           },
           "value": {
             "type": "string",
@@ -29627,7 +29727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013050+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29638,7 +29738,7 @@
             },
             "x-original-maxLength": 23,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907030+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380490+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29682,23 +29782,23 @@
               "category": "discovery",
               "maxLength": 255,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013106+00:00"
+                "validatedAt": "2026-05-05T18:42:58.069964+00:00"
               },
               "deterministic": true
             },
@@ -29711,7 +29811,7 @@
             "x-original-maxLength": 255,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907058+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380506+00:00"
           },
           "value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -29762,18 +29862,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013182+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070004+00:00"
               },
               "deterministic": true
             },
@@ -29786,7 +29886,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907096+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380527+00:00"
           },
           "values": {
             "type": "array",
@@ -29820,7 +29920,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013237+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29875,18 +29975,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013310+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070111+00:00"
               },
               "deterministic": true
             },
@@ -29899,7 +29999,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907135+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380549+00:00"
           },
           "values": {
             "type": "array",
@@ -29927,7 +30027,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013372+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29984,18 +30084,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013445+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070181+00:00"
               },
               "deterministic": true
             },
@@ -30008,7 +30108,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907175+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380570+00:00"
           },
           "values": {
             "type": "array",
@@ -30042,7 +30142,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013494+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30097,18 +30197,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013564+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070252+00:00"
               },
               "deterministic": true
             },
@@ -30121,7 +30221,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907212+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380592+00:00"
           },
           "values": {
             "type": "array",
@@ -30160,7 +30260,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013616+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30215,18 +30315,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013685+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070320+00:00"
               },
               "deterministic": true
             },
@@ -30239,7 +30339,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907249+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380626+00:00"
           },
           "values": {
             "type": "array",
@@ -30278,7 +30378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013737+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30419,18 +30519,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013834+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070400+00:00"
               },
               "deterministic": true
             },
@@ -30443,7 +30543,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907336+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380673+00:00"
           },
           "values": {
             "type": "array",
@@ -30477,7 +30577,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013888+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30532,18 +30632,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.013961+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070468+00:00"
               },
               "deterministic": true
             },
@@ -30556,7 +30656,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907373+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380695+00:00"
           },
           "values": {
             "type": "array",
@@ -30596,7 +30696,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.014016+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30723,7 +30823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014086+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30754,7 +30854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014130+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30785,7 +30885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014180+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30861,7 +30961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:10:07.014266+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070624+00:00"
               },
               "deterministic": true
             },
@@ -31012,23 +31112,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.014349+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:58.070657+00:00"
               },
               "deterministic": true
             },
@@ -31041,7 +31141,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907566+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380802+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31057,16 +31157,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.014383+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:58.070675+00:00"
               },
               "deterministic": true
             },
@@ -31079,7 +31184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907593+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380817+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31125,7 +31230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014429+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31152,7 +31257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014468+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31204,7 +31309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:10:07.014525+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31228,16 +31333,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.014559+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:58.070762+00:00"
               },
               "deterministic": true
             },
@@ -31250,7 +31360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907656+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380854+00:00"
           },
           "sort": {
             "$ref": "#/components/schemas/schemaSortOrder"
@@ -31278,7 +31388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014608+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31311,7 +31421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014645+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31387,7 +31497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014697+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31415,7 +31525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014742+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31470,7 +31580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014790+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31497,7 +31607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014830+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31534,7 +31644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:10:07.014872+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31558,16 +31668,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.014906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:58.070925+00:00"
               },
               "deterministic": true
             },
@@ -31580,7 +31695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907767+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380917+00:00"
           },
           "sort": {
             "$ref": "#/components/schemas/schemaSortOrder"
@@ -31608,7 +31723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.014953+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31680,7 +31795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015008+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31726,7 +31841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015059+00:00"
+                "validatedAt": "2026-05-05T18:42:58.070996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31751,7 +31866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015105+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31776,7 +31891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015154+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31801,7 +31916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015193+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31814,7 +31929,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.907860+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.380970+00:00"
           },
           "query_type": {
             "type": "string",
@@ -31831,7 +31946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015238+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31856,7 +31971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015287+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31897,7 +32012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.015349+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071126+00:00"
               },
               "deterministic": true
             },
@@ -31948,7 +32063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015394+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32049,7 +32164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015457+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32072,7 +32187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015500+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32116,7 +32231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015546+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32225,7 +32340,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908041+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381073+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -32272,7 +32387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015653+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32285,7 +32400,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908080+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381095+00:00"
           },
           "num_of_dns_records": {
             "type": "integer",
@@ -32371,7 +32486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.015751+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071313+00:00"
               },
               "deterministic": true
             },
@@ -32408,7 +32523,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.015822+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32484,7 +32599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.015881+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32496,7 +32611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908172+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381149+00:00"
           },
           "file": {
             "type": "string",
@@ -32523,7 +32638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.015919+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071394+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32640,7 +32755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.016022+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32652,7 +32767,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908239+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381187+00:00"
           },
           "file": {
             "type": "string",
@@ -32679,7 +32794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.016058+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32778,7 +32893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.016112+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32802,7 +32917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.016155+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32910,7 +33025,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.016250+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32949,7 +33064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.016311+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33036,7 +33151,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.016417+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33075,7 +33190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.016472+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33220,7 +33335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:07.016559+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33282,7 +33397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.016616+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33294,7 +33409,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908479+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381324+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33344,23 +33459,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.016655+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:58.071799+00:00"
               },
               "deterministic": true
             },
@@ -33373,7 +33488,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908545+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381359+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33388,16 +33503,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:07.016687+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:58.071817+00:00"
               },
               "deterministic": true
             },
@@ -33410,7 +33530,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908573+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381374+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -33449,7 +33569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.016738+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33462,7 +33582,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908625+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381405+00:00"
           },
           "uid": {
             "type": "string",
@@ -33479,7 +33599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.016766+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33493,7 +33613,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908652+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381421+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dns_zone is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -33574,7 +33694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.016830+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33587,7 +33707,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908685+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381438+00:00"
           },
           "priority": {
             "type": "integer",
@@ -33614,7 +33734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.016873+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33676,7 +33796,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.908734+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381466+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -33729,7 +33849,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.016974+00:00"
+                "validatedAt": "2026-05-05T18:42:58.071993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33817,7 +33937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017068+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33843,7 +33963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.017112+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33878,7 +33998,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017195+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33948,7 +34068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017257+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33989,7 +34109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017313+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34039,7 +34159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.017363+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34084,7 +34204,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017424+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34125,7 +34245,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017479+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34220,7 +34340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.017556+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34232,7 +34352,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.909005+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381635+00:00"
           },
           "ds_record": {
             "$ref": "#/components/schemas/dns_zoneDNSDSRecord"
@@ -34363,7 +34483,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017627+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34491,7 +34611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017707+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34555,7 +34675,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017791+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072482+00:00"
               },
               "deterministic": true
             },
@@ -34615,7 +34735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017858+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34679,7 +34799,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.017945+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072580+00:00"
               },
               "deterministic": true
             },
@@ -34739,7 +34859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018016+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34940,7 +35060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018132+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072690+00:00"
               },
               "deterministic": true
             },
@@ -34977,7 +35097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.018171+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35011,7 +35131,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018257+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35047,7 +35167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:07.018297+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35164,18 +35284,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018381+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072885+00:00"
               },
               "deterministic": true
             },
@@ -35188,7 +35308,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.909377+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381851+00:00"
           },
           "values": {
             "type": "array",
@@ -35222,7 +35342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018432+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072918+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35290,7 +35410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018490+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35327,7 +35447,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018565+00:00"
+                "validatedAt": "2026-05-05T18:42:58.072994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35377,7 +35497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.018621+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35420,7 +35540,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018681+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35454,7 +35574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018757+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35658,7 +35778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018889+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35726,18 +35846,18 @@
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.018964+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073194+00:00"
               },
               "deterministic": true
             },
@@ -35750,7 +35870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.909570+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.381963+00:00"
           },
           "values": {
             "type": "array",
@@ -35784,7 +35904,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.019018+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35843,7 +35963,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.019102+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35932,7 +36052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.019166+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073332+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35981,7 +36101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.019502+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36019,7 +36139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.019574+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36031,7 +36151,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.909842+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.382118+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -36050,7 +36170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.019624+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36101,7 +36221,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:07.019668+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36113,7 +36233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.909881+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.382139+00:00"
           },
           "url": {
             "type": "string",
@@ -36151,7 +36271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.019741+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073659+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -36212,7 +36332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.020180+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073897+00:00"
               },
               "deterministic": true
             },
@@ -36225,7 +36345,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.910100+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.382256+00:00"
           },
           "name": {
             "type": "string",
@@ -36253,23 +36373,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:07.020240+00:00"
+                "validatedAt": "2026-05-05T18:42:58.073929+00:00"
               },
               "deterministic": true
             },
@@ -36281,7 +36401,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.910127+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.382271+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -36429,7 +36549,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:03.628741+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36468,7 +36588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:03.628828+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36527,7 +36647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:03.628915+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36566,7 +36686,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:03.629006+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36597,7 +36717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:03.629059+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36632,7 +36752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:03.629097+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36679,7 +36799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:03.629146+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36703,7 +36823,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:03.629193+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36725,16 +36845,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:03.629227+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:26.869331+00:00"
               },
               "deterministic": true
             },
@@ -36747,7 +36872,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.161100+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.092018+00:00"
           },
           "record_name": {
             "type": "string",
@@ -36763,7 +36888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:03.629274+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869351+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36789,7 +36914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:03.629309+00:00"
+                "validatedAt": "2026-05-05T18:43:26.869367+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/index.json
+++ b/docs/specifications/api/index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.1.68",
-  "timestamp": "2026-05-05T06:23:49.765634+00:00",
+  "timestamp": "2026-05-05T18:47:28.754478+00:00",
   "specifications": [
     {
       "domain": "admin_console_and_ui",

--- a/docs/specifications/api/managed_kubernetes.json
+++ b/docs/specifications/api/managed_kubernetes.json
@@ -5943,7 +5943,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.581125+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691354+00:00"
               },
               "deterministic": true
             },
@@ -5983,7 +5983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.581207+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6018,7 +6018,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.581288+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6078,23 +6078,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.581351+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.691459+00:00"
               },
               "deterministic": true
             },
@@ -6107,7 +6107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049220+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885125+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6123,16 +6123,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.581387+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.691477+00:00"
               },
               "deterministic": true
             },
@@ -6145,7 +6150,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049251+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885142+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -6248,7 +6253,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049355+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885195+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6310,7 +6315,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.581529+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691546+00:00"
               },
               "deterministic": true
             },
@@ -6350,7 +6355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.581600+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6385,7 +6390,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.581674+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6453,7 +6458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:27.581730+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6516,7 +6521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:27.581796+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6528,7 +6533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049463+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885257+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6578,23 +6583,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.581838+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.691704+00:00"
               },
               "deterministic": true
             },
@@ -6607,7 +6612,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049529+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885294+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6622,16 +6627,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.581869+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.691721+00:00"
               },
               "deterministic": true
             },
@@ -6644,7 +6654,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049558+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885310+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -6683,7 +6693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.581925+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6696,7 +6706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049613+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885340+00:00"
           },
           "uid": {
             "type": "string",
@@ -6714,7 +6724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.581956+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6728,7 +6738,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049644+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885357+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of container_registry is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6833,7 +6843,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.582034+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691807+00:00"
               },
               "deterministic": true
             },
@@ -6873,7 +6883,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.582101+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6908,7 +6918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.582176+00:00"
+                "validatedAt": "2026-05-05T18:42:38.691950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7007,7 +7017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582252+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7030,7 +7040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582291+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7042,7 +7052,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049776+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885430+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -7085,7 +7095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582355+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7123,7 +7133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.582427+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7135,7 +7145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049815+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885452+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -7154,7 +7164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582476+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7205,7 +7215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582519+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7217,7 +7227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049854+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885474+00:00"
           },
           "url": {
             "type": "string",
@@ -7255,7 +7265,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.582590+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692214+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7312,7 +7322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.582630+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692234+00:00"
               },
               "deterministic": true
             },
@@ -7338,7 +7348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582681+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7365,7 +7375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582721+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7377,7 +7387,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049911+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885507+00:00"
           },
           "service_name": {
             "type": "string",
@@ -7394,7 +7404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582768+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7427,7 +7437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582810+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7439,7 +7449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.049949+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885527+00:00"
           },
           "type": {
             "type": "string",
@@ -7464,7 +7474,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582849+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7552,7 +7562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.582893+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7598,23 +7608,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.582929+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692382+00:00"
               },
               "deterministic": true
             },
@@ -7627,7 +7637,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050020+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885566+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -7745,7 +7755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.583037+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692443+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7761,7 +7771,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050082+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885601+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -7815,23 +7825,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583079+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692464+00:00"
               },
               "deterministic": true
             },
@@ -7844,7 +7854,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050131+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885633+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7861,16 +7871,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583110+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692480+00:00"
               },
               "deterministic": true
             },
@@ -7883,7 +7898,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050157+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885649+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -7965,7 +7980,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.583201+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692532+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -7981,7 +7996,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050198+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885673+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8037,23 +8052,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583240+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692551+00:00"
               },
               "deterministic": true
             },
@@ -8066,7 +8081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050243+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885699+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8083,16 +8098,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583271+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692567+00:00"
               },
               "deterministic": true
             },
@@ -8105,7 +8125,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050269+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885715+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -8150,7 +8170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583308+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8163,7 +8183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885732+00:00"
           },
           "name": {
             "type": "string",
@@ -8180,23 +8200,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583349+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692607+00:00"
               },
               "deterministic": true
             },
@@ -8209,7 +8229,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050331+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885747+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8226,16 +8246,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583381+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692634+00:00"
               },
               "deterministic": true
             },
@@ -8248,7 +8273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050358+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885763+00:00"
           },
           "tenant": {
             "type": "string",
@@ -8267,7 +8292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583422+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8281,7 +8306,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050384+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885778+00:00"
           },
           "uid": {
             "type": "string",
@@ -8300,7 +8325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583451+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8315,7 +8340,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050411+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885795+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -8397,7 +8422,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:27.583542+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692721+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8413,7 +8438,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885818+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8467,23 +8492,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583582+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692741+00:00"
               },
               "deterministic": true
             },
@@ -8496,7 +8521,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050494+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885845+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8513,16 +8538,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.583612+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.692756+00:00"
               },
               "deterministic": true
             },
@@ -8535,7 +8565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050520+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885860+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -8630,7 +8660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583667+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8658,7 +8688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583714+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8686,7 +8716,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583758+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8715,7 +8745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583802+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8742,7 +8772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583831+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8756,7 +8786,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050611+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885915+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -8772,7 +8802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583873+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8881,7 +8911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583931+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8893,7 +8923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050667+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885948+00:00"
           },
           "status": {
             "type": "string",
@@ -8911,7 +8941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.583971+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8923,7 +8953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050693+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.885963+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -8965,7 +8995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584023+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8992,7 +9022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584070+00:00"
+                "validatedAt": "2026-05-05T18:42:38.692982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9019,7 +9049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584114+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9047,7 +9077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584165+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693025+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9112,7 +9142,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584233+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693056+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9161,7 +9191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584288+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9174,7 +9204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050812+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.886031+00:00"
           },
           "uid": {
             "type": "string",
@@ -9193,7 +9223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584318+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9207,7 +9237,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050841+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.886048+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -9257,7 +9287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584364+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9269,7 +9299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050870+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.886064+00:00"
           },
           "name": {
             "type": "string",
@@ -9286,23 +9316,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.584398+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.693135+00:00"
               },
               "deterministic": true
             },
@@ -9315,7 +9345,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050895+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.886080+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9332,16 +9362,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:27.584430+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:38.693151+00:00"
               },
               "deterministic": true
             },
@@ -9354,7 +9389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050921+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.886095+00:00"
           },
           "uid": {
             "type": "string",
@@ -9371,7 +9406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:27.584458+00:00"
+                "validatedAt": "2026-05-05T18:42:38.693164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9385,7 +9420,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.050947+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.886111+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -9499,7 +9534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.024832+00:00"
+                "validatedAt": "2026-05-05T18:44:43.364907+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -9566,23 +9601,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:40.024897+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:43.364932+00:00"
               },
               "deterministic": true
             },
@@ -9595,7 +9630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.034686+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633143+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9611,16 +9646,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:40.024929+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:43.364949+00:00"
               },
               "deterministic": true
             },
@@ -9633,7 +9673,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.034714+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633160+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -9736,7 +9776,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.034803+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633212+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9802,7 +9842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025089+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365023+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -9876,7 +9916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:40.025141+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9939,7 +9979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:40.025208+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9951,7 +9991,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.034898+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633270+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10001,23 +10041,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:40.025249+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:43.365097+00:00"
               },
               "deterministic": true
             },
@@ -10030,7 +10070,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.034958+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633307+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10045,16 +10085,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:40.025284+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:43.365114+00:00"
               },
               "deterministic": true
             },
@@ -10067,7 +10112,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.034985+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633323+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10106,7 +10151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:40.025353+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10119,7 +10164,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.035039+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633354+00:00"
           },
           "uid": {
             "type": "string",
@@ -10137,7 +10182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:40.025386+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10151,7 +10196,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.035066+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.633371+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster_role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -10226,7 +10271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025452+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10275,7 +10320,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025510+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10342,7 +10387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025572+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10473,7 +10518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025658+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365296+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -10553,7 +10598,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025713+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10595,7 +10640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025768+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10644,7 +10689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025825+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10693,7 +10738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.025881+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10820,7 +10865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:40.026417+00:00"
+                "validatedAt": "2026-05-05T18:44:43.365675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10869,7 +10914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:44.148562+00:00"
+                "validatedAt": "2026-05-05T18:44:45.301947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10882,7 +10927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131711+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678442+00:00"
           },
           "name": {
             "type": "string",
@@ -10899,23 +10944,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:44.148630+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:45.301979+00:00"
               },
               "deterministic": true
             },
@@ -10928,7 +10973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131741+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678459+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10945,16 +10990,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:44.148668+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:45.301997+00:00"
               },
               "deterministic": true
             },
@@ -10967,7 +11017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131769+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678475+00:00"
           },
           "tenant": {
             "type": "string",
@@ -10986,7 +11036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:44.148712+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11000,7 +11050,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131796+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678491+00:00"
           },
           "uid": {
             "type": "string",
@@ -11019,7 +11069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:44.148743+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11034,7 +11084,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131824+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678508+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11153,7 +11203,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.148828+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11213,23 +11263,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:44.148873+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:45.302094+00:00"
               },
               "deterministic": true
             },
@@ -11242,7 +11292,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131930+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678572+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11258,16 +11308,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:44.148907+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:45.302112+00:00"
               },
               "deterministic": true
             },
@@ -11280,7 +11335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.131955+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678588+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11383,7 +11438,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132042+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678651+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -11452,7 +11507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.149039+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11520,7 +11575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:44.149092+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11583,7 +11638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:44.149156+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11595,7 +11650,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132130+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678703+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -11646,23 +11701,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:44.149196+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:45.302244+00:00"
               },
               "deterministic": true
             },
@@ -11675,7 +11730,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678740+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11690,16 +11745,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:44.149228+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:45.302260+00:00"
               },
               "deterministic": true
             },
@@ -11712,7 +11772,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132223+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678756+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -11751,7 +11811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:44.149283+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11764,7 +11824,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132275+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678787+00:00"
           },
           "uid": {
             "type": "string",
@@ -11782,7 +11842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:44.149314+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11796,7 +11856,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132302+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678803+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_cluster_role_binding is returned in 'List'.",
@@ -11908,7 +11968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.149393+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11966,23 +12026,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 64,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.149472+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302369+00:00"
               },
               "deterministic": true
             },
@@ -11994,7 +12054,7 @@
             },
             "x-original-maxLength": 64,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132381+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678843+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12022,16 +12082,21 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 64,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.149538+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302405+00:00"
               },
               "deterministic": true
             },
@@ -12043,7 +12108,7 @@
             },
             "x-original-maxLength": 64,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.132406+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.678859+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12150,7 +12215,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.149640+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12198,7 +12263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.149708+00:00"
+                "validatedAt": "2026-05-05T18:44:45.302486+00:00"
               },
               "deterministic": true
             },
@@ -12262,23 +12327,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.151578+00:00"
+                "validatedAt": "2026-05-05T18:44:45.303354+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -12294,7 +12359,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.133451+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.679465+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12317,16 +12382,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.151640+00:00"
+                "validatedAt": "2026-05-05T18:44:45.303386+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -12342,7 +12412,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.133477+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.679480+00:00"
           },
           "tenant": {
             "type": "string",
@@ -12371,7 +12441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:44.151705+00:00"
+                "validatedAt": "2026-05-05T18:44:45.303419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12385,7 +12455,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.133503+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.679496+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -12514,7 +12584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:48.139232+00:00"
+                "validatedAt": "2026-05-05T18:44:47.157754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12572,23 +12642,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:48.139273+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:47.157774+00:00"
               },
               "deterministic": true
             },
@@ -12601,7 +12671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.192842+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.711921+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12617,16 +12687,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:48.139305+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:47.157791+00:00"
               },
               "deterministic": true
             },
@@ -12639,7 +12714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.192870+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.711937+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12742,7 +12817,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.192960+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.711991+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -12807,7 +12882,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:48.139466+00:00"
+                "validatedAt": "2026-05-05T18:44:47.157853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12873,7 +12948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:48.139519+00:00"
+                "validatedAt": "2026-05-05T18:44:47.157878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12936,7 +13011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:48.139587+00:00"
+                "validatedAt": "2026-05-05T18:44:47.157907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12948,7 +13023,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.193039+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.712037+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12999,23 +13074,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:48.139626+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:47.157927+00:00"
               },
               "deterministic": true
             },
@@ -13028,7 +13103,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.193104+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.712075+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13043,16 +13118,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:48.139659+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:47.157944+00:00"
               },
               "deterministic": true
             },
@@ -13065,7 +13145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.193131+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.712091+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -13104,7 +13184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:48.139715+00:00"
+                "validatedAt": "2026-05-05T18:44:47.157968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13117,7 +13197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.193184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.712122+00:00"
           },
           "uid": {
             "type": "string",
@@ -13135,7 +13215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:48.139744+00:00"
+                "validatedAt": "2026-05-05T18:44:47.157982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13149,7 +13229,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.193214+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.712138+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_pod_security_admission is returned in 'List'.",
@@ -13303,7 +13383,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:48.139820+00:00"
+                "validatedAt": "2026-05-05T18:44:47.158017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13427,7 +13507,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.424671+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13543,7 +13623,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.424834+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170430+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -13608,23 +13688,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:52.424894+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:49.170451+00:00"
               },
               "deterministic": true
             },
@@ -13637,7 +13717,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268480+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753715+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13653,16 +13733,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:52.424940+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:49.170468+00:00"
               },
               "deterministic": true
             },
@@ -13675,7 +13760,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268510+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753732+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13778,7 +13863,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268597+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753785+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -13841,7 +13926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425088+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170538+00:00"
               },
               "deterministic": true,
               "format": "uri"
@@ -13910,7 +13995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425172+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14055,7 +14140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425268+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14096,7 +14181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425352+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14162,7 +14247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:13:52.425405+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14225,7 +14310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:52.425471+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14237,7 +14322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268743+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753880+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14288,23 +14373,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:52.425512+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:49.170748+00:00"
               },
               "deterministic": true
             },
@@ -14317,7 +14402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268804+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753918+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14332,16 +14417,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:52.425545+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:49.170765+00:00"
               },
               "deterministic": true
             },
@@ -14354,7 +14444,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268831+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753934+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14393,7 +14483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:52.425599+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14406,7 +14496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268882+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753966+00:00"
           },
           "uid": {
             "type": "string",
@@ -14424,7 +14514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:52.425632+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14438,7 +14528,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.268911+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.753982+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of k8s_pod_security_policy is returned in 'List'.",
@@ -14535,7 +14625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425700+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14580,7 +14670,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425762+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14617,7 +14707,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425814+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14656,7 +14746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425873+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14695,7 +14785,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425932+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14754,7 +14844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.425991+00:00"
+                "validatedAt": "2026-05-05T18:44:49.170987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14831,7 +14921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:52.426051+00:00"
+                "validatedAt": "2026-05-05T18:44:49.171012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14940,7 +15030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.426118+00:00"
+                "validatedAt": "2026-05-05T18:44:49.171045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15070,7 +15160,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:13:52.426205+00:00"
+                "validatedAt": "2026-05-05T18:44:49.171087+00:00"
               },
               "deterministic": true,
               "format": "uri"

--- a/docs/specifications/api/marketplace.json
+++ b/docs/specifications/api/marketplace.json
@@ -8870,7 +8870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:20.057820+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8882,7 +8882,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.653841+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736213+00:00"
           },
           "subject": {
             "type": "string",
@@ -8897,7 +8897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.057873+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9030,7 +9030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.057949+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9055,7 +9055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.058004+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224772+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9084,7 +9084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:20.058044+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9240,7 +9240,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654056+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736341+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -9306,7 +9306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:20.058174+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9369,7 +9369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:20.058237+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224872+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9381,7 +9381,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654127+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736381+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9431,23 +9431,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.058281+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.224892+00:00"
               },
               "deterministic": true
             },
@@ -9460,7 +9460,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654191+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736419+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9475,16 +9475,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.058315+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.224908+00:00"
               },
               "deterministic": true
             },
@@ -9497,7 +9502,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654217+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736435+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9536,7 +9541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.058389+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9549,7 +9554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654268+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736466+00:00"
           },
           "uid": {
             "type": "string",
@@ -9566,7 +9571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.058419+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9580,7 +9585,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654295+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736483+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of addon_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9688,7 +9693,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.058519+00:00"
+                "validatedAt": "2026-05-05T18:40:03.224991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9925,7 +9930,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.058612+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9983,7 +9988,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.058674+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10021,7 +10026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.058734+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10058,7 +10063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.058803+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225131+00:00"
               },
               "deterministic": true
             },
@@ -10095,7 +10100,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.058862+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10132,7 +10137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:04:20.058901+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225176+00:00"
               },
               "deterministic": true
             },
@@ -10185,7 +10190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.058947+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10208,7 +10213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.058987+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10220,7 +10225,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654575+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736611+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -10342,7 +10347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.059029+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225234+00:00"
               },
               "deterministic": true
             },
@@ -10368,7 +10373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059080+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225256+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10394,7 +10399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059121+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10406,7 +10411,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654626+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736650+00:00"
           },
           "service_name": {
             "type": "string",
@@ -10423,7 +10428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059168+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10456,7 +10461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059212+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10468,7 +10473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654661+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736671+00:00"
           },
           "type": {
             "type": "string",
@@ -10493,7 +10498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059252+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10581,7 +10586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059296+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10652,23 +10657,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.059341+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225376+00:00"
               },
               "deterministic": true
             },
@@ -10681,7 +10686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654728+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736711+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -10800,7 +10805,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:20.059447+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225428+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -10816,7 +10821,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654787+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736745+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -10872,23 +10877,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.059489+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225447+00:00"
               },
               "deterministic": true
             },
@@ -10901,7 +10906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654832+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736773+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10918,16 +10923,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.059521+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225462+00:00"
               },
               "deterministic": true
             },
@@ -10940,7 +10950,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654857+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736789+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -10985,7 +10995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059558+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10998,7 +11008,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654884+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736806+00:00"
           },
           "name": {
             "type": "string",
@@ -11015,23 +11025,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.059592+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225493+00:00"
               },
               "deterministic": true
             },
@@ -11044,7 +11054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654909+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736822+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11061,16 +11071,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.059626+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225509+00:00"
               },
               "deterministic": true
             },
@@ -11083,7 +11098,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654934+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736837+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11102,7 +11117,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059665+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11116,7 +11131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654961+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736853+00:00"
           },
           "uid": {
             "type": "string",
@@ -11135,7 +11150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059695+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11150,7 +11165,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.654990+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736869+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11195,7 +11210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059746+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11223,7 +11238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059797+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11251,7 +11266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059842+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11280,7 +11295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059886+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11307,7 +11322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059916+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11321,7 +11336,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655064+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736913+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -11337,7 +11352,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.059958+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11446,7 +11461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060016+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225689+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11458,7 +11473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655120+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736946+00:00"
           },
           "status": {
             "type": "string",
@@ -11476,7 +11491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060056+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11488,7 +11503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655145+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.736962+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -11530,7 +11545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060109+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11557,7 +11572,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060157+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11584,7 +11599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060201+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11612,7 +11627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060252+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225794+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11677,7 +11692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060335+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11726,7 +11741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060389+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11739,7 +11754,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655262+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.737031+00:00"
           },
           "uid": {
             "type": "string",
@@ -11758,7 +11773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060419+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11772,7 +11787,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655288+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.737048+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -11822,7 +11837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060456+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11834,7 +11849,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655316+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.737070+00:00"
           },
           "name": {
             "type": "string",
@@ -11851,23 +11866,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.060492+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225894+00:00"
               },
               "deterministic": true
             },
@@ -11880,7 +11895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655355+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.737086+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11897,16 +11912,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:20.060526+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:03.225911+00:00"
               },
               "deterministic": true
             },
@@ -11919,7 +11939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655383+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.737102+00:00"
           },
           "uid": {
             "type": "string",
@@ -11936,7 +11956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:20.060555+00:00"
+                "validatedAt": "2026-05-05T18:40:03.225924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11950,7 +11970,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.655411+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.737118+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -12116,23 +12136,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.048813+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.173588+00:00"
               },
               "deterministic": true
             },
@@ -12145,7 +12165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689424+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755434+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12161,16 +12181,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.048857+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.173608+00:00"
               },
               "deterministic": true
             },
@@ -12183,7 +12208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689455+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755451+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -12365,7 +12390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:22.048973+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12428,7 +12453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:22.049039+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12440,7 +12465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689620+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755543+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -12490,23 +12515,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.049082+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.173717+00:00"
               },
               "deterministic": true
             },
@@ -12519,7 +12544,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689682+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755581+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12534,16 +12559,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.049116+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.173734+00:00"
               },
               "deterministic": true
             },
@@ -12556,7 +12586,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689710+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755596+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -12579,7 +12609,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049159+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12592,7 +12622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689752+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755634+00:00"
           },
           "uid": {
             "type": "string",
@@ -12610,7 +12640,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049191+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12624,7 +12654,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689783+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755652+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of addon_subscription is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -12776,7 +12806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049257+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12801,7 +12831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049313+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12851,7 +12881,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049368+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12864,7 +12894,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689900+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755722+00:00"
           },
           "name": {
             "type": "string",
@@ -12881,23 +12911,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.049403+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.173854+00:00"
               },
               "deterministic": true
             },
@@ -12910,7 +12940,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689928+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755738+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12927,16 +12957,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.049436+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.173869+00:00"
               },
               "deterministic": true
             },
@@ -12949,7 +12984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689956+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755754+00:00"
           },
           "tenant": {
             "type": "string",
@@ -12968,7 +13003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049477+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12982,7 +13017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.689982+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755769+00:00"
           },
           "uid": {
             "type": "string",
@@ -13001,7 +13036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:22.049508+00:00"
+                "validatedAt": "2026-05-05T18:40:04.173900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13016,7 +13051,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690011+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755785+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -13097,7 +13132,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:22.049857+00:00"
+                "validatedAt": "2026-05-05T18:40:04.174062+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13113,7 +13148,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690184+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755883+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13167,23 +13202,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.049902+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.174081+00:00"
               },
               "deterministic": true
             },
@@ -13196,7 +13231,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690233+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755910+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13213,16 +13248,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.049934+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.174096+00:00"
               },
               "deterministic": true
             },
@@ -13235,7 +13275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690258+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.755926+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -13317,7 +13357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:22.050194+00:00"
+                "validatedAt": "2026-05-05T18:40:04.174221+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -13333,7 +13373,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690415+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.756015+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -13387,23 +13427,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.050235+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.174239+00:00"
               },
               "deterministic": true
             },
@@ -13416,7 +13456,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690462+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.756042+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13433,16 +13473,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:22.050265+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:04.174254+00:00"
               },
               "deterministic": true
             },
@@ -13455,7 +13500,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690487+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.756057+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -13510,23 +13555,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:22.050926+00:00"
+                "validatedAt": "2026-05-05T18:40:04.174549+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13542,7 +13587,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690831+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.756263+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13565,16 +13610,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:22.050987+00:00"
+                "validatedAt": "2026-05-05T18:40:04.174581+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13590,7 +13640,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690857+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.756278+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13619,7 +13669,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:22.051055+00:00"
+                "validatedAt": "2026-05-05T18:40:04.174620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13633,7 +13683,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.690882+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.756294+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -13753,7 +13803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.597095+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552698+00:00"
               },
               "deterministic": true
             },
@@ -13797,7 +13847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.597183+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552742+00:00"
               },
               "deterministic": true
             },
@@ -13860,23 +13910,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:33.597228+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:12.552763+00:00"
               },
               "deterministic": true
             },
@@ -13889,7 +13939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.572855+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382174+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13905,16 +13955,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:33.597263+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:12.552780+00:00"
               },
               "deterministic": true
             },
@@ -13927,7 +13982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.572885+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382194+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -14030,7 +14085,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.572975+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382249+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -14102,7 +14157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.597395+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552827+00:00"
               },
               "deterministic": true
             },
@@ -14146,7 +14201,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.597469+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552864+00:00"
               },
               "deterministic": true
             },
@@ -14217,7 +14272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:33.597519+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14280,7 +14335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:33.597586+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14292,7 +14347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382316+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14342,23 +14397,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:33.597627+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:12.552934+00:00"
               },
               "deterministic": true
             },
@@ -14371,7 +14426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573156+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382353+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14386,16 +14441,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:33.597661+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:12.552951+00:00"
               },
               "deterministic": true
             },
@@ -14408,7 +14468,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573181+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382369+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14447,7 +14507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:33.597716+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14460,7 +14520,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573232+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382400+00:00"
           },
           "uid": {
             "type": "string",
@@ -14477,7 +14537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:33.597747+00:00"
+                "validatedAt": "2026-05-05T18:41:12.552992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14491,7 +14551,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573261+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382417+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of cminstance is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14606,7 +14666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.597792+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553013+00:00"
               },
               "deterministic": true
             },
@@ -14650,7 +14710,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.597857+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553047+00:00"
               },
               "deterministic": true
             },
@@ -14761,7 +14821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:33.598025+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14799,7 +14859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.598096+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14811,7 +14871,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573442+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382517+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -14830,7 +14890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:33.598146+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14881,7 +14941,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:33.598191+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14893,7 +14953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.573479+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.382539+00:00"
           },
           "url": {
             "type": "string",
@@ -14931,7 +14991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.598266+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553238+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14991,7 +15051,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:33.598705+00:00"
+                "validatedAt": "2026-05-05T18:41:12.553435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15210,23 +15270,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:01.424132+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:25.640115+00:00"
               },
               "deterministic": true
             },
@@ -15239,7 +15299,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.117823+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.059891+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15255,16 +15315,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:01.424178+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:25.640140+00:00"
               },
               "deterministic": true
             },
@@ -15277,7 +15342,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.117854+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.059908+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -15324,7 +15389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:11:01.424233+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640166+00:00"
               },
               "deterministic": true
             },
@@ -15500,7 +15565,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.118007+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.060004+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -15600,7 +15665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424408+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15688,7 +15753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:01.424465+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15751,7 +15816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:01.424533+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15763,7 +15828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.118178+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.060108+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -15813,23 +15878,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:01.424579+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:25.640307+00:00"
               },
               "deterministic": true
             },
@@ -15842,7 +15907,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.118243+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.060145+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15857,16 +15922,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:01.424613+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:25.640323+00:00"
               },
               "deterministic": true
             },
@@ -15879,7 +15949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.118269+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.060161+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -15918,7 +15988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424668+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15931,7 +16001,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.118330+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.060192+00:00"
           },
           "uid": {
             "type": "string",
@@ -15949,7 +16019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424699+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15963,7 +16033,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.118358+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.060209+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of external_connector is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16148,7 +16218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424787+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16184,7 +16254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424842+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16216,7 +16286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424882+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16252,7 +16322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424937+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640472+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16312,7 +16382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:01.424973+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16362,7 +16432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:01.425047+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16480,7 +16550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:01.425843+00:00"
+                "validatedAt": "2026-05-05T18:43:25.640948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16538,7 +16608,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:01.426403+00:00"
+                "validatedAt": "2026-05-05T18:43:25.641272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16664,7 +16734,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.941644+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.675223+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16722,7 +16792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:26.430383+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16753,7 +16823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:26.430483+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16790,7 +16860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:26.430555+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158184+00:00"
               },
               "deterministic": true
             },
@@ -16840,7 +16910,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:26.430621+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16876,7 +16946,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:26.430672+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16904,7 +16974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:15:26.430711+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158264+00:00"
               },
               "deterministic": true
             },
@@ -16977,7 +17047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:26.430761+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17040,7 +17110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:26.430824+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17052,7 +17122,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.941783+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.675302+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -17102,23 +17172,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:26.430867+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:35.158337+00:00"
               },
               "deterministic": true
             },
@@ -17131,7 +17201,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.941847+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.675339+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17146,16 +17216,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:26.430901+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:35.158356+00:00"
               },
               "deterministic": true
             },
@@ -17168,7 +17243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.941875+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.675355+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -17207,7 +17282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:26.430956+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17220,7 +17295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.941927+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.675386+00:00"
           },
           "uid": {
             "type": "string",
@@ -17237,7 +17312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:26.430986+00:00"
+                "validatedAt": "2026-05-05T18:45:35.158395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17251,7 +17326,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.941955+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.675402+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of navigation_tile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -17358,7 +17433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063113+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17432,7 +17507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063198+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17479,7 +17554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063246+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17551,7 +17626,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.063341+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899645+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17563,7 +17638,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.558633+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.011469+00:00"
           },
           "locale": {
             "type": "string",
@@ -17587,7 +17662,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.063413+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17614,7 +17689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063464+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17646,7 +17721,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.063535+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17700,23 +17775,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.063605+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899779+00:00"
               },
               "deterministic": true
             },
@@ -17729,7 +17804,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.558703+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.011509+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17767,7 +17842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063650+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17792,7 +17867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063692+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17817,7 +17892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063726+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17842,7 +17917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063768+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17868,7 +17943,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063808+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17893,7 +17968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063854+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17919,7 +17994,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063892+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17945,7 +18020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063936+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17970,7 +18045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:58.063978+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18031,7 +18106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.064060+00:00"
+                "validatedAt": "2026-05-05T18:45:50.899990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18071,7 +18146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.064134+00:00"
+                "validatedAt": "2026-05-05T18:45:50.900027+00:00"
               },
               "deterministic": true
             },
@@ -18104,7 +18179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.064204+00:00"
+                "validatedAt": "2026-05-05T18:45:50.900061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18136,7 +18211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:58.064276+00:00"
+                "validatedAt": "2026-05-05T18:45:50.900097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18242,7 +18317,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.871462+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.191713+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18300,7 +18375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:16.791259+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18337,7 +18412,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:16.791406+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831447+00:00"
               },
               "deterministic": true
             },
@@ -18375,7 +18450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:16.791493+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18443,7 +18518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:16.791550+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18505,7 +18580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:16.791620+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18517,7 +18592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.871565+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.191771+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18566,23 +18641,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:16.791667+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:59.831552+00:00"
               },
               "deterministic": true
             },
@@ -18595,7 +18670,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.871629+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.191808+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18610,16 +18685,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:16.791702+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:59.831569+00:00"
               },
               "deterministic": true
             },
@@ -18632,7 +18712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.871657+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.191824+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18671,7 +18751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:16.791760+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18684,7 +18764,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.871711+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.191855+00:00"
           },
           "uid": {
             "type": "string",
@@ -18701,7 +18781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:16.791792+00:00"
+                "validatedAt": "2026-05-05T18:45:59.831609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18715,7 +18795,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.871741+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.191872+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of plan is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -18820,7 +18900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173019+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18879,23 +18959,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:30.173136+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:42.653100+00:00"
               },
               "deterministic": true
             },
@@ -18908,7 +18988,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.726147+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.977877+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -18963,7 +19043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173219+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653135+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18988,7 +19068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173292+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19021,7 +19101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173382+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19145,7 +19225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173445+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19234,7 +19314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173532+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19258,7 +19338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173583+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19329,7 +19409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173637+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19353,7 +19433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.173686+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19667,7 +19747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.173886+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653483+00:00"
               },
               "deterministic": true
             },
@@ -19750,7 +19830,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.173952+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19862,7 +19942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174019+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19900,7 +19980,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174112+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653630+00:00"
               },
               "deterministic": true
             },
@@ -19992,7 +20072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174175+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20050,7 +20130,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174252+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20063,7 +20143,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.726712+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.978211+00:00"
           },
           "simple_login": {
             "$ref": "#/components/schemas/common_wafSimpleLogin"
@@ -20126,7 +20206,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174356+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20165,7 +20245,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174431+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20394,7 +20474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174514+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20468,7 +20548,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174575+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20531,7 +20611,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174647+00:00"
+                "validatedAt": "2026-05-05T18:45:42.653972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20570,7 +20650,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174723+00:00"
+                "validatedAt": "2026-05-05T18:45:42.654019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20611,7 +20691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174801+00:00"
+                "validatedAt": "2026-05-05T18:45:42.654069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20682,7 +20762,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174874+00:00"
+                "validatedAt": "2026-05-05T18:45:42.654118+00:00"
               },
               "deterministic": true
             },
@@ -20747,7 +20827,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.174930+00:00"
+                "validatedAt": "2026-05-05T18:45:42.654153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20917,7 +20997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.175942+00:00"
+                "validatedAt": "2026-05-05T18:45:42.654784+00:00"
               },
               "deterministic": true
             },
@@ -20930,7 +21010,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.727560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.978724+00:00"
           },
           "name": {
             "type": "string",
@@ -20958,23 +21038,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.176006+00:00"
+                "validatedAt": "2026-05-05T18:45:42.654824+00:00"
               },
               "deterministic": true
             },
@@ -20986,7 +21066,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.727585+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.978740+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -21057,7 +21137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:20:30.177460+00:00"
+                "validatedAt": "2026-05-05T18:45:42.655803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21165,7 +21245,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728409+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979233+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -21222,16 +21302,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:30.177563+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:42.655858+00:00"
               },
               "deterministic": true
             },
@@ -21244,7 +21329,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728455+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979260+00:00"
           },
           "third_party_applications_list": {
             "$ref": "#/components/schemas/third_party_applicationThirdPartyApplicationList"
@@ -21307,7 +21392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:30.177616+00:00"
+                "validatedAt": "2026-05-05T18:45:42.655888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21370,7 +21455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:30.177675+00:00"
+                "validatedAt": "2026-05-05T18:45:42.655923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21382,7 +21467,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728522+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979300+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21433,23 +21518,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:30.177714+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:42.655942+00:00"
               },
               "deterministic": true
             },
@@ -21462,7 +21547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728585+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979337+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21477,16 +21562,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:30.177747+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:42.655964+00:00"
               },
               "deterministic": true
             },
@@ -21499,7 +21589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728612+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979353+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21538,7 +21628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.177801+00:00"
+                "validatedAt": "2026-05-05T18:45:42.655991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21551,7 +21641,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728664+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979384+00:00"
           },
           "uid": {
             "type": "string",
@@ -21569,7 +21659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:30.177831+00:00"
+                "validatedAt": "2026-05-05T18:45:42.656010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21583,7 +21673,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.728690+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.979400+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of third_party_application is returned in 'List'.",
@@ -21754,7 +21844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:30.177932+00:00"
+                "validatedAt": "2026-05-05T18:45:42.656070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22002,7 +22092,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130260+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22030,7 +22120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130308+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22060,7 +22150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130377+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22086,7 +22176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130426+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138524+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22112,7 +22202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130471+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22135,7 +22225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130514+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22209,16 +22299,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:47.130555+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:20.138582+00:00"
               },
               "deterministic": true
             },
@@ -22231,7 +22326,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.079063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.754393+00:00"
           },
           "view_kind": {
             "type": "string",
@@ -22249,7 +22344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130598+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22275,7 +22370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130641+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22430,7 +22525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130695+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22460,7 +22555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130749+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22489,7 +22584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130799+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22515,7 +22610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130847+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22591,16 +22686,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:47.130883+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:20.138739+00:00"
               },
               "deterministic": true
             },
@@ -22613,7 +22713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.079201+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.754471+00:00"
           },
           "view_kind": {
             "type": "string",
@@ -22631,7 +22731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130926+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22657,7 +22757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.130969+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22787,7 +22887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:47.131055+00:00"
+                "validatedAt": "2026-05-05T18:46:20.138819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22867,7 +22967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:43.320054+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22892,7 +22992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:43.320117+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22905,7 +23005,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.305105+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.493268+00:00"
           },
           "email": {
             "type": "string",
@@ -22931,7 +23031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:43.320170+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892388+00:00"
               },
               "deterministic": true
             },
@@ -22958,7 +23058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:43.320219+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23006,7 +23106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:43.320262+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23069,7 +23169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:22:43.320313+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23129,7 +23229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:43.320412+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23140,7 +23240,7 @@
             },
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.305183+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.493314+00:00"
           },
           "token": {
             "type": "string",
@@ -23158,7 +23258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:22:43.320459+00:00"
+                "validatedAt": "2026-05-05T18:46:49.892520+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/network.json
+++ b/docs/specifications/api/network.json
@@ -22867,7 +22867,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:24.043471+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22930,23 +22930,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.043528+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.119687+00:00"
               },
               "deterministic": true
             },
@@ -22959,7 +22959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723528+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774455+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22975,16 +22975,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.043564+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.119705+00:00"
               },
               "deterministic": true
             },
@@ -22997,7 +23002,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723558+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774471+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23097,7 +23102,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723643+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774520+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23167,7 +23172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:24.043697+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23238,7 +23243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:24.043749+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119792+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23301,7 +23306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:24.043818+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23313,7 +23318,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723741+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774576+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23363,23 +23368,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.043857+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.119843+00:00"
               },
               "deterministic": true
             },
@@ -23392,7 +23397,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723803+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774620+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23407,16 +23412,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.043889+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.119860+00:00"
               },
               "deterministic": true
             },
@@ -23429,7 +23439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723831+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774636+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -23468,7 +23478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.043946+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23481,7 +23491,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723883+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774668+00:00"
           },
           "uid": {
             "type": "string",
@@ -23499,7 +23509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.043979+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23513,7 +23523,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723912+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774684+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of address_allocator is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23640,7 +23650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044054+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23663,7 +23673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044094+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23675,7 +23685,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.723979+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774725+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -23721,7 +23731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044135+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119974+00:00"
               },
               "deterministic": true
             },
@@ -23747,7 +23757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044185+00:00"
+                "validatedAt": "2026-05-05T18:40:05.119996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23773,7 +23783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044226+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23785,7 +23795,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724026+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774752+00:00"
           },
           "service_name": {
             "type": "string",
@@ -23802,7 +23812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044274+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23835,7 +23845,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044330+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23847,7 +23857,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724061+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774774+00:00"
           },
           "type": {
             "type": "string",
@@ -23872,7 +23882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044370+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23960,7 +23970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044415+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24006,23 +24016,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044451+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120115+00:00"
               },
               "deterministic": true
             },
@@ -24035,7 +24045,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724126+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774813+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -24153,7 +24163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:24.044565+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120170+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24169,7 +24179,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724184+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774848+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24223,23 +24233,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044608+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120190+00:00"
               },
               "deterministic": true
             },
@@ -24252,7 +24262,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724232+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774876+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24269,16 +24279,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044638+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120206+00:00"
               },
               "deterministic": true
             },
@@ -24291,7 +24306,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724257+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774892+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -24373,7 +24388,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:24.044728+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120251+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -24389,7 +24404,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724295+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774915+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -24445,23 +24460,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044768+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120271+00:00"
               },
               "deterministic": true
             },
@@ -24474,7 +24489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724348+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774943+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24491,16 +24506,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044801+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120288+00:00"
               },
               "deterministic": true
             },
@@ -24513,7 +24533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724374+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774959+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -24558,7 +24578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044838+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120305+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24571,7 +24591,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724402+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774976+00:00"
           },
           "name": {
             "type": "string",
@@ -24588,23 +24608,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044871+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120322+00:00"
               },
               "deterministic": true
             },
@@ -24617,7 +24637,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724429+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.774992+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24634,16 +24654,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.044904+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120338+00:00"
               },
               "deterministic": true
             },
@@ -24656,7 +24681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724456+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775007+00:00"
           },
           "tenant": {
             "type": "string",
@@ -24675,7 +24700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044943+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24689,7 +24714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724485+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775023+00:00"
           },
           "uid": {
             "type": "string",
@@ -24708,7 +24733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.044974+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24723,7 +24748,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724514+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775039+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -24768,7 +24793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045027+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24796,7 +24821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045075+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24824,7 +24849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045123+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24853,7 +24878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045167+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24880,7 +24905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045198+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24894,7 +24919,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724587+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775083+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -24910,7 +24935,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045240+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25019,7 +25044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045293+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25031,7 +25056,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724643+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775116+00:00"
           },
           "status": {
             "type": "string",
@@ -25049,7 +25074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045345+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25061,7 +25086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724668+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775132+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -25103,7 +25128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045398+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25130,7 +25155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045446+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25157,7 +25182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045494+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25185,7 +25210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045545+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25250,7 +25275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045615+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120667+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25299,7 +25324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045669+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25312,7 +25337,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724787+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775202+00:00"
           },
           "uid": {
             "type": "string",
@@ -25331,7 +25356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045698+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25345,7 +25370,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724813+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775218+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -25395,7 +25420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045734+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25407,7 +25432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724843+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775235+00:00"
           },
           "name": {
             "type": "string",
@@ -25424,23 +25449,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.045768+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120740+00:00"
               },
               "deterministic": true
             },
@@ -25453,7 +25478,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724871+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775251+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25470,16 +25495,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:24.045799+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:05.120757+00:00"
               },
               "deterministic": true
             },
@@ -25492,7 +25522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724896+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775267+00:00"
           },
           "uid": {
             "type": "string",
@@ -25509,7 +25539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:24.045828+00:00"
+                "validatedAt": "2026-05-05T18:40:05.120770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25523,7 +25553,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.724922+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.775283+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -25628,7 +25658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.264881+00:00"
+                "validatedAt": "2026-05-05T18:40:06.183820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25663,7 +25693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.264968+00:00"
+                "validatedAt": "2026-05-05T18:40:06.183850+00:00"
               },
               "deterministic": true
             },
@@ -25708,7 +25738,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.265056+00:00"
+                "validatedAt": "2026-05-05T18:40:06.183891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25741,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.265104+00:00"
+                "validatedAt": "2026-05-05T18:40:06.183913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25843,23 +25873,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.265170+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.183943+00:00"
               },
               "deterministic": true
             },
@@ -25872,7 +25902,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759080+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794250+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25888,16 +25918,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.265208+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.183961+00:00"
               },
               "deterministic": true
             },
@@ -25910,7 +25945,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759109+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794267+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26013,7 +26048,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759202+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794320+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -26070,7 +26105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.265360+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26105,7 +26140,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.265403+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184042+00:00"
               },
               "deterministic": true
             },
@@ -26150,7 +26185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.265487+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26183,7 +26218,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.265535+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26292,7 +26327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:26.265606+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26355,7 +26390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:26.265671+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26367,7 +26402,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759357+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794403+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26417,23 +26452,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.265713+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.184179+00:00"
               },
               "deterministic": true
             },
@@ -26446,7 +26481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759422+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794441+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26461,16 +26496,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.265747+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.184195+00:00"
               },
               "deterministic": true
             },
@@ -26483,7 +26523,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759449+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794457+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26522,7 +26562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.265802+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26535,7 +26575,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759504+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794488+00:00"
           },
           "uid": {
             "type": "string",
@@ -26553,7 +26593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.265834+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26567,7 +26607,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759533+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794504+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of advertise_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26612,23 +26652,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.265870+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.184250+00:00"
               },
               "deterministic": true
             },
@@ -26641,7 +26681,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759563+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794522+00:00"
           },
           "port": {
             "type": "integer",
@@ -26661,7 +26701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.265904+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184266+00:00"
               },
               "deterministic": true
             },
@@ -26686,7 +26726,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.265944+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26698,7 +26738,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759599+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794544+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26786,7 +26826,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.266019+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26821,7 +26861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.266057+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184338+00:00"
               },
               "deterministic": true
             },
@@ -26866,7 +26906,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.266136+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26899,7 +26939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.266180+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27081,7 +27121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.266387+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27119,7 +27159,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.266455+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27131,7 +27171,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759803+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794673+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -27150,7 +27190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.266506+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27201,7 +27241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:26.266546+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184560+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27213,7 +27253,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.759841+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.794695+00:00"
           },
           "url": {
             "type": "string",
@@ -27251,7 +27291,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.266619+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184596+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -27328,7 +27368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.266941+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27421,7 +27461,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.267052+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27479,7 +27519,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.267151+00:00"
+                "validatedAt": "2026-05-05T18:40:06.184859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27598,7 +27638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.267744+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185147+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -27614,7 +27654,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.760526+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.795096+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -27668,23 +27708,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.267786+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.185168+00:00"
               },
               "deterministic": true
             },
@@ -27697,7 +27737,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.760570+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.795124+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27714,16 +27754,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:26.267816+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:06.185184+00:00"
               },
               "deterministic": true
             },
@@ -27736,7 +27781,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.760598+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.795140+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -27850,7 +27895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.267872+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185212+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27922,7 +27967,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.268661+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27954,7 +27999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:26.268717+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27966,7 +28011,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.761003+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.795378+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -28028,7 +28073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.268771+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28160,7 +28205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.268873+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28240,7 +28285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.268948+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28307,7 +28352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:26.269000+00:00"
+                "validatedAt": "2026-05-05T18:40:06.185741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28559,7 +28604,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.217445+00:00"
+                "validatedAt": "2026-05-05T18:40:28.155963+00:00"
               },
               "deterministic": true
             },
@@ -28673,7 +28718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.217538+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28697,7 +28742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.217585+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28750,7 +28795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.217659+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28797,7 +28842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.217729+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28886,7 +28931,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.217799+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28960,7 +29005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.217865+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29025,7 +29070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.217931+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29075,7 +29120,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218002+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29193,7 +29238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218065+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29257,23 +29302,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:11.218108+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:28.156272+00:00"
               },
               "deterministic": true
             },
@@ -29286,7 +29331,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.785854+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377090+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29302,16 +29347,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:11.218143+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:28.156289+00:00"
               },
               "deterministic": true
             },
@@ -29324,7 +29374,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.785884+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377120+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29585,7 +29635,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377342+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -29648,7 +29698,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218277+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156348+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29704,7 +29754,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786151+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377414+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -29760,7 +29810,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218363+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29825,7 +29875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:11.218414+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29887,7 +29937,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:11.218480+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29899,7 +29949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786222+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377491+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -29948,23 +29998,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:11.218522+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:28.156457+00:00"
               },
               "deterministic": true
             },
@@ -29977,7 +30027,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786285+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377555+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29992,16 +30042,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:11.218557+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:28.156474+00:00"
               },
               "deterministic": true
             },
@@ -30014,7 +30069,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786311+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377582+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -30053,7 +30108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.218611+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30066,7 +30121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786380+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377640+00:00"
           },
           "uid": {
             "type": "string",
@@ -30083,7 +30138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.218640+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30097,7 +30152,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786408+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.377668+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of BGP is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -30202,7 +30257,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.218694+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30280,7 +30335,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218770+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30321,7 +30376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218844+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156608+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30407,7 +30462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.218912+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30450,7 +30505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.218953+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156664+00:00"
               },
               "deterministic": true
             },
@@ -30692,7 +30747,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.219088+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30807,7 +30862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.219155+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30820,7 +30875,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786783+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378047+00:00"
           },
           "name": {
             "type": "string",
@@ -30837,23 +30892,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:11.219188+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:28.156775+00:00"
               },
               "deterministic": true
             },
@@ -30866,7 +30921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786812+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378077+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30883,16 +30938,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:11.219221+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:28.156791+00:00"
               },
               "deterministic": true
             },
@@ -30905,7 +30965,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786840+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378106+00:00"
           },
           "tenant": {
             "type": "string",
@@ -30924,7 +30984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.219262+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30938,7 +30998,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786868+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378136+00:00"
           },
           "uid": {
             "type": "string",
@@ -30957,7 +31017,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:11.219291+00:00"
+                "validatedAt": "2026-05-05T18:40:28.156823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30972,7 +31032,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.786895+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378166+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -31054,7 +31114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.219813+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31108,7 +31168,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.219877+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31164,7 +31224,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.219966+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157134+00:00"
               },
               "deterministic": true
             },
@@ -31177,7 +31237,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.787181+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378470+00:00"
           },
           "name": {
             "type": "string",
@@ -31205,23 +31265,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.220029+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157172+00:00"
               },
               "deterministic": true
             },
@@ -31233,7 +31293,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.787208+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.378498+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -31315,23 +31375,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.221540+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157885+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31347,7 +31407,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.788092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.379370+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31370,16 +31430,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.221599+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157916+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -31395,7 +31460,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.788117+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.379397+00:00"
           },
           "tenant": {
             "type": "string",
@@ -31424,7 +31489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:11.221669+00:00"
+                "validatedAt": "2026-05-05T18:40:28.157950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31438,7 +31503,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.788143+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.379424+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -31483,7 +31548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:13.584610+00:00"
+                "validatedAt": "2026-05-05T18:40:29.258502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31515,7 +31580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:13.584723+00:00"
+                "validatedAt": "2026-05-05T18:40:29.258542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31559,7 +31624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:13.584771+00:00"
+                "validatedAt": "2026-05-05T18:40:29.258564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31675,7 +31740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:13.584910+00:00"
+                "validatedAt": "2026-05-05T18:40:29.258631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31731,7 +31796,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:13.586713+00:00"
+                "validatedAt": "2026-05-05T18:40:29.259474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31888,7 +31953,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:15.682890+00:00"
+                "validatedAt": "2026-05-05T18:40:30.243999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31946,23 +32011,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:15.682950+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:30.244026+00:00"
               },
               "deterministic": true
             },
@@ -31975,7 +32040,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.886940+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437366+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31991,16 +32056,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:15.682985+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:30.244046+00:00"
               },
               "deterministic": true
             },
@@ -32013,7 +32083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.886969+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437384+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -32116,7 +32186,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.887061+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437441+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -32186,7 +32256,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:15.683119+00:00"
+                "validatedAt": "2026-05-05T18:40:30.244107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32252,7 +32322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:15.683173+00:00"
+                "validatedAt": "2026-05-05T18:40:30.244131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32315,7 +32385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:15.683241+00:00"
+                "validatedAt": "2026-05-05T18:40:30.244163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32327,7 +32397,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.887142+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437491+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32377,23 +32447,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:15.683284+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:30.244181+00:00"
               },
               "deterministic": true
             },
@@ -32406,7 +32476,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.887204+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437530+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32421,16 +32491,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:15.683317+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:30.244199+00:00"
               },
               "deterministic": true
             },
@@ -32443,7 +32518,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.887232+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437547+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32482,7 +32557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:15.683389+00:00"
+                "validatedAt": "2026-05-05T18:40:30.244224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32495,7 +32570,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.887285+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437580+00:00"
           },
           "uid": {
             "type": "string",
@@ -32512,7 +32587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:15.683420+00:00"
+                "validatedAt": "2026-05-05T18:40:30.244240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32526,7 +32601,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.887312+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.437597+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bgp_asn_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -32639,7 +32714,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:15.683485+00:00"
+                "validatedAt": "2026-05-05T18:40:30.244274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32738,7 +32813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:19.521846+00:00"
+                "validatedAt": "2026-05-05T18:40:32.067577+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32802,7 +32877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:19.521947+00:00"
+                "validatedAt": "2026-05-05T18:40:32.067629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32903,7 +32978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:19.522015+00:00"
+                "validatedAt": "2026-05-05T18:40:32.067658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32976,23 +33051,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:19.522085+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:32.067691+00:00"
               },
               "deterministic": true
             },
@@ -33005,7 +33080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.953492+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.476018+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33080,7 +33155,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:19.522149+00:00"
+                "validatedAt": "2026-05-05T18:40:32.067718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33139,23 +33214,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:19.522500+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:32.067865+00:00"
               },
               "deterministic": true
             },
@@ -33168,7 +33243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.953660+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.476117+00:00"
           },
           "peer": {
             "type": "array",
@@ -33220,23 +33295,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:19.522547+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:32.067887+00:00"
               },
               "deterministic": true
             },
@@ -33249,7 +33324,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.953699+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.476139+00:00"
           },
           "ri_table": {
             "type": "array",
@@ -33327,7 +33402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:21.544398+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33385,7 +33460,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:21.544498+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33452,7 +33527,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:21.544566+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33505,7 +33580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:21.544616+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33622,7 +33697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:21.544691+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33777,23 +33852,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:21.544751+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:33.031504+00:00"
               },
               "deterministic": true
             },
@@ -33806,7 +33881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.972985+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486385+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33822,16 +33897,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:21.544786+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:33.031522+00:00"
               },
               "deterministic": true
             },
@@ -33844,7 +33924,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.973014+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486402+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33993,7 +34073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:21.544889+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34056,7 +34136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:21.544952+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34068,7 +34148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.973143+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486483+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34118,23 +34198,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:21.544992+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:33.031625+00:00"
               },
               "deterministic": true
             },
@@ -34147,7 +34227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.973206+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486522+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34162,16 +34242,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:21.545024+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:33.031643+00:00"
               },
               "deterministic": true
             },
@@ -34184,7 +34269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.973232+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486539+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34207,7 +34292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:21.545064+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34220,7 +34305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.973274+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486566+00:00"
           },
           "uid": {
             "type": "string",
@@ -34238,7 +34323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:21.545094+00:00"
+                "validatedAt": "2026-05-05T18:40:33.031678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34252,7 +34337,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.973305+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.486583+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of bgp_routing_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -34359,7 +34444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:21.546596+00:00"
+                "validatedAt": "2026-05-05T18:40:33.032401+00:00"
               },
               "deterministic": true
             },
@@ -34424,7 +34509,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:21.546663+00:00"
+                "validatedAt": "2026-05-05T18:40:33.032435+00:00"
               },
               "deterministic": true
             },
@@ -34489,7 +34574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:21.546730+00:00"
+                "validatedAt": "2026-05-05T18:40:33.032469+00:00"
               },
               "deterministic": true
             },
@@ -34657,23 +34742,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:37.592129+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:43.638146+00:00"
               },
               "deterministic": true
             },
@@ -34686,7 +34771,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.305761+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028393+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34702,16 +34787,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:37.592178+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:43.638169+00:00"
               },
               "deterministic": true
             },
@@ -34724,7 +34814,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.305790+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028410+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34827,7 +34917,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.305883+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028463+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -34920,7 +35010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:37.592301+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34983,7 +35073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:37.592384+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34995,7 +35085,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.305965+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028510+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35045,23 +35135,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:37.592423+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:43.638284+00:00"
               },
               "deterministic": true
             },
@@ -35074,7 +35164,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.306028+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028547+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35089,16 +35179,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:37.592458+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:43.638302+00:00"
               },
               "deterministic": true
             },
@@ -35111,7 +35206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.306054+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028562+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -35150,7 +35245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592513+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35163,7 +35258,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.306104+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028593+00:00"
           },
           "uid": {
             "type": "string",
@@ -35181,7 +35276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592544+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35195,7 +35290,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.306132+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028610+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of dc_cluster_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35321,7 +35416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592610+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35366,7 +35461,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:37.592683+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35393,7 +35488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592725+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35432,16 +35527,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:37.592772+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:43.638468+00:00"
               },
               "deterministic": true
             },
@@ -35454,7 +35554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.306225+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028675+00:00"
           },
           "range": {
             "type": "string",
@@ -35479,7 +35579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592812+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35512,7 +35612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592859+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638514+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35545,7 +35645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592897+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35623,7 +35723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.592947+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35857,7 +35957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.593498+00:00"
+                "validatedAt": "2026-05-05T18:42:43.638855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35869,7 +35969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.306621+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.028895+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -35944,7 +36044,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:37.594237+00:00"
+                "validatedAt": "2026-05-05T18:42:43.639248+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36018,7 +36118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:37.595006+00:00"
+                "validatedAt": "2026-05-05T18:42:43.639638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36030,7 +36130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.307445+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.029375+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -36048,7 +36148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.595053+00:00"
+                "validatedAt": "2026-05-05T18:42:43.639662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36076,7 +36176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:37.595092+00:00"
+                "validatedAt": "2026-05-05T18:42:43.639683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36088,7 +36188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.307490+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.029401+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -36200,7 +36300,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.307631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.029482+00:00"
           },
           "value": {
             "type": "array",
@@ -36219,7 +36319,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.307662+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.029498+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -36484,23 +36584,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:58.517447+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:54.319726+00:00"
               },
               "deterministic": true
             },
@@ -36513,7 +36613,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.094799+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595594+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36529,16 +36629,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:58.517488+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:54.319746+00:00"
               },
               "deterministic": true
             },
@@ -36551,7 +36656,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.094828+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595611+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -36654,7 +36759,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.094914+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595670+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -36825,7 +36930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:58.517634+00:00"
+                "validatedAt": "2026-05-05T18:43:54.319807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36888,7 +36993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:58.517700+00:00"
+                "validatedAt": "2026-05-05T18:43:54.319837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36900,7 +37005,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.095054+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595752+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36950,23 +37055,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:58.517741+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:54.319855+00:00"
               },
               "deterministic": true
             },
@@ -36979,7 +37084,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.095117+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595789+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36994,16 +37099,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:58.517775+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:54.319872+00:00"
               },
               "deterministic": true
             },
@@ -37016,7 +37126,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.095143+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595805+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -37055,7 +37165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:58.517830+00:00"
+                "validatedAt": "2026-05-05T18:43:54.319897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37068,7 +37178,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.095195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595836+00:00"
           },
           "uid": {
             "type": "string",
@@ -37086,7 +37196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:58.517862+00:00"
+                "validatedAt": "2026-05-05T18:43:54.319914+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37100,7 +37210,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.095224+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.595853+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of forwarding_class is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -37392,23 +37502,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:28.024826+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:08.853081+00:00"
               },
               "deterministic": true
             },
@@ -37421,7 +37531,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672468+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884055+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37437,16 +37547,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:28.024883+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:08.853114+00:00"
               },
               "deterministic": true
             },
@@ -37459,7 +37574,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672500+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884072+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37562,7 +37677,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672591+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884124+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -37630,7 +37745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:28.025004+00:00"
+                "validatedAt": "2026-05-05T18:44:08.853188+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37692,7 +37807,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:28.025074+00:00"
+                "validatedAt": "2026-05-05T18:44:08.853221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37704,7 +37819,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672662+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884165+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -37753,23 +37868,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:28.025118+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:08.853241+00:00"
               },
               "deterministic": true
             },
@@ -37782,7 +37897,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672729+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884203+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37797,16 +37912,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:28.025155+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:08.853259+00:00"
               },
               "deterministic": true
             },
@@ -37819,7 +37939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672758+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884219+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -37858,7 +37978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:28.025212+00:00"
+                "validatedAt": "2026-05-05T18:44:08.853287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37871,7 +37991,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672811+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884249+00:00"
           },
           "uid": {
             "type": "string",
@@ -37888,7 +38008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:28.025243+00:00"
+                "validatedAt": "2026-05-05T18:44:08.853303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37902,7 +38022,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.672839+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.884266+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike1 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -38518,23 +38638,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:32.236369+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:10.893875+00:00"
               },
               "deterministic": true
             },
@@ -38547,7 +38667,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747080+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923507+00:00"
           },
           "namespace": {
             "type": "string",
@@ -38563,16 +38683,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:32.236410+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:10.893895+00:00"
               },
               "deterministic": true
             },
@@ -38585,7 +38710,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923523+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38688,7 +38813,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747199+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923577+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -38896,7 +39021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:32.236648+00:00"
+                "validatedAt": "2026-05-05T18:44:10.893998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38959,7 +39084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:32.236715+00:00"
+                "validatedAt": "2026-05-05T18:44:10.894028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38971,7 +39096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747395+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923694+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39021,23 +39146,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:32.236759+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:10.894046+00:00"
               },
               "deterministic": true
             },
@@ -39050,7 +39175,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747457+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923732+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39065,16 +39190,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:32.236793+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:10.894064+00:00"
               },
               "deterministic": true
             },
@@ -39087,7 +39217,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747485+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923748+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -39126,7 +39256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:32.236848+00:00"
+                "validatedAt": "2026-05-05T18:44:10.894094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39139,7 +39269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747537+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923779+00:00"
           },
           "uid": {
             "type": "string",
@@ -39157,7 +39287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:32.236878+00:00"
+                "validatedAt": "2026-05-05T18:44:10.894108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39171,7 +39301,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.747565+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.923796+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike_phase1_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -39675,23 +39805,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:35.977826+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:12.674680+00:00"
               },
               "deterministic": true
             },
@@ -39704,7 +39834,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.796912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950061+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39720,16 +39850,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:35.977867+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:12.674699+00:00"
               },
               "deterministic": true
             },
@@ -39742,7 +39877,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.796943+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950078+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39845,7 +39980,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.797034+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950131+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -39913,7 +40048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:35.977986+00:00"
+                "validatedAt": "2026-05-05T18:44:12.674749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39975,7 +40110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:35.978052+00:00"
+                "validatedAt": "2026-05-05T18:44:12.674783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39987,7 +40122,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.797103+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950171+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40036,23 +40171,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:35.978093+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:12.674803+00:00"
               },
               "deterministic": true
             },
@@ -40065,7 +40200,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.797166+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950209+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40080,16 +40215,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:35.978128+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:12.674821+00:00"
               },
               "deterministic": true
             },
@@ -40102,7 +40242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.797193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950224+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -40141,7 +40281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:35.978184+00:00"
+                "validatedAt": "2026-05-05T18:44:12.674845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40154,7 +40294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.797246+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950255+00:00"
           },
           "uid": {
             "type": "string",
@@ -40171,7 +40311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:35.978215+00:00"
+                "validatedAt": "2026-05-05T18:44:12.674860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40185,7 +40325,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.797273+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.950272+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike2 is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40573,23 +40713,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:40.513080+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:15.040261+00:00"
               },
               "deterministic": true
             },
@@ -40602,7 +40742,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892341+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002437+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40618,16 +40758,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:40.513121+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:15.040281+00:00"
               },
               "deterministic": true
             },
@@ -40640,7 +40785,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892371+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002454+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -40743,7 +40888,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892466+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002506+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -40811,7 +40956,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:40.513237+00:00"
+                "validatedAt": "2026-05-05T18:44:15.040331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40874,7 +41019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:40.513301+00:00"
+                "validatedAt": "2026-05-05T18:44:15.040362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40886,7 +41031,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892541+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002547+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40936,23 +41081,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:40.513355+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:15.040380+00:00"
               },
               "deterministic": true
             },
@@ -40965,7 +41110,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892607+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002583+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40980,16 +41125,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:40.513389+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:15.040398+00:00"
               },
               "deterministic": true
             },
@@ -41002,7 +41152,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892635+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002599+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -41041,7 +41191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:40.513445+00:00"
+                "validatedAt": "2026-05-05T18:44:15.040423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41054,7 +41204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892688+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002636+00:00"
           },
           "uid": {
             "type": "string",
@@ -41072,7 +41222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:40.513476+00:00"
+                "validatedAt": "2026-05-05T18:44:15.040438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41086,7 +41236,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.892715+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.002653+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ike_phase2_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -41566,7 +41716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:42.581765+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41624,23 +41774,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:42.581825+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:16.017435+00:00"
               },
               "deterministic": true
             },
@@ -41653,7 +41803,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930077+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023138+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41669,16 +41819,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:42.581861+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:16.017453+00:00"
               },
               "deterministic": true
             },
@@ -41691,7 +41846,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930108+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023154+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41794,7 +41949,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930197+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023207+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -41852,7 +42007,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:42.581993+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41908,7 +42063,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:42.582090+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017563+00:00"
               },
               "byteLength": {
                 "max": 64
@@ -41924,7 +42079,7 @@
             "x-original-maxLength": 64,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930247+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023236+00:00"
           },
           "ipv4_prefix": {
             "type": "string",
@@ -41952,7 +42107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:42.582144+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42018,7 +42173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:42.582196+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42081,7 +42236,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:42.582257+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42093,7 +42248,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930358+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023276+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -42143,23 +42298,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:42.582299+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:16.017669+00:00"
               },
               "deterministic": true
             },
@@ -42172,7 +42327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930424+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023313+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42187,16 +42342,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:42.582349+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:16.017687+00:00"
               },
               "deterministic": true
             },
@@ -42209,7 +42369,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930449+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023329+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -42248,7 +42408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:42.582404+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42261,7 +42421,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930501+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023360+00:00"
           },
           "uid": {
             "type": "string",
@@ -42278,7 +42438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:42.582434+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42292,7 +42452,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.930530+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.023376+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ip_prefix_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -42393,7 +42553,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:42.582498+00:00"
+                "validatedAt": "2026-05-05T18:44:16.017760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42604,23 +42764,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:28.623243+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.189222+00:00"
               },
               "deterministic": true
             },
@@ -42633,7 +42793,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.971769+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.692803+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42649,16 +42809,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:28.623288+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.189238+00:00"
               },
               "deterministic": true
             },
@@ -42671,7 +42836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.971798+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.692820+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42774,7 +42939,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.971888+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.692882+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -42884,7 +43049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:28.623427+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42947,7 +43112,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:28.623493+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42959,7 +43124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.972001+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.692958+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -43009,23 +43174,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:28.623536+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.189341+00:00"
               },
               "deterministic": true
             },
@@ -43038,7 +43203,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.972063+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.692999+00:00"
           },
           "namespace": {
             "type": "string",
@@ -43053,16 +43218,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:28.623570+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.189358+00:00"
               },
               "deterministic": true
             },
@@ -43075,7 +43245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.972091+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.693018+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -43114,7 +43284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:28.623626+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43127,7 +43297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.972145+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.693056+00:00"
           },
           "uid": {
             "type": "string",
@@ -43145,7 +43315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:28.623656+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189396+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43159,7 +43329,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.972173+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.693077+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_connector is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -43209,7 +43379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:28.623702+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43443,7 +43613,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.624483+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43486,7 +43656,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.624561+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43531,7 +43701,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.624639+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43649,7 +43819,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.624788+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43691,7 +43861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.624843+00:00"
+                "validatedAt": "2026-05-05T18:45:36.189957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43763,7 +43933,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.626372+00:00"
+                "validatedAt": "2026-05-05T18:45:36.190679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43868,7 +44038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:28.626455+00:00"
+                "validatedAt": "2026-05-05T18:45:36.190720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44013,7 +44183,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.353520+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.448125+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -44072,7 +44242,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:45.129442+00:00"
+                "validatedAt": "2026-05-05T18:46:14.040929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44105,7 +44275,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:45.129508+00:00"
+                "validatedAt": "2026-05-05T18:46:14.040963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44172,7 +44342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:45.129565+00:00"
+                "validatedAt": "2026-05-05T18:46:14.040989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44234,7 +44404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:45.129632+00:00"
+                "validatedAt": "2026-05-05T18:46:14.041020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44246,7 +44416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.353625+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.448180+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -44296,23 +44466,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:45.129677+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:14.041042+00:00"
               },
               "deterministic": true
             },
@@ -44325,7 +44495,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.353691+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.448220+00:00"
           },
           "namespace": {
             "type": "string",
@@ -44340,16 +44510,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:45.129709+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:14.041060+00:00"
               },
               "deterministic": true
             },
@@ -44362,7 +44537,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.353717+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.448238+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -44401,7 +44576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:45.129763+00:00"
+                "validatedAt": "2026-05-05T18:46:14.041085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44414,7 +44589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.353770+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.448270+00:00"
           },
           "uid": {
             "type": "string",
@@ -44431,7 +44606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:45.129794+00:00"
+                "validatedAt": "2026-05-05T18:46:14.041100+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44445,7 +44620,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.353798+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.448286+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of public_ip is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -44544,7 +44719,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:45.129853+00:00"
+                "validatedAt": "2026-05-05T18:46:14.041133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44661,7 +44836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002141+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44716,23 +44891,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002237+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225507+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -44748,7 +44923,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.162401+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120492+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -44793,7 +44968,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002343+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225549+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -44865,7 +45040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002602+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225684+00:00"
               },
               "deterministic": true
             },
@@ -44905,7 +45080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002669+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44946,7 +45121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002755+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225763+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -45019,7 +45194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002800+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225786+00:00"
               },
               "deterministic": true
             },
@@ -45063,7 +45238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002883+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45115,7 +45290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.002925+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45162,7 +45337,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.002989+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45173,7 +45348,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.162659+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120661+00:00"
           },
           "regex": {
             "type": "string",
@@ -45201,7 +45376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.003072+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225917+00:00"
               },
               "byteLength": {
                 "max": 256,
@@ -45304,7 +45479,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.003225+00:00"
+                "validatedAt": "2026-05-05T18:46:35.225990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45381,23 +45556,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.003299+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226026+00:00"
               },
               "deterministic": true
             },
@@ -45409,7 +45584,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.162800+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120748+00:00"
           },
           "path": {
             "type": "string",
@@ -45430,7 +45605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:25.003354+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45580,23 +45755,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:25.003410+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:35.226073+00:00"
               },
               "deterministic": true
             },
@@ -45609,7 +45784,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.162931+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120828+00:00"
           },
           "namespace": {
             "type": "string",
@@ -45625,16 +45800,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:25.003440+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:35.226089+00:00"
               },
               "deterministic": true
             },
@@ -45647,7 +45827,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.162958+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120845+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -45750,7 +45930,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163047+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120903+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -45815,7 +45995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.003586+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45945,7 +46125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.003676+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45982,7 +46162,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.003732+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46048,7 +46228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:25.003783+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46110,7 +46290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:25.003845+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46122,7 +46302,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163175+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.120982+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -46172,23 +46352,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:25.003887+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:35.226299+00:00"
               },
               "deterministic": true
             },
@@ -46201,7 +46381,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163238+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121020+00:00"
           },
           "namespace": {
             "type": "string",
@@ -46216,16 +46396,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:25.003919+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:35.226315+00:00"
               },
               "deterministic": true
             },
@@ -46238,7 +46423,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163266+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121036+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -46277,7 +46462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.003973+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46290,7 +46475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163332+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121070+00:00"
           },
           "uid": {
             "type": "string",
@@ -46307,7 +46492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.004003+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226354+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46321,7 +46506,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163359+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121086+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of route is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -46386,7 +46571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004055+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46451,7 +46636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004136+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46560,7 +46745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004191+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46617,7 +46802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:25.004235+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46652,7 +46837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:25.004273+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46746,7 +46931,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004344+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46806,7 +46991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004399+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46844,7 +47029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004481+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46886,7 +47071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004562+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46942,7 +47127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:17:25.004605+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226655+00:00"
               },
               "deterministic": true
             },
@@ -47025,7 +47210,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004692+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47099,7 +47284,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.004758+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47134,7 +47319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004833+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47173,7 +47358,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.004912+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47209,7 +47394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.004964+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47247,7 +47432,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005040+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47366,7 +47551,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005113+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47403,7 +47588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005173+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47446,7 +47631,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005232+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47481,7 +47666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005289+00:00"
+                "validatedAt": "2026-05-05T18:46:35.226989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47523,7 +47708,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005354+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47561,7 +47746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005411+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47605,7 +47790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005474+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47640,7 +47825,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005532+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47682,7 +47867,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005591+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47925,7 +48110,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.005720+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48000,7 +48185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.005763+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48012,7 +48197,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.163988+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121473+00:00"
           },
           "status": {
             "type": "string",
@@ -48037,7 +48222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.005803+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48049,7 +48234,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.164015+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121492+00:00"
           }
         },
         "x-f5xc-description-short": "Status information sent for each route entry within route.",
@@ -48246,23 +48431,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.006460+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227560+00:00"
               },
               "deterministic": true
             },
@@ -48275,7 +48460,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.164260+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121653+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -48316,7 +48501,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.006529+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48328,7 +48513,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.164306+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:09.121679+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -48388,7 +48573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.006581+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48420,7 +48605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.006630+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48466,7 +48651,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.006690+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48514,7 +48699,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.006748+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48556,7 +48741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:25.006799+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48593,7 +48778,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.006860+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48734,7 +48919,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.006931+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227795+00:00"
               },
               "deterministic": true
             },
@@ -48854,23 +49039,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.007059+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227860+00:00"
               },
               "deterministic": true
             },
@@ -48883,7 +49068,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.164513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.121891+00:00"
           },
           "secret_value": {
             "$ref": "#/components/schemas/schemaSecretType"
@@ -48909,7 +49094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.007125+00:00"
+                "validatedAt": "2026-05-05T18:46:35.227893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48921,7 +49106,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.164547+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:09.121914+00:00",
             "x-f5xc-conflicts-with": [
               "secret_value"
             ]
@@ -49010,7 +49195,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.007756+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49044,7 +49229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.007829+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49218,7 +49403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.007959+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49267,7 +49452,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008016+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49330,7 +49515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008087+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228361+00:00"
               },
               "deterministic": true
             },
@@ -49376,7 +49561,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008144+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49472,7 +49657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008224+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49506,7 +49691,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008293+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49548,7 +49733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008370+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49639,23 +49824,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008452+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228550+00:00"
               },
               "deterministic": true
             },
@@ -49668,7 +49853,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.165238+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.122467+00:00"
           },
           "overwrite": {
             "type": "boolean",
@@ -49718,7 +49903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.008519+00:00"
+                "validatedAt": "2026-05-05T18:46:35.228584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49730,7 +49915,7 @@
             "x-original-maxLength": 8096,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.165307+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:09.122523+00:00",
             "x-f5xc-conflicts-with": [
               "ignore_value",
               "secret_value"
@@ -49838,7 +50023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.009416+00:00"
+                "validatedAt": "2026-05-05T18:46:35.229002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49896,7 +50081,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.009467+00:00"
+                "validatedAt": "2026-05-05T18:46:35.229030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49954,7 +50139,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:25.009517+00:00"
+                "validatedAt": "2026-05-05T18:46:35.229058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50004,7 +50189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232224+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50069,7 +50254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232337+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275701+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50113,7 +50298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232408+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50157,7 +50342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232480+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50284,7 +50469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232605+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50346,7 +50531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232657+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50390,7 +50575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232703+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50495,7 +50680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232759+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50550,7 +50735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232821+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50575,7 +50760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.232861+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50631,16 +50816,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:29.232906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:37.275914+00:00"
               },
               "deterministic": true
             },
@@ -50653,7 +50843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.270686+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.234737+00:00"
           },
           "node": {
             "type": "string",
@@ -50682,7 +50872,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:29.232984+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50714,7 +50904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233026+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50744,7 +50934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233060+00:00"
+                "validatedAt": "2026-05-05T18:46:37.275989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50770,7 +50960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233087+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50869,7 +51059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233139+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50928,7 +51118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233192+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50977,7 +51167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:17:29.233239+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51085,7 +51275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233296+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51146,7 +51336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233371+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51175,16 +51365,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:29.233407+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:37.276137+00:00"
               },
               "deterministic": true
             },
@@ -51197,7 +51392,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.270932+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.234888+00:00"
           },
           "node": {
             "type": "string",
@@ -51226,7 +51421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:29.233477+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51258,7 +51453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233517+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276189+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51289,7 +51484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233550+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51388,7 +51583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233603+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51452,7 +51647,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233660+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51497,7 +51692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233707+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51560,7 +51755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:29.233757+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51645,7 +51840,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:29.233952+00:00"
+                "validatedAt": "2026-05-05T18:46:37.276393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51760,7 +51955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:36.053044+00:00"
+                "validatedAt": "2026-05-05T18:46:40.550868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51877,7 +52072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:36.053107+00:00"
+                "validatedAt": "2026-05-05T18:46:40.550902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51994,7 +52189,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:36.053174+00:00"
+                "validatedAt": "2026-05-05T18:46:40.550934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52111,23 +52306,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:36.053217+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:40.550953+00:00"
               },
               "deterministic": true
             },
@@ -52140,7 +52335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408167+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52156,16 +52351,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:36.053248+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:40.550969+00:00"
               },
               "deterministic": true
             },
@@ -52178,7 +52378,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419046+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408191+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52281,7 +52481,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419132+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408269+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -52349,7 +52549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:36.053371+00:00"
+                "validatedAt": "2026-05-05T18:46:40.551017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52412,7 +52612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:36.053430+00:00"
+                "validatedAt": "2026-05-05T18:46:40.551044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52424,7 +52624,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419200+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408331+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52474,23 +52674,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:36.053469+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:40.551061+00:00"
               },
               "deterministic": true
             },
@@ -52503,7 +52703,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419261+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408390+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52518,16 +52718,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:36.053500+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:40.551078+00:00"
               },
               "deterministic": true
             },
@@ -52540,7 +52745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419288+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408414+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -52579,7 +52784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:36.053553+00:00"
+                "validatedAt": "2026-05-05T18:46:40.551101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52592,7 +52797,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419352+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408453+00:00"
           },
           "uid": {
             "type": "string",
@@ -52610,7 +52815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:36.053585+00:00"
+                "validatedAt": "2026-05-05T18:46:40.551116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52624,7 +52829,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.419380+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.408478+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of srv6_network_slice is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -52798,7 +53003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:30.665744+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52857,7 +53062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:30.665798+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52915,7 +53120,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:30.665859+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52988,7 +53193,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:30.665925+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53157,23 +53362,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:30.666171+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:12.745264+00:00"
               },
               "deterministic": true
             },
@@ -53186,7 +53391,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452569+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215357+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53202,16 +53407,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:30.666203+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:12.745280+00:00"
               },
               "deterministic": true
             },
@@ -53224,7 +53434,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452594+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215374+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -53327,7 +53537,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452681+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215426+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -53395,7 +53605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:30.666316+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53457,7 +53667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:30.666388+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53469,7 +53679,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452750+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215467+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -53519,23 +53729,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:30.666427+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:12.745381+00:00"
               },
               "deterministic": true
             },
@@ -53548,7 +53758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452810+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215504+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53563,16 +53773,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:30.666458+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:12.745397+00:00"
               },
               "deterministic": true
             },
@@ -53585,7 +53800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452837+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215520+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -53624,7 +53839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:30.666511+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53637,7 +53852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215556+00:00"
           },
           "uid": {
             "type": "string",
@@ -53654,7 +53869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:30.666541+00:00"
+                "validatedAt": "2026-05-05T18:45:12.745437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53668,7 +53883,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.452916+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.215576+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of subnet is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53868,7 +54083,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:45.138479+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014533+00:00"
               },
               "deterministic": true
             },
@@ -53906,7 +54121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:45.138550+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53972,7 +54187,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:45.138625+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54023,7 +54238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:45.138664+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014635+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54061,7 +54276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:45.138719+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54151,16 +54366,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:45.138789+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:50.014695+00:00"
               },
               "deterministic": true
             },
@@ -54173,7 +54393,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.049492+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.162550+00:00"
           },
           "node": {
             "type": "string",
@@ -54205,7 +54425,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:45.138860+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54238,7 +54458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:45.138904+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54264,7 +54484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:45.138940+00:00"
+                "validatedAt": "2026-05-05T18:45:50.014769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54364,7 +54584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.085071+00:00"
+                "validatedAt": "2026-05-05T18:45:52.839958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54585,7 +54805,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:51.086532+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54634,7 +54854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.086585+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54677,7 +54897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:51.086646+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54700,7 +54920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.086689+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840691+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54732,7 +54952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:20:51.086726+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840710+00:00"
               },
               "deterministic": true
             },
@@ -54757,7 +54977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.086767+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54781,7 +55001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.086813+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54836,7 +55056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.086864+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54864,7 +55084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:20:51.086912+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840794+00:00"
               },
               "deterministic": true
             },
@@ -55027,23 +55247,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:51.086958+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:52.840813+00:00"
               },
               "deterministic": true
             },
@@ -55056,7 +55276,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.114991+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.200971+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55072,16 +55292,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:51.086991+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:52.840829+00:00"
               },
               "deterministic": true
             },
@@ -55094,7 +55319,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.200989+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -55197,7 +55422,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115109+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.201045+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -55254,7 +55479,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:51.087106+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55344,7 +55569,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:51.087159+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55406,7 +55631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:51.087219+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55418,7 +55643,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115200+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.201101+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -55468,23 +55693,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:51.087261+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:52.840953+00:00"
               },
               "deterministic": true
             },
@@ -55497,7 +55722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115262+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.201141+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55512,16 +55737,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:51.087293+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:52.840968+00:00"
               },
               "deterministic": true
             },
@@ -55534,7 +55764,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115287+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.201161+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -55573,7 +55803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.087358+00:00"
+                "validatedAt": "2026-05-05T18:45:52.840992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55586,7 +55816,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115347+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.201197+00:00"
           },
           "uid": {
             "type": "string",
@@ -55603,7 +55833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:51.087388+00:00"
+                "validatedAt": "2026-05-05T18:45:52.841006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55617,7 +55847,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.115375+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.201216+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tunnel is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -55980,7 +56210,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.562849+00:00"
+                "validatedAt": "2026-05-05T18:46:27.564171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56096,7 +56326,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.467438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032142+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Route Target\" BGP Two-Octet AS Specific Route Target as per RFC 4360.",
@@ -56149,7 +56379,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.467474+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032165+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Four-Octet AS Specific Route Target\" BGP Four-Octet AS Specific Route Target as per RFC 5668.",
@@ -56186,7 +56416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.563475+00:00"
+                "validatedAt": "2026-05-05T18:46:27.564471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56213,7 +56443,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.467513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032187+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"IPv4 Address Specific Route Target\" BGP IPv4 Address Specific Route Target as per RFC 4360.",
@@ -56355,7 +56585,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.564654+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56417,23 +56647,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.564693+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565059+00:00"
               },
               "deterministic": true
             },
@@ -56446,7 +56676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468215+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032620+00:00"
           },
           "namespace": {
             "type": "string",
@@ -56462,16 +56692,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.564725+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565076+00:00"
               },
               "deterministic": true
             },
@@ -56484,7 +56719,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468241+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032637+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -56587,7 +56822,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468336+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032690+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -56660,7 +56895,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.564845+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56697,7 +56932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.564904+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56768,7 +57003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:22:02.564955+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56831,7 +57066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:22:02.565014+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56843,7 +57078,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468456+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032763+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -56893,23 +57128,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565052+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565238+00:00"
               },
               "deterministic": true
             },
@@ -56922,7 +57157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468523+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032803+00:00"
           },
           "namespace": {
             "type": "string",
@@ -56937,16 +57172,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565082+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565254+00:00"
               },
               "deterministic": true
             },
@@ -56959,7 +57199,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468548+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032819+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -56998,7 +57238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565134+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57011,7 +57251,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468598+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032850+00:00"
           },
           "uid": {
             "type": "string",
@@ -57028,7 +57268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565163+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57042,7 +57282,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468627+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032867+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_network is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -57158,7 +57398,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565228+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57284,7 +57524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565290+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57329,7 +57569,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565358+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57356,7 +57596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565399+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57395,16 +57635,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565448+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565432+00:00"
               },
               "deterministic": true
             },
@@ -57417,7 +57662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468785+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032958+00:00"
           },
           "range": {
             "type": "string",
@@ -57442,7 +57687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565489+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57475,7 +57720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565539+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57508,7 +57753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565577+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57584,7 +57829,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565627+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57655,7 +57900,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468862+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.033002+00:00"
           },
           "value": {
             "type": "array",
@@ -57674,7 +57919,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468891+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.033020+00:00"
           }
         },
         "x-f5xc-description-short": "SID Counter Type Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -57762,16 +58007,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565684+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565544+00:00"
               },
               "deterministic": true
             },
@@ -57784,7 +58034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468942+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.033050+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Srv6 Network Namespace Parameters\" Configure the how namespace network is connected to srv6 network.",
@@ -57836,7 +58086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565743+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57875,7 +58125,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565815+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565611+00:00"
               },
               "deterministic": true
             },
@@ -57928,7 +58178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565879+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57994,7 +58244,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565934+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58033,7 +58283,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.566006+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565716+00:00"
               },
               "deterministic": true
             },
@@ -58086,7 +58336,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.566066+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565747+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/network_security.json
+++ b/docs/specifications/api/network_security.json
@@ -17058,23 +17058,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.512687+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.189250+00:00"
               },
               "deterministic": true
             },
@@ -17087,7 +17087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000339+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760376+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17103,16 +17103,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.512729+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.189270+00:00"
               },
               "deterministic": true
             },
@@ -17125,7 +17130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760395+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -17174,7 +17179,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.512799+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189306+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17350,7 +17355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.512869+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17374,16 +17379,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.512905+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.189356+00:00"
               },
               "deterministic": true
             },
@@ -17396,7 +17406,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000587+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760537+00:00"
           },
           "policy": {
             "type": "string",
@@ -17413,7 +17423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.512947+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17438,7 +17448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.512994+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17463,7 +17473,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513029+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17488,7 +17498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513075+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17548,7 +17558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513125+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189460+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17606,16 +17616,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.513186+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.189489+00:00"
               },
               "deterministic": true
             },
@@ -17628,7 +17643,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000679+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760600+00:00"
           },
           "start_time": {
             "type": "string",
@@ -17653,7 +17668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513234+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17686,7 +17701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513272+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17761,7 +17776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513340+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17841,7 +17856,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513380+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17853,7 +17868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000766+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760664+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -17911,7 +17926,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.513453+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189611+00:00"
               },
               "deterministic": true
             },
@@ -17980,7 +17995,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.513512+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18016,7 +18031,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.513571+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18052,7 +18067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.513628+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18167,7 +18182,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000924+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760764+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -18235,7 +18250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:21.513741+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18298,7 +18313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:21.513806+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18310,7 +18325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.000992+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760813+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -18360,23 +18375,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.513846+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.189808+00:00"
               },
               "deterministic": true
             },
@@ -18389,7 +18404,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001055+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760860+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18404,16 +18419,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.513880+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.189824+00:00"
               },
               "deterministic": true
             },
@@ -18426,7 +18446,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001081+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760879+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -18465,7 +18485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513932+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189848+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18478,7 +18498,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001133+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760918+00:00"
           },
           "uid": {
             "type": "string",
@@ -18496,7 +18516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.513962+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18510,7 +18530,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001162+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.760943+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of forward_proxy_policy is returned in 'List'.",
@@ -18674,7 +18694,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514054+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189907+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18729,7 +18749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514113+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18794,7 +18814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514196+00:00"
+                "validatedAt": "2026-05-05T18:42:06.189979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18837,7 +18857,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514277+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190019+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18882,7 +18902,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514365+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190058+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18927,7 +18947,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514446+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18971,7 +18991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514527+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19016,7 +19036,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514607+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19090,7 +19110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.514644+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19103,7 +19123,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001330+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761059+00:00"
           },
           "name": {
             "type": "string",
@@ -19120,23 +19140,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.514678+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.190210+00:00"
               },
               "deterministic": true
             },
@@ -19149,7 +19169,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001356+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761077+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19166,16 +19186,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.514711+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.190226+00:00"
               },
               "deterministic": true
             },
@@ -19188,7 +19213,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001381+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761093+00:00"
           },
           "tenant": {
             "type": "string",
@@ -19207,7 +19232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.514750+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19221,7 +19246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001407+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761110+00:00"
           },
           "uid": {
             "type": "string",
@@ -19240,7 +19265,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.514778+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19255,7 +19280,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001435+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761130+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -19321,7 +19346,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.514842+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19491,7 +19516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.514887+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190310+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19514,7 +19539,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.514925+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19526,7 +19551,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001489+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761166+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -19572,7 +19597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.514966+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190350+00:00"
               },
               "deterministic": true
             },
@@ -19598,7 +19623,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515014+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19625,7 +19650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515054+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19637,7 +19662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001538+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761200+00:00"
           },
           "service_name": {
             "type": "string",
@@ -19654,7 +19679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515100+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19687,7 +19712,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515144+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19699,7 +19724,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001572+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761231+00:00"
           },
           "type": {
             "type": "string",
@@ -19724,7 +19749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515182+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190449+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19792,7 +19817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515259+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19835,7 +19860,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515346+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19880,7 +19905,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515426+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19967,7 +19992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515470+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20013,23 +20038,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.515505+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.190602+00:00"
               },
               "deterministic": true
             },
@@ -20042,7 +20067,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001671+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761300+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -20139,7 +20164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515579+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20182,7 +20207,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515661+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20224,7 +20249,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515717+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20294,7 +20319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515777+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20351,7 +20376,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515863+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190788+00:00"
               },
               "deterministic": true
             },
@@ -20364,7 +20389,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001758+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761354+00:00"
           },
           "name": {
             "type": "string",
@@ -20392,23 +20417,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.515925+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190819+00:00"
               },
               "deterministic": true
             },
@@ -20420,7 +20445,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001785+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761370+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -20500,7 +20525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.515980+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20512,7 +20537,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001832+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761398+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -20590,7 +20615,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.516071+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190889+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -20606,7 +20631,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001870+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761426+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -20660,23 +20685,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.516109+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.190908+00:00"
               },
               "deterministic": true
             },
@@ -20689,7 +20714,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001914+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761453+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20706,16 +20731,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.516139+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.190924+00:00"
               },
               "deterministic": true
             },
@@ -20728,7 +20758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001939+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761469+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -20810,7 +20840,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.516223+00:00"
+                "validatedAt": "2026-05-05T18:42:06.190967+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -20826,7 +20856,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.001977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761492+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -20882,23 +20912,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.516263+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.190988+00:00"
               },
               "deterministic": true
             },
@@ -20911,7 +20941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002023+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761519+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20928,16 +20958,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.516294+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.191006+00:00"
               },
               "deterministic": true
             },
@@ -20950,7 +20985,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002048+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761535+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -21032,7 +21067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.516392+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191051+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -21048,7 +21083,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002085+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761558+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -21102,23 +21137,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.516432+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.191070+00:00"
               },
               "deterministic": true
             },
@@ -21131,7 +21166,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002133+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761585+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21148,16 +21183,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.516462+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.191085+00:00"
               },
               "deterministic": true
             },
@@ -21170,7 +21210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002161+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761600+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -21215,7 +21255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516514+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21243,7 +21283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516559+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21271,7 +21311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516604+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21300,7 +21340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516649+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21327,7 +21367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516679+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21341,7 +21381,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002236+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761655+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -21357,7 +21397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516719+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21466,7 +21506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516772+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21478,7 +21518,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761689+00:00"
           },
           "status": {
             "type": "string",
@@ -21496,7 +21536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516815+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21508,7 +21548,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002330+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761705+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -21550,7 +21590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516866+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21577,7 +21617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516916+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21604,7 +21644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.516961+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21632,7 +21672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517012+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21697,7 +21737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517079+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21746,7 +21786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517132+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21759,7 +21799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761774+00:00"
           },
           "uid": {
             "type": "string",
@@ -21778,7 +21818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517161+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21792,7 +21832,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002478+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761790+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -21870,7 +21910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:21.517218+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21882,7 +21922,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002508+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761807+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -21900,7 +21940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517265+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21928,7 +21968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517301+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21940,7 +21980,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002554+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761833+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -21982,7 +22022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517349+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21994,7 +22034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002581+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761849+00:00"
           },
           "name": {
             "type": "string",
@@ -22011,23 +22051,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.517384+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.191497+00:00"
               },
               "deterministic": true
             },
@@ -22040,7 +22080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002607+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761866+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22057,16 +22097,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:21.517415+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:06.191513+00:00"
               },
               "deterministic": true
             },
@@ -22079,7 +22124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002635+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761884+00:00"
           },
           "uid": {
             "type": "string",
@@ -22096,7 +22141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:21.517443+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22110,7 +22155,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002662+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761901+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -22184,7 +22229,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.517498+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22244,23 +22289,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.517563+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191588+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22276,7 +22321,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002709+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761929+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22299,16 +22344,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.517623+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191627+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -22324,7 +22374,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002734+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761949+00:00"
           },
           "tenant": {
             "type": "string",
@@ -22353,7 +22403,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.517690+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22367,7 +22417,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.002761+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:02.761966+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -22424,7 +22474,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:21.517746+00:00"
+                "validatedAt": "2026-05-05T18:42:06.191692+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22863,7 +22913,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.900098+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22895,7 +22945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900146+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23079,23 +23129,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:43.900198+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:17.500414+00:00"
               },
               "deterministic": true
             },
@@ -23108,7 +23158,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224106+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23124,16 +23174,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:43.900232+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:17.500430+00:00"
               },
               "deterministic": true
             },
@@ -23146,7 +23201,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826113+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224123+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23249,7 +23304,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826202+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224176+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23317,7 +23372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:08:43.900366+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23380,7 +23435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:08:43.900431+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23392,7 +23447,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826276+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224216+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -23442,23 +23497,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:43.900471+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:17.500530+00:00"
               },
               "deterministic": true
             },
@@ -23471,7 +23526,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826366+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224253+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23486,16 +23541,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:43.900503+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:17.500546+00:00"
               },
               "deterministic": true
             },
@@ -23508,7 +23568,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826393+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224269+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -23547,7 +23607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900557+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23560,7 +23620,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826446+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224300+00:00"
           },
           "uid": {
             "type": "string",
@@ -23578,7 +23638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900588+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23592,7 +23652,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826473+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224317+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_view is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -23683,7 +23743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900643+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23707,16 +23767,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:43.900678+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:17.500636+00:00"
               },
               "deterministic": true
             },
@@ -23729,7 +23794,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826532+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224353+00:00"
           },
           "policy": {
             "type": "string",
@@ -23746,7 +23811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900719+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23771,7 +23836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900766+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23796,7 +23861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900805+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23855,7 +23920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900854+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23913,16 +23978,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:08:43.900915+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:17.500743+00:00"
               },
               "deterministic": true
             },
@@ -23935,7 +24005,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826612+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224402+00:00"
           },
           "start_time": {
             "type": "string",
@@ -23960,7 +24030,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.900963+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23993,7 +24063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.901003+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24068,7 +24138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.901056+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24146,7 +24216,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:08:43.901099+00:00"
+                "validatedAt": "2026-05-05T18:42:17.500825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24158,7 +24228,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:09.826698+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.224453+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -24305,7 +24375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.901629+00:00"
+                "validatedAt": "2026-05-05T18:42:17.501066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24371,7 +24441,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.901687+00:00"
+                "validatedAt": "2026-05-05T18:42:17.501096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24429,7 +24499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.903568+00:00"
+                "validatedAt": "2026-05-05T18:42:17.501972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24468,7 +24538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.903623+00:00"
+                "validatedAt": "2026-05-05T18:42:17.502000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24527,7 +24597,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.903680+00:00"
+                "validatedAt": "2026-05-05T18:42:17.502028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24566,7 +24636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.903738+00:00"
+                "validatedAt": "2026-05-05T18:42:17.502057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24625,7 +24695,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.903794+00:00"
+                "validatedAt": "2026-05-05T18:42:17.502085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24664,7 +24734,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:08:43.903850+00:00"
+                "validatedAt": "2026-05-05T18:42:17.502112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24712,7 +24782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:05.333447+00:00"
+                "validatedAt": "2026-05-05T18:43:27.680172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24738,7 +24808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:05.333514+00:00"
+                "validatedAt": "2026-05-05T18:43:27.680200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24764,7 +24834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:05.333561+00:00"
+                "validatedAt": "2026-05-05T18:43:27.680221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24790,7 +24860,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:05.333597+00:00"
+                "validatedAt": "2026-05-05T18:43:27.680237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24816,7 +24886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:05.333646+00:00"
+                "validatedAt": "2026-05-05T18:43:27.680259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24870,7 +24940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:05.333697+00:00"
+                "validatedAt": "2026-05-05T18:43:27.680282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24982,23 +25052,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:30.263810+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:40.011018+00:00"
               },
               "deterministic": true
             },
@@ -25011,7 +25081,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.609532+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336638+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25027,16 +25097,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:30.263867+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:40.011038+00:00"
               },
               "deterministic": true
             },
@@ -25049,7 +25124,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.609563+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336655+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25114,7 +25189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.263983+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25250,7 +25325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264091+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25275,7 +25350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264149+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25299,16 +25374,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:30.264189+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:40.011141+00:00"
               },
               "deterministic": true
             },
@@ -25321,7 +25401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.609721+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336747+00:00"
           },
           "site": {
             "type": "string",
@@ -25338,7 +25418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264226+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25396,7 +25476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264280+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25454,16 +25534,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:30.264358+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:40.011213+00:00"
               },
               "deterministic": true
             },
@@ -25476,7 +25561,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.609784+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336790+00:00"
           },
           "start_time": {
             "type": "string",
@@ -25501,7 +25586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264410+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25534,7 +25619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264451+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25609,7 +25694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264504+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25686,7 +25771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264547+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25698,7 +25783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.609866+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336840+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -25759,7 +25844,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.264615+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25875,7 +25960,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.609999+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336919+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -25943,7 +26028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:30.264730+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26005,7 +26090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:30.264796+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26017,7 +26102,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.610067+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336960+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -26067,23 +26152,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:30.264840+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:40.011429+00:00"
               },
               "deterministic": true
             },
@@ -26096,7 +26181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.610129+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.336997+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26111,16 +26196,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:30.264875+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:40.011446+00:00"
               },
               "deterministic": true
             },
@@ -26133,7 +26223,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.610158+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.337013+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -26172,7 +26262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264930+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26185,7 +26275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.610212+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.337044+00:00"
           },
           "uid": {
             "type": "string",
@@ -26202,7 +26292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.264960+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26216,7 +26306,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.610239+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.337061+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fast_acl is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -26285,7 +26375,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.265024+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26406,7 +26496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.265095+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26503,7 +26593,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.265169+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26703,7 +26793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.265920+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26747,7 +26837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:30.265956+00:00"
+                "validatedAt": "2026-05-05T18:43:40.011956+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26801,7 +26891,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.266713+00:00"
+                "validatedAt": "2026-05-05T18:43:40.012331+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26915,7 +27005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.266790+00:00"
+                "validatedAt": "2026-05-05T18:43:40.012368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26970,7 +27060,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:30.266836+00:00"
+                "validatedAt": "2026-05-05T18:43:40.012393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27220,7 +27310,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:34.051306+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475274+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27284,23 +27374,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:34.051401+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:42.475301+00:00"
               },
               "deterministic": true
             },
@@ -27313,7 +27403,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667181+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367544+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27329,16 +27419,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:34.051453+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:42.475317+00:00"
               },
               "deterministic": true
             },
@@ -27351,7 +27446,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667212+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367561+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27454,7 +27549,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667337+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367635+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -27522,7 +27617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:34.051585+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27593,7 +27688,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:34.051643+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27656,7 +27751,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:34.051710+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27668,7 +27763,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667444+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367696+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27718,23 +27813,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:34.051753+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:42.475448+00:00"
               },
               "deterministic": true
             },
@@ -27747,7 +27842,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667508+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367733+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27762,16 +27857,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:34.051786+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:42.475464+00:00"
               },
               "deterministic": true
             },
@@ -27784,7 +27884,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667533+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367749+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27823,7 +27923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:34.051842+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27836,7 +27936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667584+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367779+00:00"
           },
           "uid": {
             "type": "string",
@@ -27853,7 +27953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:34.051875+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27867,7 +27967,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.667611+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.367796+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of fast_acl_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27978,7 +28078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:34.051934+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28091,7 +28191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:34.052859+00:00"
+                "validatedAt": "2026-05-05T18:43:42.475959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28104,7 +28204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.668157+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.368121+00:00"
           },
           "name": {
             "type": "string",
@@ -28121,23 +28221,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:34.052895+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:42.475974+00:00"
               },
               "deterministic": true
             },
@@ -28150,7 +28250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.668183+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.368136+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28167,16 +28267,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:34.052928+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:42.475990+00:00"
               },
               "deterministic": true
             },
@@ -28189,7 +28294,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.668208+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.368152+00:00"
           },
           "tenant": {
             "type": "string",
@@ -28208,7 +28313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:34.052968+00:00"
+                "validatedAt": "2026-05-05T18:43:42.476008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28222,7 +28327,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.668235+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.368167+00:00"
           },
           "uid": {
             "type": "string",
@@ -28241,7 +28346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:34.052998+00:00"
+                "validatedAt": "2026-05-05T18:43:42.476022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28256,7 +28361,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.668263+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.368183+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -28360,7 +28465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.287671+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28399,7 +28504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.287769+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28457,23 +28562,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.287821+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.534428+00:00"
               },
               "deterministic": true
             },
@@ -28486,7 +28591,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389509+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28502,16 +28607,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.287858+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.534445+00:00"
               },
               "deterministic": true
             },
@@ -28524,7 +28634,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708116+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389526+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28571,7 +28681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.287911+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534468+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28626,7 +28736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.287963+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28726,7 +28836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.288031+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28792,7 +28902,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.288090+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28823,16 +28933,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.288129+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.534574+00:00"
               },
               "deterministic": true
             },
@@ -28845,7 +28960,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708234+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389595+00:00"
           }
         },
         "x-f5xc-description-short": "Find Filter Sets API returns FilterSets that match the given context key(s).",
@@ -28984,7 +29099,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708343+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389662+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -29038,7 +29153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.288260+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29077,7 +29192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.288315+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29130,7 +29245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.288381+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29170,7 +29285,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.288443+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29236,7 +29351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:36.288500+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29299,7 +29414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:36.288563+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29311,7 +29426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708454+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389726+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -29361,23 +29476,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.288606+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.534800+00:00"
               },
               "deterministic": true
             },
@@ -29390,7 +29505,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708519+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389764+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29405,16 +29520,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.288639+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.534817+00:00"
               },
               "deterministic": true
             },
@@ -29427,7 +29547,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708545+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389781+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -29466,7 +29586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.288694+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29479,7 +29599,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708595+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389813+00:00"
           },
           "uid": {
             "type": "string",
@@ -29496,7 +29616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.288725+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29510,7 +29630,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.708624+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.389829+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of filter_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -29638,7 +29758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.288782+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29677,7 +29797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.288839+00:00"
+                "validatedAt": "2026-05-05T18:43:43.534911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29810,7 +29930,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.289258+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29842,7 +29962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.289305+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29928,7 +30048,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.289833+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535377+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -29944,7 +30064,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.709233+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390184+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -30000,23 +30120,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.289873+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.535397+00:00"
               },
               "deterministic": true
             },
@@ -30029,7 +30149,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.709279+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390211+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30046,16 +30166,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:36.289906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:43.535413+00:00"
               },
               "deterministic": true
             },
@@ -30068,7 +30193,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.709308+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390227+00:00"
           },
           "uid": {
             "type": "string",
@@ -30087,7 +30212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.289935+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30102,7 +30227,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.709346+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390244+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -30149,7 +30274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291017+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30177,7 +30302,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291063+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30206,7 +30331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291109+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30233,7 +30358,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291153+00:00"
+                "validatedAt": "2026-05-05T18:43:43.535999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30262,7 +30387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291202+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30287,7 +30412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291252+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30352,7 +30477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291331+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30390,7 +30515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:36.291387+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30402,7 +30527,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.710008+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390651+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -30443,7 +30568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291443+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30487,7 +30612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291484+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30501,7 +30626,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.710072+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390689+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -30520,7 +30645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291528+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30547,7 +30672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291560+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30562,7 +30687,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.710110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.390710+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -30577,7 +30702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:36.291600+00:00"
+                "validatedAt": "2026-05-05T18:43:43.536200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30670,7 +30795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.567781+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30790,7 +30915,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.567869+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460430+00:00"
               },
               "deterministic": true
             },
@@ -30853,23 +30978,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:47.567909+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:15.460448+00:00"
               },
               "deterministic": true
             },
@@ -30882,7 +31007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.229869+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.287910+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30898,16 +31023,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:47.567942+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:15.460465+00:00"
               },
               "deterministic": true
             },
@@ -30920,7 +31050,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.229896+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.287926+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31051,7 +31181,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230003+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.287989+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -31114,7 +31244,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.568085+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460532+00:00"
               },
               "deterministic": true
             },
@@ -31186,7 +31316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:47.568131+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31249,7 +31379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:47.568195+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460587+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31261,7 +31391,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230098+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.288041+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31311,23 +31441,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:47.568234+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:15.460605+00:00"
               },
               "deterministic": true
             },
@@ -31340,7 +31470,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230161+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.288078+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31355,16 +31485,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:47.568265+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:15.460632+00:00"
               },
               "deterministic": true
             },
@@ -31377,7 +31512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230187+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.288094+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -31416,7 +31551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:47.568330+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31429,7 +31564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230239+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.288125+00:00"
           },
           "uid": {
             "type": "string",
@@ -31446,7 +31581,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:47.568360+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31460,7 +31595,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230268+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.288141+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nat_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -31700,7 +31835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.568475+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460732+00:00"
               },
               "deterministic": true
             },
@@ -31774,23 +31909,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:47.568515+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:15.460752+00:00"
               },
               "deterministic": true
             },
@@ -31803,7 +31938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.230500+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.288274+00:00"
           },
           "network_interface": {
             "$ref": "#/components/schemas/schemaNetworkInterfaceRefType"
@@ -31927,7 +32062,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.568686+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31984,7 +32119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.568741+00:00"
+                "validatedAt": "2026-05-05T18:45:15.460865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32042,7 +32177,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.569150+00:00"
+                "validatedAt": "2026-05-05T18:45:15.461081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32099,7 +32234,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:47.569201+00:00"
+                "validatedAt": "2026-05-05T18:45:15.461106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32163,7 +32298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.569752+00:00"
+                "validatedAt": "2026-05-05T18:45:15.461372+00:00"
               },
               "deterministic": true
             },
@@ -32207,7 +32342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.569833+00:00"
+                "validatedAt": "2026-05-05T18:45:15.461413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32294,7 +32429,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.569888+00:00"
+                "validatedAt": "2026-05-05T18:45:15.461441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32389,7 +32524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:47.570817+00:00"
+                "validatedAt": "2026-05-05T18:45:15.461885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32445,7 +32580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:11.094466+00:00"
+                "validatedAt": "2026-05-05T18:45:27.654952+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32507,7 +32642,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:32.782110+00:00"
+                "validatedAt": "2026-05-05T18:45:38.166957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32570,7 +32705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:32.782175+00:00"
+                "validatedAt": "2026-05-05T18:45:38.166991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32631,7 +32766,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:32.782239+00:00"
+                "validatedAt": "2026-05-05T18:45:38.167022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32693,7 +32828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:32.782300+00:00"
+                "validatedAt": "2026-05-05T18:45:38.167053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32856,23 +32991,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:32.782371+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:38.167083+00:00"
               },
               "deterministic": true
             },
@@ -32885,7 +33020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.046850+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736662+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32901,16 +33036,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:32.782405+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:38.167100+00:00"
               },
               "deterministic": true
             },
@@ -32923,7 +33063,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.046878+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736680+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33026,7 +33166,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.047582+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736736+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33145,7 +33285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:32.782524+00:00"
+                "validatedAt": "2026-05-05T18:45:38.167151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33208,7 +33348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:32.782588+00:00"
+                "validatedAt": "2026-05-05T18:45:38.167180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33220,7 +33360,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.047710+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736813+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -33270,23 +33410,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:32.782629+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:38.167198+00:00"
               },
               "deterministic": true
             },
@@ -33299,7 +33439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.047772+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736851+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33314,16 +33454,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:32.782662+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:38.167215+00:00"
               },
               "deterministic": true
             },
@@ -33336,7 +33481,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.047797+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736867+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -33375,7 +33520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:32.782716+00:00"
+                "validatedAt": "2026-05-05T18:45:38.167243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33388,7 +33533,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.047847+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736903+00:00"
           },
           "uid": {
             "type": "string",
@@ -33406,7 +33551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:32.782746+00:00"
+                "validatedAt": "2026-05-05T18:45:38.167259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33420,7 +33565,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.047877+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.736920+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_firewall is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -33723,23 +33868,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:44.349467+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.347363+00:00"
               },
               "deterministic": true
             },
@@ -33752,7 +33897,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.313774+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881408+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33768,16 +33913,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:44.349500+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.347380+00:00"
               },
               "deterministic": true
             },
@@ -33790,7 +33940,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.313802+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881424+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33893,7 +34043,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.313935+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881502+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -33955,7 +34105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:44.349641+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33994,7 +34144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:44.349698+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34060,7 +34210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:44.349753+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34123,7 +34273,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:44.349818+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34135,7 +34285,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314024+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881553+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -34185,23 +34335,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:44.349858+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.347550+00:00"
               },
               "deterministic": true
             },
@@ -34214,7 +34364,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314085+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881590+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34229,16 +34379,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:44.349892+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.347566+00:00"
               },
               "deterministic": true
             },
@@ -34251,7 +34406,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314111+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881606+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -34290,7 +34445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.349946+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347591+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34303,7 +34458,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314161+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881643+00:00"
           },
           "uid": {
             "type": "string",
@@ -34320,7 +34475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.349976+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34334,7 +34489,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314188+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881660+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -34425,7 +34580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350032+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34449,16 +34604,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:44.350066+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.347656+00:00"
               },
               "deterministic": true
             },
@@ -34471,7 +34631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881693+00:00"
           },
           "policy": {
             "type": "string",
@@ -34488,7 +34648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350106+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34513,7 +34673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350152+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34538,7 +34698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350198+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34563,7 +34723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350234+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34623,7 +34783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350285+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34681,16 +34841,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:44.350357+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.347788+00:00"
               },
               "deterministic": true
             },
@@ -34703,7 +34868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314342+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881745+00:00"
           },
           "start_time": {
             "type": "string",
@@ -34728,7 +34893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350405+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34761,7 +34926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350445+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34836,7 +35001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350498+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34915,7 +35080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:44.350541+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34927,7 +35092,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.314429+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.881793+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -34979,7 +35144,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:44.350602+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35016,7 +35181,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:44.350662+00:00"
+                "validatedAt": "2026-05-05T18:45:44.347933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35334,7 +35499,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:48.508731+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35371,7 +35536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:48.508782+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35436,23 +35601,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:48.508823+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.343753+00:00"
               },
               "deterministic": true
             },
@@ -35465,7 +35630,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.420786+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932717+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35481,16 +35646,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:48.508857+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.343774+00:00"
               },
               "deterministic": true
             },
@@ -35503,7 +35673,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.420813+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932733+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -35606,7 +35776,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.420903+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932787+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35680,7 +35850,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:48.508978+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35717,7 +35887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:48.509025+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35790,7 +35960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:48.509074+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35853,7 +36023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:48.509137+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35865,7 +36035,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.421040+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932869+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35915,23 +36085,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:48.509178+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.343945+00:00"
               },
               "deterministic": true
             },
@@ -35944,7 +36114,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.421102+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932906+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35959,16 +36129,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:48.509210+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.343967+00:00"
               },
               "deterministic": true
             },
@@ -35981,7 +36156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.421129+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932922+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -36020,7 +36195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:48.509263+00:00"
+                "validatedAt": "2026-05-05T18:45:46.343991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36033,7 +36208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.421182+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932954+00:00"
           },
           "uid": {
             "type": "string",
@@ -36051,7 +36226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:48.509293+00:00"
+                "validatedAt": "2026-05-05T18:45:46.344010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36065,7 +36240,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.421215+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.932971+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_rule is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36182,7 +36357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:48.509366+00:00"
+                "validatedAt": "2026-05-05T18:45:46.344044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36219,7 +36394,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:48.509413+00:00"
+                "validatedAt": "2026-05-05T18:45:46.344070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36387,7 +36562,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.456728+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.952312+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -36441,7 +36616,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:50.463981+00:00"
+                "validatedAt": "2026-05-05T18:45:47.286378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36507,7 +36682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:50.464056+00:00"
+                "validatedAt": "2026-05-05T18:45:47.286406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36570,7 +36745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:50.464126+00:00"
+                "validatedAt": "2026-05-05T18:45:47.286438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36582,7 +36757,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.456814+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.952360+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -36632,23 +36807,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:50.464170+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:47.286459+00:00"
               },
               "deterministic": true
             },
@@ -36661,7 +36836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.456879+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.952397+00:00"
           },
           "namespace": {
             "type": "string",
@@ -36676,16 +36851,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:50.464206+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:47.286476+00:00"
               },
               "deterministic": true
             },
@@ -36698,7 +36878,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.456905+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.952413+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -36737,7 +36917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:50.464268+00:00"
+                "validatedAt": "2026-05-05T18:45:47.286502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36750,7 +36930,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.456957+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.952444+00:00"
           },
           "uid": {
             "type": "string",
@@ -36768,7 +36948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:50.464298+00:00"
+                "validatedAt": "2026-05-05T18:45:47.286516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36782,7 +36962,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.456984+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.952461+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of network_policy_set is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -36957,23 +37137,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:28.684665+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:05.657877+00:00"
               },
               "deterministic": true
             },
@@ -36986,7 +37166,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.061792+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290243+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37002,16 +37182,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:28.684698+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:05.657893+00:00"
               },
               "deterministic": true
             },
@@ -37024,7 +37209,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.061818+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290259+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -37087,7 +37272,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.684766+00:00"
+                "validatedAt": "2026-05-05T18:46:05.657927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37170,7 +37355,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.684831+00:00"
+                "validatedAt": "2026-05-05T18:46:05.657958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37279,7 +37464,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.061993+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290367+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -37347,7 +37532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:28.684945+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37410,7 +37595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:28.685008+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37422,7 +37607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.062065+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290408+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -37472,23 +37657,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:28.685047+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:05.658055+00:00"
               },
               "deterministic": true
             },
@@ -37501,7 +37686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.062128+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290446+00:00"
           },
           "namespace": {
             "type": "string",
@@ -37516,16 +37701,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:28.685078+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:05.658074+00:00"
               },
               "deterministic": true
             },
@@ -37538,7 +37728,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.062154+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290461+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -37577,7 +37767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:28.685135+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37590,7 +37780,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.062208+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290493+00:00"
           },
           "uid": {
             "type": "string",
@@ -37608,7 +37798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:28.685164+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37622,7 +37812,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.062238+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.290509+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of policy_based_routing is returned in 'List'.",
@@ -37708,7 +37898,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.685235+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658155+00:00"
               },
               "deterministic": true
             },
@@ -37755,7 +37945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.685293+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37840,7 +38030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.685363+00:00"
+                "validatedAt": "2026-05-05T18:46:05.658216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38009,7 +38199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.687980+00:00"
+                "validatedAt": "2026-05-05T18:46:05.659466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38080,7 +38270,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.688038+00:00"
+                "validatedAt": "2026-05-05T18:46:05.659500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38151,7 +38341,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:28.688098+00:00"
+                "validatedAt": "2026-05-05T18:46:05.659531+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38344,7 +38534,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:58.709484+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38376,7 +38566,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:58.709540+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024186+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38493,7 +38683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.709595+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38505,7 +38695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.958882+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.304881+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter. Filters that will use segment labels to filter out timeseries.",
@@ -38552,7 +38742,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.958928+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.304977+00:00"
           }
         },
         "x-f5xc-description-short": "Node Metric Data. Metric Data for each metric type in the segments node.",
@@ -38619,7 +38809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.709661+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38642,7 +38832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.709710+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38664,23 +38854,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:58.709745+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.024279+00:00"
               },
               "deterministic": true
             },
@@ -38693,7 +38883,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.958994+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305063+00:00"
           },
           "site": {
             "type": "string",
@@ -38708,7 +38898,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.709780+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38731,7 +38921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.709815+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38847,23 +39037,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:58.709858+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.024334+00:00"
               },
               "deterministic": true
             },
@@ -38876,7 +39066,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959097+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305147+00:00"
           },
           "namespace": {
             "type": "string",
@@ -38892,16 +39082,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:58.709889+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.024351+00:00"
               },
               "deterministic": true
             },
@@ -38914,7 +39109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959125+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305169+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -39017,7 +39212,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959214+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305238+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -39085,7 +39280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:58.710001+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39147,7 +39342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:58.710060+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39159,7 +39354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959280+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305367+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39209,23 +39404,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:58.710099+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.024444+00:00"
               },
               "deterministic": true
             },
@@ -39238,7 +39433,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959349+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305416+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39253,16 +39448,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:58.710131+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.024461+00:00"
               },
               "deterministic": true
             },
@@ -39275,7 +39475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959375+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305678+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -39314,7 +39514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710184+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39327,7 +39527,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959425+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305726+00:00"
           },
           "uid": {
             "type": "string",
@@ -39344,7 +39544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710214+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024499+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39358,7 +39558,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959453+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305749+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of segment is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -39432,7 +39632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710266+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39555,7 +39755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710345+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39616,16 +39816,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:58.710412+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.024580+00:00"
               },
               "deterministic": true
             },
@@ -39638,7 +39843,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.959563+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.305896+00:00"
           },
           "start_time": {
             "type": "string",
@@ -39663,7 +39868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710459+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024602+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39696,7 +39901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710499+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39788,7 +39993,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:58.710559+00:00"
+                "validatedAt": "2026-05-05T18:46:52.024654+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39955,7 +40160,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.999829+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.393765+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -40010,7 +40215,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:00.718588+00:00"
+                "validatedAt": "2026-05-05T18:46:52.991988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40076,7 +40281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:18:00.718639+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992012+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40139,7 +40344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:18:00.718699+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40151,7 +40356,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.999908+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.393818+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -40201,23 +40406,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:00.718738+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.992057+00:00"
               },
               "deterministic": true
             },
@@ -40230,7 +40435,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.999970+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.393866+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40245,16 +40450,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:00.718771+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:52.992073+00:00"
               },
               "deterministic": true
             },
@@ -40267,7 +40477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.999996+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.393885+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -40306,7 +40516,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:00.718824+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40319,7 +40529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.000046+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.393920+00:00"
           },
           "uid": {
             "type": "string",
@@ -40337,7 +40547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:00.718854+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40351,7 +40561,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.000074+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.393939+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of segment_connection is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40450,7 +40660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:00.718916+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40515,7 +40725,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:00.718981+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40561,7 +40771,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:00.719045+00:00"
+                "validatedAt": "2026-05-05T18:46:52.992208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40795,7 +41005,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192030+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40858,7 +41068,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192102+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40896,7 +41106,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192161+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40933,7 +41143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192226+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40970,7 +41180,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192287+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41032,7 +41242,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192379+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41121,7 +41331,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192479+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41227,23 +41437,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192556+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948689+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -41259,7 +41469,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.323658+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.813488+00:00"
           }
         },
         "x-f5xc-description-short": "Argument matcher specifies the name of a single argument in the body and the criteria to match it.",
@@ -41314,7 +41524,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.192676+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41405,7 +41615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.192738+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41417,7 +41627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.323742+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.813540+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"BotAdvanced Domain Matcher Type\" Bot Advanced Domain Matcher Type.",
@@ -41592,7 +41802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.192822+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41604,7 +41814,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.323877+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.813625+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Bot Advanced Path Matcher Type\" Bot Advanced Path Matcher Type.",
@@ -41686,7 +41896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.192877+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41776,7 +41986,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.192931+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41800,7 +42010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.192981+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41898,23 +42108,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193065+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948939+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -41930,7 +42140,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.324025+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.813714+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -42338,7 +42548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.193171+00:00"
+                "validatedAt": "2026-05-05T18:47:00.948987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42442,7 +42652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193229+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42548,7 +42758,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193289+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42610,7 +42820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193359+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42688,23 +42898,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193434+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949115+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -42720,7 +42930,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.324207+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.813819+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -42884,7 +43094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193513+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42930,7 +43140,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193571+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949181+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42968,7 +43178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193628+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43036,7 +43246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193690+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43082,7 +43292,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193748+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43339,7 +43549,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.193856+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43825,7 +44035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194169+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43912,7 +44122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194212+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43936,7 +44146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194255+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44010,7 +44220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194314+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44034,7 +44244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194377+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44113,7 +44323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194415+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949578+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44172,7 +44382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194465+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44276,7 +44486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.194526+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44337,7 +44547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.194585+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44378,7 +44588,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.194645+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44420,7 +44630,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.194704+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44495,7 +44705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194754+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44519,7 +44729,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194800+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44543,7 +44753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194844+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44567,7 +44777,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194888+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44591,7 +44801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.194931+00:00"
+                "validatedAt": "2026-05-05T18:47:00.949841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45032,23 +45242,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.195176+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.949947+00:00"
               },
               "deterministic": true
             },
@@ -45061,7 +45271,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.325222+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.814454+00:00"
           },
           "regex_values": {
             "type": "array",
@@ -45368,23 +45578,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197429+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951047+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -45400,7 +45610,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.326482+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815208+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -45464,7 +45674,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197488+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45523,7 +45733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197548+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45569,7 +45779,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197600+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45613,7 +45823,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197655+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45651,7 +45861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197714+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45741,7 +45951,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197839+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45753,7 +45963,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.326617+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815292+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -45886,7 +46096,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.197947+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45989,7 +46199,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198032+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46092,7 +46302,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198115+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46192,7 +46402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198174+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46241,7 +46451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198249+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951481+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46288,7 +46498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198306+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46320,7 +46530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.198371+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46357,7 +46567,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198448+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951574+00:00"
               },
               "deterministic": true
             },
@@ -46408,7 +46618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198507+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951603+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46455,7 +46665,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198566+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46545,7 +46755,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.198633+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46690,23 +46900,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.198874+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.951793+00:00"
               },
               "deterministic": true
             },
@@ -46719,7 +46929,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327354+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815747+00:00"
           },
           "namespace": {
             "type": "string",
@@ -46735,16 +46945,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.198906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.951809+00:00"
               },
               "deterministic": true
             },
@@ -46757,7 +46972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327383+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815762+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -46870,7 +47085,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327470+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815814+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -46934,7 +47149,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.199038+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951869+00:00"
               },
               "deterministic": true
             },
@@ -47014,7 +47229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:18:17.199084+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47088,7 +47303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:18:17.199140+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47100,7 +47315,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327547+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815864+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -47150,23 +47365,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.199179+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.951947+00:00"
               },
               "deterministic": true
             },
@@ -47179,7 +47394,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327609+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815901+00:00"
           },
           "namespace": {
             "type": "string",
@@ -47194,16 +47409,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.199211+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.951964+00:00"
               },
               "deterministic": true
             },
@@ -47216,7 +47436,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327633+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815917+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -47255,7 +47475,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199266+00:00"
+                "validatedAt": "2026-05-05T18:47:00.951988+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47268,7 +47488,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327684+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815947+00:00"
           },
           "uid": {
             "type": "string",
@@ -47285,7 +47505,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199293+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47299,7 +47519,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327710+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.815963+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of service_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -47469,7 +47689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.199379+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952039+00:00"
               },
               "deterministic": true
             },
@@ -47579,7 +47799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199438+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47603,16 +47823,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.199468+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.952079+00:00"
               },
               "deterministic": true
             },
@@ -47625,7 +47850,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327815+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.816024+00:00"
           },
           "policy": {
             "type": "string",
@@ -47642,7 +47867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199514+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47667,7 +47892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199563+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47692,7 +47917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199609+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47717,7 +47942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199645+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47742,7 +47967,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199695+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47809,7 +48034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199743+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47867,16 +48092,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:17.199808+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:00.952232+00:00"
               },
               "deterministic": true
             },
@@ -47889,7 +48119,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327910+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.816081+00:00"
           },
           "start_time": {
             "type": "string",
@@ -47914,7 +48144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199859+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47947,7 +48177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199897+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48029,7 +48259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199948+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48134,7 +48364,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:17.199991+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48146,7 +48376,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.327991+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.816130+00:00"
           }
         },
         "x-f5xc-description-short": "Label filter can be specified to filter metrics based on label match.",
@@ -48214,7 +48444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.200051+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952344+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48256,7 +48486,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.200112+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48302,7 +48532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.200171+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48342,7 +48572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.200228+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48383,7 +48613,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:17.200282+00:00"
+                "validatedAt": "2026-05-05T18:47:00.952477+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/nginx_one.json
+++ b/docs/specifications/api/nginx_one.json
@@ -3341,7 +3341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353132+00:00"
+                "validatedAt": "2026-05-05T18:45:19.666825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3354,7 +3354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.421796+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394132+00:00"
           },
           "name": {
             "type": "string",
@@ -3371,23 +3371,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.353199+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.666860+00:00"
               },
               "deterministic": true
             },
@@ -3400,7 +3400,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.421828+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394149+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3417,16 +3417,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.353238+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.666878+00:00"
               },
               "deterministic": true
             },
@@ -3439,7 +3444,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.421856+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394166+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3458,7 +3463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353279+00:00"
+                "validatedAt": "2026-05-05T18:45:19.666897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3472,7 +3477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.421885+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394182+00:00"
           },
           "uid": {
             "type": "string",
@@ -3491,7 +3496,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353309+00:00"
+                "validatedAt": "2026-05-05T18:45:19.666911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3506,7 +3511,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.421914+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394199+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3651,7 +3656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:56.353433+00:00"
+                "validatedAt": "2026-05-05T18:45:19.666960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3713,7 +3718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:56.353498+00:00"
+                "validatedAt": "2026-05-05T18:45:19.666990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3725,7 +3730,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394267+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -3775,23 +3780,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.353541+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667010+00:00"
               },
               "deterministic": true
             },
@@ -3804,7 +3809,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422098+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394304+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3819,16 +3824,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.353575+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667027+00:00"
               },
               "deterministic": true
             },
@@ -3841,7 +3851,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422126+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394319+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -3864,7 +3874,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353616+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3877,7 +3887,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422172+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394345+00:00"
           },
           "uid": {
             "type": "string",
@@ -3894,7 +3904,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353646+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667059+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3908,7 +3918,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422202+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394362+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_csg is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4003,7 +4013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353714+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4035,7 +4045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353765+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4120,7 +4130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353830+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4143,7 +4153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353873+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4190,7 +4200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353918+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4213,7 +4223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.353956+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4225,7 +4235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422394+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394463+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4301,7 +4311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354001+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4347,23 +4357,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.354038+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667240+00:00"
               },
               "deterministic": true
             },
@@ -4376,7 +4386,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422456+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394497+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4495,7 +4505,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:56.354149+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667296+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4511,7 +4521,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422514+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394531+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4567,23 +4577,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.354193+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667316+00:00"
               },
               "deterministic": true
             },
@@ -4596,7 +4606,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394559+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4613,16 +4623,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.354225+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667332+00:00"
               },
               "deterministic": true
             },
@@ -4635,7 +4650,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422588+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394574+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -4696,7 +4711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354279+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4708,7 +4723,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422627+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394596+00:00"
           },
           "status": {
             "type": "string",
@@ -4726,7 +4741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354317+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4738,7 +4753,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422654+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394625+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -4780,7 +4795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354404+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4807,7 +4822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354454+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4834,7 +4849,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354498+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4862,7 +4877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354549+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4927,7 +4942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354619+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4976,7 +4991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354674+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4989,7 +5004,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422773+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394697+00:00"
           },
           "uid": {
             "type": "string",
@@ -5008,7 +5023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354704+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5022,7 +5037,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422800+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394714+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -5072,7 +5087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354740+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5084,7 +5099,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422829+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394733+00:00"
           },
           "name": {
             "type": "string",
@@ -5101,23 +5116,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.354774+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667566+00:00"
               },
               "deterministic": true
             },
@@ -5130,7 +5145,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422854+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394748+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5147,16 +5162,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:56.354808+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:19.667583+00:00"
               },
               "deterministic": true
             },
@@ -5169,7 +5189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422879+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394764+00:00"
           },
           "uid": {
             "type": "string",
@@ -5186,7 +5206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:56.354837+00:00"
+                "validatedAt": "2026-05-05T18:45:19.667596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5200,7 +5220,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.422905+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.394780+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -5325,7 +5345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:59.870189+00:00"
+                "validatedAt": "2026-05-05T18:45:22.120201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5348,7 +5368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:59.870234+00:00"
+                "validatedAt": "2026-05-05T18:45:22.120224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5420,7 +5440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:59.870289+00:00"
+                "validatedAt": "2026-05-05T18:45:22.120254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5483,7 +5503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:59.870368+00:00"
+                "validatedAt": "2026-05-05T18:45:22.120288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5495,7 +5515,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.453774+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.411443+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -5545,23 +5565,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:59.870410+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:22.120310+00:00"
               },
               "deterministic": true
             },
@@ -5574,7 +5594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.453836+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.411480+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5589,16 +5609,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:59.870443+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:22.120328+00:00"
               },
               "deterministic": true
             },
@@ -5611,7 +5636,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.453862+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.411496+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -5634,7 +5659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:59.870484+00:00"
+                "validatedAt": "2026-05-05T18:45:22.120347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5647,7 +5672,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.453903+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.411522+00:00"
           },
           "uid": {
             "type": "string",
@@ -5664,7 +5689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:59.870513+00:00"
+                "validatedAt": "2026-05-05T18:45:22.120361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5678,7 +5703,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.453930+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.411539+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_instance is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -5784,16 +5809,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:03.628624+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:23.966913+00:00"
               },
               "deterministic": true
             },
@@ -5806,7 +5836,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.494843+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433573+00:00"
           }
         },
         "x-f5xc-description-short": "GET NGINX One Dataplane servers request.",
@@ -5856,7 +5886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:03.628669+00:00"
+                "validatedAt": "2026-05-05T18:45:23.966936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5960,7 +5990,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.494926+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433635+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -6026,7 +6056,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:03.628781+00:00"
+                "validatedAt": "2026-05-05T18:45:23.966987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6089,7 +6119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:03.628845+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6101,7 +6131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.494996+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433677+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -6151,23 +6181,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:03.628885+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:23.967034+00:00"
               },
               "deterministic": true
             },
@@ -6180,7 +6210,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495061+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433714+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6195,16 +6225,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:03.628918+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:23.967051+00:00"
               },
               "deterministic": true
             },
@@ -6217,7 +6252,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495088+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433731+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -6256,7 +6291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.628972+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6269,7 +6304,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495140+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433761+00:00"
           },
           "uid": {
             "type": "string",
@@ -6286,7 +6321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629003+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6300,7 +6335,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495169+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433778+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_server is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -6362,7 +6397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629042+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6396,7 +6431,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:03.629101+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967144+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6420,7 +6455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629153+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6446,7 +6481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629205+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6483,7 +6518,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:03.629250+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967213+00:00"
               },
               "deterministic": true
             },
@@ -6510,7 +6545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629295+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6673,7 +6708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629400+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6704,23 +6739,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:03.629438+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:23.967296+00:00"
               },
               "deterministic": true
             },
@@ -6733,7 +6768,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495351+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433880+00:00"
           },
           "waf_spec": {
             "$ref": "#/components/schemas/nginx_instanceWAFSpec"
@@ -6782,7 +6817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:03.629562+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967355+00:00"
               },
               "deterministic": true
             },
@@ -6808,7 +6843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629611+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6835,7 +6870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629651+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6847,7 +6882,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495449+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433935+00:00"
           },
           "service_name": {
             "type": "string",
@@ -6864,7 +6899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629699+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6897,7 +6932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629742+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6909,7 +6944,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495485+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.433957+00:00"
           },
           "type": {
             "type": "string",
@@ -6934,7 +6969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.629780+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6988,7 +7023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.630096+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7016,7 +7051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.630142+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7044,7 +7079,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.630187+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7073,7 +7108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.630230+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7100,7 +7135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.630260+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7114,7 +7149,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.495759+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.434117+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -7130,7 +7165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:03.630301+00:00"
+                "validatedAt": "2026-05-05T18:45:23.967706+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7233,23 +7268,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:03.630948+00:00"
+                "validatedAt": "2026-05-05T18:45:23.968012+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7265,7 +7300,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.496124+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.434333+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7288,16 +7323,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:03.631011+00:00"
+                "validatedAt": "2026-05-05T18:45:23.968045+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -7313,7 +7353,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.496150+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.434349+00:00"
           },
           "tenant": {
             "type": "string",
@@ -7342,7 +7382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:03.631078+00:00"
+                "validatedAt": "2026-05-05T18:45:23.968079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7356,7 +7396,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.496176+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.434365+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -7473,7 +7513,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.188834+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7590,7 +7630,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.188925+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7649,23 +7689,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.188976+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.670611+00:00"
               },
               "deterministic": true
             },
@@ -7678,7 +7718,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651076+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511739+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7694,16 +7734,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.189012+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.670638+00:00"
               },
               "deterministic": true
             },
@@ -7716,7 +7761,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651105+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511757+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7846,7 +7891,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651214+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511822+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7894,7 +7939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.189134+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7919,7 +7964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.189191+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7957,7 +8002,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.189251+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8026,7 +8071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:13.189306+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8089,7 +8134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:13.189386+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670812+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8101,7 +8146,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651331+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511885+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8152,23 +8197,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.189426+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.670832+00:00"
               },
               "deterministic": true
             },
@@ -8181,7 +8226,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651395+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511922+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8196,16 +8241,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.189459+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.670849+00:00"
               },
               "deterministic": true
             },
@@ -8218,7 +8268,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651420+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511938+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8257,7 +8307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.189513+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8270,7 +8320,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651470+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511969+00:00"
           },
           "uid": {
             "type": "string",
@@ -8288,7 +8338,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.189543+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8302,7 +8352,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651497+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.511986+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nginx_service_discovery is returned in 'List'.",
@@ -8365,7 +8415,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.189605+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8467,7 +8517,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.189672+00:00"
+                "validatedAt": "2026-05-05T18:45:28.670957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8522,7 +8572,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.189750+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8562,7 +8612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.189827+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8702,7 +8752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.190396+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671312+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -8718,7 +8768,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651846+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512190+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -8772,23 +8822,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.190438+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.671333+00:00"
               },
               "deterministic": true
             },
@@ -8801,7 +8851,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651894+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512218+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8818,16 +8868,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.190469+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.671349+00:00"
               },
               "deterministic": true
             },
@@ -8840,7 +8895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.651919+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512234+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -8885,7 +8940,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.190669+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8898,7 +8953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652058+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512317+00:00"
           },
           "name": {
             "type": "string",
@@ -8915,23 +8970,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.190702+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.671466+00:00"
               },
               "deterministic": true
             },
@@ -8944,7 +8999,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652084+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512333+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8961,16 +9016,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.190734+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.671483+00:00"
               },
               "deterministic": true
             },
@@ -8983,7 +9043,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512349+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9002,7 +9062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.190773+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9016,7 +9076,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652139+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512365+00:00"
           },
           "uid": {
             "type": "string",
@@ -9035,7 +9095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:13.190801+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9050,7 +9110,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652168+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512382+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9132,7 +9192,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:13.190893+00:00"
+                "validatedAt": "2026-05-05T18:45:28.671564+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -9148,7 +9208,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652205+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512405+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -9202,23 +9262,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.190934+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.671584+00:00"
               },
               "deterministic": true
             },
@@ -9231,7 +9291,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652250+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512432+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9248,16 +9308,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:13.190966+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:28.671600+00:00"
               },
               "deterministic": true
             },
@@ -9270,7 +9335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.652276+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.512448+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",

--- a/docs/specifications/api/object_storage.json
+++ b/docs/specifications/api/object_storage.json
@@ -2879,7 +2879,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.218157+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615509+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2914,7 +2914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.218236+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615546+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2950,7 +2950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.218351+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615596+00:00"
               },
               "deterministic": true
             },
@@ -2963,7 +2963,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363138+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.123784+00:00"
           },
           "mobile_app_shield": {
             "$ref": "#/components/schemas/stored_objectMobileAppShieldAttributes"
@@ -3002,23 +3002,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 512,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.218430+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615646+00:00"
               },
               "deterministic": true
             },
@@ -3030,7 +3030,7 @@
             },
             "x-original-maxLength": 512,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.123816+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3053,16 +3053,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:26.218468+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:10.615665+00:00"
               },
               "deterministic": true
             },
@@ -3075,7 +3080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363224+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.123832+00:00"
           },
           "no_attributes": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -3105,7 +3110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.218519+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3136,7 +3141,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.218597+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615726+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3278,7 +3283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.218678+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615759+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3308,7 +3313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.218727+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3346,7 +3351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.218808+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3406,23 +3411,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:26.218850+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:10.615835+00:00"
               },
               "deterministic": true
             },
@@ -3435,7 +3440,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363411+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.123935+00:00"
           },
           "no_attributes": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -3455,7 +3460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.218891+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3468,7 +3473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363447+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.123956+00:00"
           },
           "versions": {
             "type": "array",
@@ -3531,7 +3536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:26.218947+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3588,7 +3593,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.219030+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3647,7 +3652,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.219104+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3697,7 +3702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.219154+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3801,7 +3806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:19:26.219196+00:00"
+                "validatedAt": "2026-05-05T18:45:10.615996+00:00"
               },
               "deterministic": true
             },
@@ -3857,7 +3862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.219250+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3892,7 +3897,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.219347+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616063+00:00"
               },
               "deterministic": true
             },
@@ -3905,7 +3910,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363592+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.124041+00:00"
           },
           "mobile_app_shield": {
             "$ref": "#/components/schemas/stored_objectMobileAppShieldAttributes"
@@ -3936,23 +3941,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:26.219386+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:10.616080+00:00"
               },
               "deterministic": true
             },
@@ -3965,7 +3970,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363644+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.124072+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3987,16 +3992,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:26.219422+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:10.616099+00:00"
               },
               "deterministic": true
             },
@@ -4009,7 +4019,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363671+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.124087+00:00"
           },
           "no_attributes": {
             "$ref": "#/components/schemas/schemaEmpty"
@@ -4042,7 +4052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:19:26.219463+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616118+00:00"
               },
               "deterministic": true
             },
@@ -4075,7 +4085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.219509+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4087,7 +4097,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363713+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.124118+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4166,7 +4176,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.219566+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4201,7 +4211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:26.219651+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616204+00:00"
               },
               "deterministic": true
             },
@@ -4214,7 +4224,7 @@
             "x-original-maxLength": 512,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363750+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.124142+00:00"
           },
           "latest_version": {
             "type": "boolean",
@@ -4258,7 +4268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:19:26.219693+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616223+00:00"
               },
               "deterministic": true
             },
@@ -4283,7 +4293,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:26.219732+00:00"
+                "validatedAt": "2026-05-05T18:45:10.616239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4295,7 +4305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.363793+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.124170+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {

--- a/docs/specifications/api/observability.json
+++ b/docs/specifications/api/observability.json
@@ -14894,7 +14894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606333+00:00"
+                "validatedAt": "2026-05-05T18:40:09.206936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14920,7 +14920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606399+00:00"
+                "validatedAt": "2026-05-05T18:40:09.206964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14945,16 +14945,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:32.606440+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:09.206983+00:00"
               },
               "deterministic": true
             },
@@ -14967,7 +14972,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.903966+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871502+00:00"
           },
           "start_time": {
             "type": "string",
@@ -14992,7 +14997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606492+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15059,7 +15064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606546+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15126,7 +15131,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606609+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15155,7 +15160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606656+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15201,16 +15206,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:32.606695+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:09.207092+00:00"
               },
               "deterministic": true
             },
@@ -15223,7 +15233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904056+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871554+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -15241,7 +15251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606741+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15311,7 +15321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606782+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15499,7 +15509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606864+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15597,7 +15607,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904218+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871653+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -15633,7 +15643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606931+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15682,7 +15692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606971+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15721,7 +15731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:04:32.607020+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207232+00:00"
               },
               "deterministic": true
             },
@@ -15788,7 +15798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607073+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15833,7 +15843,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607114+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15856,7 +15866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607146+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15868,7 +15878,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904348+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871721+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -15961,7 +15971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607206+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15985,7 +15995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607236+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15997,7 +16007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904423+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871766+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -16039,7 +16049,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607276+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16063,7 +16073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607306+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16075,7 +16085,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904470+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871793+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -16113,7 +16123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607357+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16170,7 +16180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607398+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16194,7 +16204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607428+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16206,7 +16216,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904527+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871828+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -16256,7 +16266,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904566+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871851+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -16313,7 +16323,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904604+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871873+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -16349,7 +16359,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607498+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16460,7 +16470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607559+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16526,7 +16536,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904707+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871933+00:00"
           },
           "value": {
             "type": "number",
@@ -16542,7 +16552,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904733+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871948+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -16579,7 +16589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607622+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16664,7 +16674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:32.607696+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16676,7 +16686,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904785+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871977+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -16691,7 +16701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607745+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16717,7 +16727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607783+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16729,7 +16739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904858+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.872004+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -16782,7 +16792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864515+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16805,7 +16815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864578+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16817,7 +16827,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.317949+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -16863,7 +16873,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.864626+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438868+00:00"
               },
               "deterministic": true
             },
@@ -16889,7 +16899,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864678+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16916,7 +16926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864719+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16928,7 +16938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795488+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.317977+00:00"
           },
           "service_name": {
             "type": "string",
@@ -16945,7 +16955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864768+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16978,7 +16988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864816+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16990,7 +17000,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795525+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.317998+00:00"
           },
           "type": {
             "type": "string",
@@ -17015,7 +17025,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864854+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17103,7 +17113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.864898+00:00"
+                "validatedAt": "2026-05-05T18:42:55.438991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17149,23 +17159,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.864938+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439010+00:00"
               },
               "deterministic": true
             },
@@ -17178,7 +17188,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795595+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318038+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -17296,7 +17306,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.865057+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439070+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17312,7 +17322,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795655+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318073+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17366,23 +17376,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865100+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439090+00:00"
               },
               "deterministic": true
             },
@@ -17395,7 +17405,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795702+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318100+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17412,16 +17422,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865131+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439107+00:00"
               },
               "deterministic": true
             },
@@ -17434,7 +17449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795727+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318116+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -17516,7 +17531,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.865223+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439152+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17532,7 +17547,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795766+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318139+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17588,23 +17603,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865262+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439172+00:00"
               },
               "deterministic": true
             },
@@ -17617,7 +17632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795811+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318166+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17634,16 +17649,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865292+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439187+00:00"
               },
               "deterministic": true
             },
@@ -17656,7 +17676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795838+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318182+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -17738,7 +17758,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.865396+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439232+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -17754,7 +17774,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795876+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318205+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -17810,23 +17830,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865438+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439252+00:00"
               },
               "deterministic": true
             },
@@ -17839,7 +17859,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795924+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318232+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17856,16 +17876,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865469+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439268+00:00"
               },
               "deterministic": true
             },
@@ -17878,7 +17903,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795952+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318248+00:00"
           },
           "uid": {
             "type": "string",
@@ -17897,7 +17922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865499+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17912,7 +17937,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.795982+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318264+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -17959,7 +17984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865534+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439298+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17972,7 +17997,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796009+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318281+00:00"
           },
           "name": {
             "type": "string",
@@ -17989,23 +18014,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865568+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439314+00:00"
               },
               "deterministic": true
             },
@@ -18018,7 +18043,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796035+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318297+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18035,16 +18060,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865598+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439329+00:00"
               },
               "deterministic": true
             },
@@ -18057,7 +18087,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796060+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318312+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18076,7 +18106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865636+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18090,7 +18120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796087+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318328+00:00"
           },
           "uid": {
             "type": "string",
@@ -18109,7 +18139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865665+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18124,7 +18154,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796116+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318344+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -18206,7 +18236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.865756+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439405+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -18222,7 +18252,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796158+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318367+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -18276,23 +18306,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865795+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439424+00:00"
               },
               "deterministic": true
             },
@@ -18305,7 +18335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796205+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318394+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18322,16 +18352,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.865827+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.439439+00:00"
               },
               "deterministic": true
             },
@@ -18344,7 +18379,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318410+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -18389,7 +18424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865878+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18417,7 +18452,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865926+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439482+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18445,7 +18480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.865971+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18474,7 +18509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866016+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18501,7 +18536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866046+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18515,7 +18550,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796307+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318453+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -18531,7 +18566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866088+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18640,7 +18675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866144+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439589+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18652,7 +18687,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796375+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318486+00:00"
           },
           "status": {
             "type": "string",
@@ -18670,7 +18705,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866184+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439607+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18682,7 +18717,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796401+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318502+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -18724,7 +18759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866236+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18751,7 +18786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866285+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18778,7 +18813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866341+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18806,7 +18841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866392+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18871,7 +18906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866461+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18920,7 +18955,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866515+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18933,7 +18968,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796518+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318572+00:00"
           },
           "uid": {
             "type": "string",
@@ -18952,7 +18987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866544+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18966,7 +19001,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796547+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318588+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -19018,7 +19053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866596+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19046,7 +19081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866643+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19075,7 +19110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866689+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19102,7 +19137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866732+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19131,7 +19166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866780+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19156,7 +19191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866830+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19221,7 +19256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.866899+00:00"
+                "validatedAt": "2026-05-05T18:42:55.439975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19259,7 +19294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.866960+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19271,7 +19306,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796666+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318663+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -19312,7 +19347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867015+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19356,7 +19391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867055+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19370,7 +19405,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796727+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318700+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -19389,7 +19424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867100+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19416,7 +19451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867129+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19431,7 +19466,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796762+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318721+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -19446,7 +19481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867169+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19527,7 +19562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867209+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19539,7 +19574,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796806+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318748+00:00"
           },
           "name": {
             "type": "string",
@@ -19556,23 +19591,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.867244+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.440150+00:00"
               },
               "deterministic": true
             },
@@ -19585,7 +19620,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796832+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318764+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19602,16 +19637,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.867275+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.440166+00:00"
               },
               "deterministic": true
             },
@@ -19624,7 +19664,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796857+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318780+00:00"
           },
           "uid": {
             "type": "string",
@@ -19641,7 +19681,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867303+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19655,7 +19695,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.796883+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318796+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -19711,7 +19751,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867362+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440208+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19772,7 +19812,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867413+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19929,7 +19969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867472+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19990,7 +20030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867522+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20290,7 +20330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867649+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20303,7 +20343,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797155+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.318958+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -20338,7 +20378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867711+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20475,7 +20515,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867809+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20509,7 +20549,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.867880+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20542,7 +20582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.867929+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20646,23 +20686,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.867992+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.440515+00:00"
               },
               "deterministic": true
             },
@@ -20675,7 +20715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797371+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319081+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20691,16 +20731,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.868023+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.440533+00:00"
               },
               "deterministic": true
             },
@@ -20713,7 +20758,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797397+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319096+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20772,7 +20817,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:01.868074+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20883,7 +20928,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797503+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319160+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20947,7 +20992,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.868210+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20960,7 +21005,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797540+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319182+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -20995,7 +21040,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.868271+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21132,7 +21177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.868378+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21166,7 +21211,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.868449+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21199,7 +21244,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.868496+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21308,7 +21353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.868584+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21321,7 +21366,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797735+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319300+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -21357,7 +21402,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.868646+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21498,7 +21543,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.868740+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440881+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21533,7 +21578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.868805+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21567,7 +21612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.868851+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21680,7 +21725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:01.868919+00:00"
+                "validatedAt": "2026-05-05T18:42:55.440972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21743,7 +21788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:01.868978+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21755,7 +21800,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.797960+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319435+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -21805,23 +21850,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.869015+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.441018+00:00"
               },
               "deterministic": true
             },
@@ -21834,7 +21879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.798025+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319471+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21849,16 +21894,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:01.869046+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:55.441041+00:00"
               },
               "deterministic": true
             },
@@ -21871,7 +21921,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.798052+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319487+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21910,7 +21960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.869098+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21923,7 +21973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.798106+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319518+00:00"
           },
           "uid": {
             "type": "string",
@@ -21940,7 +21990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.869127+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21954,7 +22004,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.798134+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319534+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of v1_dns_monitor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22017,7 +22067,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.869202+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441119+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22055,7 +22105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.869240+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441139+00:00"
               },
               "deterministic": true
             },
@@ -22190,7 +22240,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.869313+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22203,7 +22253,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.798228+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.319591+00:00"
           },
           "external_sources": {
             "type": "array",
@@ -22238,7 +22288,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.869383+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22375,7 +22425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.869479+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22409,7 +22459,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:01.869550+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22442,7 +22492,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:01.869598+00:00"
+                "validatedAt": "2026-05-05T18:42:55.441312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22693,7 +22743,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.816351+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22831,7 +22881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.816454+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22892,7 +22942,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.816525+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22949,7 +22999,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.816613+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23019,7 +23069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.816698+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894671+00:00"
               },
               "deterministic": true
             },
@@ -23104,23 +23154,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:19.816736+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:04.894691+00:00"
               },
               "deterministic": true
             },
@@ -23133,7 +23183,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.518434+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802354+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23149,16 +23199,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:19.816768+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:04.894707+00:00"
               },
               "deterministic": true
             },
@@ -23171,7 +23226,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.518460+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802370+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -23230,7 +23285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:19.816818+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23341,7 +23396,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.518566+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802434+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -23412,7 +23467,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.816942+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23550,7 +23605,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817039+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894852+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23611,7 +23666,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817107+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23668,7 +23723,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817194+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23738,7 +23793,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817281+00:00"
+                "validatedAt": "2026-05-05T18:44:04.894982+00:00"
               },
               "deterministic": true
             },
@@ -23835,7 +23890,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817356+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23977,7 +24032,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817447+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24040,7 +24095,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817516+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24099,7 +24154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817601+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24171,7 +24226,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817685+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895200+00:00"
               },
               "deterministic": true
             },
@@ -24254,7 +24309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817742+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24266,7 +24321,7 @@
             "x-original-maxLength": 2048,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519077+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802751+00:00"
           },
           "value": {
             "type": "string",
@@ -24289,7 +24344,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.817808+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895275+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24301,7 +24356,7 @@
             "x-original-maxLength": 8192,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519105+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802768+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24359,7 +24414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:19.817854+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895303+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24422,7 +24477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:19.817913+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24434,7 +24489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519163+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802802+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24484,23 +24539,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:19.817951+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:04.895354+00:00"
               },
               "deterministic": true
             },
@@ -24513,7 +24568,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519224+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802839+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24528,16 +24583,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:19.817981+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:04.895374+00:00"
               },
               "deterministic": true
             },
@@ -24550,7 +24610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519250+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802854+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -24589,7 +24649,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:19.818035+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24602,7 +24662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519304+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802885+00:00"
           },
           "uid": {
             "type": "string",
@@ -24619,7 +24679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:19.818065+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24633,7 +24693,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.519339+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.802901+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of v1_http_monitor is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -24778,7 +24838,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.818135+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895461+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24916,7 +24976,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.818234+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24977,7 +25037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.818303+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25034,7 +25094,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.818404+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25104,7 +25164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.818488+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895658+00:00"
               },
               "deterministic": true
             },
@@ -25183,7 +25243,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:19.818561+00:00"
+                "validatedAt": "2026-05-05T18:44:04.895696+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25495,7 +25555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.409611+00:00"
+                "validatedAt": "2026-05-05T18:45:00.879916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25519,16 +25579,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.409679+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.879948+00:00"
               },
               "deterministic": true
             },
@@ -25541,7 +25606,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961574+00:00"
           },
           "query": {
             "type": "string",
@@ -25561,7 +25626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.409732+00:00"
+                "validatedAt": "2026-05-05T18:45:00.879973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25594,7 +25659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.409784+00:00"
+                "validatedAt": "2026-05-05T18:45:00.879996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25666,7 +25731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.409836+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25695,7 +25760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.409883+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25719,16 +25784,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.409920+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880058+00:00"
               },
               "deterministic": true
             },
@@ -25741,7 +25811,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961630+00:00"
           },
           "query": {
             "type": "string",
@@ -25761,7 +25831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.409970+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25814,7 +25884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410022+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25888,7 +25958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410076+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25912,16 +25982,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.410112+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880145+00:00"
               },
               "deterministic": true
             },
@@ -25934,7 +26009,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660719+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961682+00:00"
           },
           "query": {
             "type": "string",
@@ -25954,7 +26029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410161+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25987,7 +26062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410207+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26059,7 +26134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410256+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26088,7 +26163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410295+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26111,16 +26186,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.410341+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880249+00:00"
               },
               "deterministic": true
             },
@@ -26133,7 +26213,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660796+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961727+00:00"
           },
           "query": {
             "type": "string",
@@ -26153,7 +26233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410391+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26206,7 +26286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410444+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26266,7 +26346,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410690+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26292,7 +26372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410740+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26330,7 +26410,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:17.410808+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26365,7 +26445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410855+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26389,16 +26469,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.410890+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880502+00:00"
               },
               "deterministic": true
             },
@@ -26411,7 +26496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661010+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961850+00:00"
           },
           "site": {
             "type": "string",
@@ -26428,7 +26513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410925+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26461,7 +26546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410975+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26535,7 +26620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411381+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26559,16 +26644,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.411416+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880758+00:00"
               },
               "deterministic": true
             },
@@ -26581,7 +26671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661304+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962029+00:00"
           },
           "query": {
             "type": "string",
@@ -26601,7 +26691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411466+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26634,7 +26724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411515+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26706,7 +26796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411566+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26735,7 +26825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411606+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26759,16 +26849,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.411639+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880861+00:00"
               },
               "deterministic": true
             },
@@ -26781,7 +26876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661391+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962074+00:00"
           },
           "query": {
             "type": "string",
@@ -26801,7 +26896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411689+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26854,7 +26949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411738+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26928,7 +27023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411788+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26952,16 +27047,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.411822+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880945+00:00"
               },
               "deterministic": true
             },
@@ -26974,7 +27074,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661478+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962123+00:00"
           },
           "query": {
             "type": "string",
@@ -26994,7 +27094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411870+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27019,7 +27119,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411905+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27052,7 +27152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411953+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27125,7 +27225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412002+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27154,7 +27254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412041+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27178,16 +27278,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412074+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881061+00:00"
               },
               "deterministic": true
             },
@@ -27200,7 +27305,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661562+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962173+00:00"
           },
           "query": {
             "type": "string",
@@ -27220,7 +27325,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412123+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27262,7 +27367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412159+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27298,7 +27403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412208+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27373,7 +27478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412258+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27397,16 +27502,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412293+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881160+00:00"
               },
               "deterministic": true
             },
@@ -27419,7 +27529,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661655+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962227+00:00"
           },
           "query": {
             "type": "string",
@@ -27439,7 +27549,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412350+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27464,7 +27574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412384+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27497,7 +27607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412432+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27570,7 +27680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412482+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27599,7 +27709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412520+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27623,16 +27733,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412554+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881278+00:00"
               },
               "deterministic": true
             },
@@ -27645,7 +27760,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661735+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962279+00:00"
           },
           "query": {
             "type": "string",
@@ -27665,7 +27780,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412603+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27707,7 +27822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412640+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27743,7 +27858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412690+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27812,7 +27927,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:17.412765+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27824,7 +27939,7 @@
             "x-original-maxLength": 256,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661824+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962332+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -27881,7 +27996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412818+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27963,7 +28078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412875+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27992,7 +28107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412918+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28040,16 +28155,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412955+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881461+00:00"
               },
               "deterministic": true
             },
@@ -28062,7 +28182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962384+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -28080,7 +28200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412999+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28151,7 +28271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413198+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28175,16 +28295,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413232+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881583+00:00"
               },
               "deterministic": true
             },
@@ -28197,7 +28322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662163+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962541+00:00"
           },
           "query": {
             "type": "string",
@@ -28217,7 +28342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413280+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28250,7 +28375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413336+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28322,7 +28447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413386+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28366,7 +28491,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413426+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28389,16 +28514,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413459+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881690+00:00"
               },
               "deterministic": true
             },
@@ -28411,7 +28541,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962591+00:00"
           },
           "query": {
             "type": "string",
@@ -28431,7 +28561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413506+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28484,7 +28614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413557+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28559,7 +28689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413658+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28583,16 +28713,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413692+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881797+00:00"
               },
               "deterministic": true
             },
@@ -28605,7 +28740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662372+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962663+00:00"
           },
           "query": {
             "type": "string",
@@ -28625,7 +28760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413739+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28658,7 +28793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413786+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28730,7 +28865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413834+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28759,7 +28894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413872+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28783,16 +28918,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881897+00:00"
               },
               "deterministic": true
             },
@@ -28805,7 +28945,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662448+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962708+00:00"
           },
           "query": {
             "type": "string",
@@ -28825,7 +28965,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413953+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28878,7 +29018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414002+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28953,7 +29093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414050+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28977,16 +29117,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.414082+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881979+00:00"
               },
               "deterministic": true
             },
@@ -28999,7 +29144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662530+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962757+00:00"
           },
           "query": {
             "type": "string",
@@ -29019,7 +29164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.414129+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29052,7 +29197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414175+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29124,7 +29269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414223+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29153,7 +29298,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.414260+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29177,16 +29322,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.414292+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.882077+00:00"
               },
               "deterministic": true
             },
@@ -29199,7 +29349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662601+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962801+00:00"
           },
           "query": {
             "type": "string",
@@ -29219,7 +29369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.414348+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29272,7 +29422,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414397+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29345,7 +29495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414437+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29503,7 +29653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414492+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29640,7 +29790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414544+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29760,7 +29910,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414595+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29804,7 +29954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414631+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29910,7 +30060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414680+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30012,7 +30162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414728+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30056,7 +30206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414764+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30234,7 +30384,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:39.608684+00:00"
+                "validatedAt": "2026-05-05T18:45:11.616388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30416,7 +30566,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648010+00:00"
+                "validatedAt": "2026-05-05T18:45:18.911867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30442,7 +30592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648059+00:00"
+                "validatedAt": "2026-05-05T18:45:18.911889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30488,7 +30638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648110+00:00"
+                "validatedAt": "2026-05-05T18:45:18.911912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30513,7 +30663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648161+00:00"
+                "validatedAt": "2026-05-05T18:45:18.911934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30539,7 +30689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648215+00:00"
+                "validatedAt": "2026-05-05T18:45:18.911959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30564,7 +30714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648264+00:00"
+                "validatedAt": "2026-05-05T18:45:18.911980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30589,7 +30739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648311+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30614,7 +30764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648378+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30639,7 +30789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648427+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30682,7 +30832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648471+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30707,7 +30857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648516+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30733,7 +30883,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648565+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30758,7 +30908,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648621+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30784,7 +30934,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648674+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30809,7 +30959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648728+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912197+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30834,7 +30984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648776+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30861,7 +31011,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648825+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30887,7 +31037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648874+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30913,7 +31063,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648930+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30939,7 +31089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.648980+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30965,7 +31115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649030+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30991,7 +31141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649077+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31016,7 +31166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649118+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912377+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31042,7 +31192,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649157+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31067,7 +31217,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649203+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912420+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31092,7 +31242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649244+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912439+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31182,7 +31332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.649294+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912462+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31296,16 +31446,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:43.649379+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:18.912497+00:00"
               },
               "deterministic": true
             },
@@ -31318,7 +31473,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.904897+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.539480+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31357,7 +31512,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649421+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31382,7 +31537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649467+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31451,7 +31606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.649519+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31497,7 +31652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649568+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31522,7 +31677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649607+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31548,7 +31703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649663+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31573,7 +31728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649704+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31598,7 +31753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649750+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31623,7 +31778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.649789+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31678,7 +31833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.649826+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31795,7 +31950,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.649915+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31870,16 +32025,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:43.649969+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:18.912782+00:00"
               },
               "deterministic": true
             },
@@ -31892,7 +32052,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.905156+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.539592+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -31931,7 +32091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650010+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31956,7 +32116,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650057+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32025,7 +32185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.650106+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32071,7 +32231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650153+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32096,7 +32256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650202+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912891+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32121,7 +32281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650241+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32147,7 +32307,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650299+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912938+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32172,7 +32332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650351+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912957+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32197,7 +32357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650398+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32222,7 +32382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650442+00:00"
+                "validatedAt": "2026-05-05T18:45:18.912998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32247,7 +32407,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650480+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32301,7 +32461,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650524+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913038+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32341,16 +32501,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:43.650570+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:18.913061+00:00"
               },
               "deterministic": true
             },
@@ -32363,7 +32528,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.905393+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.539691+00:00"
           },
           "start_time": {
             "type": "string",
@@ -32381,7 +32546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650614+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32406,7 +32571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650657+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32529,7 +32694,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650727+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913133+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32541,7 +32706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.905471+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.539731+00:00"
           },
           "segments": {
             "type": "array",
@@ -32576,7 +32741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650777+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32660,7 +32825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650836+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32685,7 +32850,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650874+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32710,7 +32875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650920+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913224+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32736,7 +32901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.650964+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32788,7 +32953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.651002+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32873,7 +33038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651072+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32918,7 +33083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651116+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32943,7 +33108,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651162+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32986,7 +33151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651214+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33038,7 +33203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.651251+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33080,7 +33245,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651288+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33106,7 +33271,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651343+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33132,7 +33297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651393+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33158,7 +33323,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651442+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33183,7 +33348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651480+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33208,7 +33373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651518+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33234,7 +33399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651557+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33260,7 +33425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651606+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33285,7 +33450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651654+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33311,7 +33476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651704+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33336,7 +33501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651752+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33362,7 +33527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651800+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33388,7 +33553,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651853+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33414,7 +33579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651900+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33440,7 +33605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.651953+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33465,7 +33630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652001+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33490,7 +33655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652048+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33515,7 +33680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652088+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33541,7 +33706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652137+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33567,7 +33732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652181+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33682,7 +33847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652253+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33710,7 +33875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652298+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33738,7 +33903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:19:43.652341+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913888+00:00"
               },
               "deterministic": true
             },
@@ -33787,7 +33952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652380+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33849,7 +34014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652433+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33874,7 +34039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652477+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913951+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33899,7 +34064,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652526+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33934,7 +34099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652582+00:00"
+                "validatedAt": "2026-05-05T18:45:18.913999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33959,7 +34124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652626+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33971,7 +34136,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906071+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540014+00:00"
           },
           "source": {
             "type": "string",
@@ -33988,7 +34153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652664+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914039+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34098,7 +34263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652741+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34123,7 +34288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652781+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34184,7 +34349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652843+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34223,7 +34388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652899+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34235,7 +34400,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906226+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540080+00:00"
           },
           "region": {
             "type": "string",
@@ -34252,7 +34417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.652937+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34348,7 +34513,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906276+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540109+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -34387,7 +34552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.653007+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34412,7 +34577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653052+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34459,7 +34624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653101+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34485,7 +34650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653140+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34511,7 +34676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653179+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34537,7 +34702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653228+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34562,7 +34727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653268+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914323+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34574,7 +34739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906371+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540158+00:00"
           },
           "region": {
             "type": "string",
@@ -34591,7 +34756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653306+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34617,7 +34782,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653353+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34669,7 +34834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653391+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34694,7 +34859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653434+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34719,7 +34884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653476+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34731,7 +34896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906435+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540195+00:00"
           },
           "source": {
             "type": "string",
@@ -34748,7 +34913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653514+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34804,7 +34969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:43.653597+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34838,7 +35003,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:43.653672+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34862,16 +35027,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:43.653707+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:18.914535+00:00"
               },
               "deterministic": true
             },
@@ -34884,7 +35054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906491+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540227+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -34930,7 +35100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:43.653744+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914553+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34978,7 +35148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:43.653801+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34990,7 +35160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906541+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540257+00:00"
           },
           "value": {
             "type": "string",
@@ -35005,7 +35175,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653838+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914597+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35017,7 +35187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906569+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540274+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -35115,7 +35285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:43.653900+00:00"
+                "validatedAt": "2026-05-05T18:45:18.914633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35127,7 +35297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.906627+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.540307+00:00"
           },
           "values": {
             "type": "array",

--- a/docs/specifications/api/rate_limiting.json
+++ b/docs/specifications/api/rate_limiting.json
@@ -3727,23 +3727,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.980819+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340092+00:00"
               },
               "deterministic": true
             },
@@ -3756,7 +3756,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938621+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.228799+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3772,16 +3772,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.980862+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340111+00:00"
               },
               "deterministic": true
             },
@@ -3794,7 +3799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938652+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.228816+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -3897,7 +3902,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938740+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.228870+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -4046,7 +4051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:23.981022+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4108,7 +4113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:23.981089+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4120,7 +4125,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938845+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.228932+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -4170,23 +4175,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.981131+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340228+00:00"
               },
               "deterministic": true
             },
@@ -4199,7 +4204,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938907+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.228970+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4214,16 +4219,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.981165+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340245+00:00"
               },
               "deterministic": true
             },
@@ -4236,7 +4246,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938932+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.228986+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -4275,7 +4285,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981219+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4288,7 +4298,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.938985+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229017+00:00"
           },
           "uid": {
             "type": "string",
@@ -4305,7 +4315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981249+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4319,7 +4329,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229034+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of policer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -4589,7 +4599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981381+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4612,7 +4622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981421+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4624,7 +4634,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939144+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229108+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4670,7 +4680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.981463+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340374+00:00"
               },
               "deterministic": true
             },
@@ -4696,7 +4706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981513+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4723,7 +4733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981553+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4735,7 +4745,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229136+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4752,7 +4762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981600+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4785,7 +4795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981647+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4797,7 +4807,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939228+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229157+00:00"
           },
           "type": {
             "type": "string",
@@ -4822,7 +4832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981685+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4910,7 +4920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.981729+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4956,23 +4966,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.981768+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340516+00:00"
               },
               "deterministic": true
             },
@@ -4985,7 +4995,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229197+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -5103,7 +5113,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:23.981877+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340570+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5119,7 +5129,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939367+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229232+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5173,23 +5183,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.981920+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340590+00:00"
               },
               "deterministic": true
             },
@@ -5202,7 +5212,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939416+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229260+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5219,16 +5229,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.981952+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340606+00:00"
               },
               "deterministic": true
             },
@@ -5241,7 +5256,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939441+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229276+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5323,7 +5338,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:23.982042+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340662+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5339,7 +5354,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939480+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229300+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5395,23 +5410,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.982084+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340682+00:00"
               },
               "deterministic": true
             },
@@ -5424,7 +5439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939525+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229327+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5441,16 +5456,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.982115+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340697+00:00"
               },
               "deterministic": true
             },
@@ -5463,7 +5483,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939550+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229342+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5508,7 +5528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982151+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5521,7 +5541,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939578+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229360+00:00"
           },
           "name": {
             "type": "string",
@@ -5538,23 +5558,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.982186+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340731+00:00"
               },
               "deterministic": true
             },
@@ -5567,7 +5587,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939606+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229376+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5584,16 +5604,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.982218+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340747+00:00"
               },
               "deterministic": true
             },
@@ -5606,7 +5631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939633+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229392+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5625,7 +5650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982257+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340765+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5639,7 +5664,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939659+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229408+00:00"
           },
           "uid": {
             "type": "string",
@@ -5658,7 +5683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982287+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5673,7 +5698,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939686+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229424+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -5755,7 +5780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:23.982387+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340824+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5771,7 +5796,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939725+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229447+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5825,23 +5850,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.982430+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340844+00:00"
               },
               "deterministic": true
             },
@@ -5854,7 +5879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939768+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229474+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5871,16 +5896,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.982461+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.340860+00:00"
               },
               "deterministic": true
             },
@@ -5893,7 +5923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939793+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229491+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5938,7 +5968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982513+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5966,7 +5996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982560+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340905+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5994,7 +6024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982606+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6023,7 +6053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982650+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6050,7 +6080,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982679+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6064,7 +6094,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939867+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229534+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6080,7 +6110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982720+00:00"
+                "validatedAt": "2026-05-05T18:46:03.340977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6189,7 +6219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982773+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341000+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6201,7 +6231,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939925+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229567+00:00"
           },
           "status": {
             "type": "string",
@@ -6219,7 +6249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982811+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6231,7 +6261,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.939952+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229583+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6273,7 +6303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982860+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6300,7 +6330,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982909+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6327,7 +6357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.982954+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6355,7 +6385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.983004+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6420,7 +6450,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.983074+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6469,7 +6499,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.983129+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6482,7 +6512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.940068+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229663+00:00"
           },
           "uid": {
             "type": "string",
@@ -6501,7 +6531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.983158+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6515,7 +6545,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.940097+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229682+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6565,7 +6595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.983192+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341194+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6577,7 +6607,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.940128+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229700+00:00"
           },
           "name": {
             "type": "string",
@@ -6594,23 +6624,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.983229+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.341210+00:00"
               },
               "deterministic": true
             },
@@ -6623,7 +6653,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.940156+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229716+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6640,16 +6670,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:23.983261+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:03.341227+00:00"
               },
               "deterministic": true
             },
@@ -6662,7 +6697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.940184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229732+00:00"
           },
           "uid": {
             "type": "string",
@@ -6679,7 +6714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:23.983290+00:00"
+                "validatedAt": "2026-05-05T18:46:03.341240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6693,7 +6728,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.940213+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.229749+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -6801,7 +6836,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:36.980555+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6860,23 +6895,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:36.980604+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:09.701139+00:00"
               },
               "deterministic": true
             },
@@ -6889,7 +6924,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216240+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373243+00:00"
           },
           "namespace": {
             "type": "string",
@@ -6905,16 +6940,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:36.980640+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:09.701157+00:00"
               },
               "deterministic": true
             },
@@ -6927,7 +6967,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216268+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373260+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7047,7 +7087,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373313+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7107,7 +7147,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:36.980774+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701217+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7234,7 +7274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:36.980838+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701251+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7297,7 +7337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:36.980903+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701281+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7309,7 +7349,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216463+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373366+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7359,23 +7399,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:36.980943+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:09.701299+00:00"
               },
               "deterministic": true
             },
@@ -7388,7 +7428,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216526+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373403+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7403,16 +7443,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:36.980977+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:09.701316+00:00"
               },
               "deterministic": true
             },
@@ -7425,7 +7470,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216551+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373419+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7464,7 +7509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:36.981032+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7477,7 +7522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216604+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373450+00:00"
           },
           "uid": {
             "type": "string",
@@ -7495,7 +7540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:36.981061+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7509,7 +7554,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.216635+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.373467+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of protocol_policer is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -7576,7 +7621,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:36.981127+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7716,7 +7761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:36.981195+00:00"
+                "validatedAt": "2026-05-05T18:46:09.701424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7985,7 +8030,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:55.661280+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8019,7 +8064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:55.661394+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8081,23 +8126,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:55.661464+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:19.095600+00:00"
               },
               "deterministic": true
             },
@@ -8110,7 +8155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547452+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8126,16 +8171,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:55.661505+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:19.095633+00:00"
               },
               "deterministic": true
             },
@@ -8148,7 +8198,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536119+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547468+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -8251,7 +8301,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536208+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547521+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -8311,7 +8361,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:55.661630+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8345,7 +8395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:55.661691+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8555,7 +8605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:55.661801+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8618,7 +8668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:55.661867+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8630,7 +8680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536340+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547593+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -8680,23 +8730,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:55.661907+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:19.095818+00:00"
               },
               "deterministic": true
             },
@@ -8709,7 +8759,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536402+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547636+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8724,16 +8774,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:55.661939+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:19.095834+00:00"
               },
               "deterministic": true
             },
@@ -8746,7 +8801,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536428+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547652+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -8785,7 +8840,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:55.661993+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8798,7 +8853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536478+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547684+00:00"
           },
           "uid": {
             "type": "string",
@@ -8815,7 +8870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:55.662023+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8829,7 +8884,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.536506+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.547700+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rate_limiter is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9108,7 +9163,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:55.662147+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9142,7 +9197,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:55.662201+00:00"
+                "validatedAt": "2026-05-05T18:46:19.095959+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/secops_and_incident_response.json
+++ b/docs/specifications/api/secops_and_incident_response.json
@@ -1404,23 +1404,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.310833+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889169+00:00"
               },
               "deterministic": true
             },
@@ -1433,7 +1433,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763528+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022697+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1449,16 +1449,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.310880+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889191+00:00"
               },
               "deterministic": true
             },
@@ -1471,7 +1476,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763558+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022714+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -1574,7 +1579,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763648+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022768+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -1666,7 +1671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:21.311009+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1729,7 +1734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:21.311078+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1741,7 +1746,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763729+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022815+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -1792,23 +1797,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.311119+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889294+00:00"
               },
               "deterministic": true
             },
@@ -1821,7 +1826,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763793+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022853+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1836,16 +1841,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.311155+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889311+00:00"
               },
               "deterministic": true
             },
@@ -1858,7 +1868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022869+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -1897,7 +1907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311210+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1910,7 +1920,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763873+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022900+00:00"
           },
           "uid": {
             "type": "string",
@@ -1928,7 +1938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311241+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1942,7 +1952,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.763902+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.022916+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of malicious_user_mitigation is returned in 'List'.",
@@ -2073,7 +2083,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:21.311345+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889398+00:00"
               },
               "deterministic": true
             },
@@ -2271,7 +2281,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311430+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889434+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2294,7 +2304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311469+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2306,7 +2316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764081+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023024+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -2352,7 +2362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.311510+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889472+00:00"
               },
               "deterministic": true
             },
@@ -2378,7 +2388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311561+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2405,7 +2415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311601+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2417,7 +2427,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764126+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023052+00:00"
           },
           "service_name": {
             "type": "string",
@@ -2434,7 +2444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311647+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2467,7 +2477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311698+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889556+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2479,7 +2489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764161+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023073+00:00"
           },
           "type": {
             "type": "string",
@@ -2504,7 +2514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311735+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2592,7 +2602,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.311781+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2638,23 +2648,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.311818+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889611+00:00"
               },
               "deterministic": true
             },
@@ -2667,7 +2677,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764225+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023112+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -2785,7 +2795,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:21.311926+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889672+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -2801,7 +2811,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764283+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023147+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -2855,23 +2865,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.311968+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889693+00:00"
               },
               "deterministic": true
             },
@@ -2884,7 +2894,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764338+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023175+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2901,16 +2911,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312000+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889710+00:00"
               },
               "deterministic": true
             },
@@ -2923,7 +2938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764365+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023190+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -3005,7 +3020,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:21.312092+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889755+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -3021,7 +3036,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764404+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023214+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -3077,23 +3092,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312135+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889775+00:00"
               },
               "deterministic": true
             },
@@ -3106,7 +3121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023241+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3123,16 +3138,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312166+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889790+00:00"
               },
               "deterministic": true
             },
@@ -3145,7 +3165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764475+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023257+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -3190,7 +3210,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312204+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3203,7 +3223,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764503+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023273+00:00"
           },
           "name": {
             "type": "string",
@@ -3220,23 +3240,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312238+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889828+00:00"
               },
               "deterministic": true
             },
@@ -3249,7 +3269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764528+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023289+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3266,16 +3286,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312270+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889845+00:00"
               },
               "deterministic": true
             },
@@ -3288,7 +3313,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764554+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023305+00:00"
           },
           "tenant": {
             "type": "string",
@@ -3307,7 +3332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312309+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3321,7 +3346,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764579+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023323+00:00"
           },
           "uid": {
             "type": "string",
@@ -3340,7 +3365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312352+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3355,7 +3380,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764607+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023340+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -3437,7 +3462,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:21.312443+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889929+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -3453,7 +3478,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764648+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023363+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -3507,23 +3532,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312482+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889949+00:00"
               },
               "deterministic": true
             },
@@ -3536,7 +3561,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764693+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023391+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3553,16 +3578,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.312512+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.889965+00:00"
               },
               "deterministic": true
             },
@@ -3575,7 +3605,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764718+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023406+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -3620,7 +3650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312564+00:00"
+                "validatedAt": "2026-05-05T18:45:02.889989+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3648,7 +3678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312612+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890010+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3676,7 +3706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312657+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3705,7 +3735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312702+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890051+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3732,7 +3762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312731+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3746,7 +3776,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764791+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023449+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -3762,7 +3792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312772+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3871,7 +3901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312827+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3883,7 +3913,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764848+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023482+00:00"
           },
           "status": {
             "type": "string",
@@ -3901,7 +3931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312866+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3913,7 +3943,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764875+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023498+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -3955,7 +3985,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312920+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3982,7 +4012,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.312967+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890172+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4009,7 +4039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313011+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4037,7 +4067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313064+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4102,7 +4132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313134+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890245+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4151,7 +4181,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313188+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4164,7 +4194,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.764993+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023569+00:00"
           },
           "uid": {
             "type": "string",
@@ -4183,7 +4213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313219+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4197,7 +4227,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.765019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023585+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -4247,7 +4277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313255+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890301+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4259,7 +4289,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.765048+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023602+00:00"
           },
           "name": {
             "type": "string",
@@ -4276,23 +4306,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.313291+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.890317+00:00"
               },
               "deterministic": true
             },
@@ -4305,7 +4335,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.765073+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023624+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4322,16 +4352,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:21.313333+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:02.890339+00:00"
               },
               "deterministic": true
             },
@@ -4344,7 +4379,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.765100+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023640+00:00"
           },
           "uid": {
             "type": "string",
@@ -4361,7 +4396,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:21.313363+00:00"
+                "validatedAt": "2026-05-05T18:45:02.890353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4375,7 +4410,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.765126+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.023656+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",

--- a/docs/specifications/api/service_mesh.json
+++ b/docs/specifications/api/service_mesh.json
@@ -10234,7 +10234,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.043644+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10389,23 +10389,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.043717+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.381534+00:00"
               },
               "deterministic": true
             },
@@ -10418,7 +10418,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026608+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.936921+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10434,16 +10434,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.043754+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.381551+00:00"
               },
               "deterministic": true
             },
@@ -10456,7 +10461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026637+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.936938+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -10654,7 +10659,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026747+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937003+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -10722,7 +10727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:39.043926+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10785,7 +10790,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:39.043991+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10797,7 +10802,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026819+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937043+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -10847,23 +10852,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.044033+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.381681+00:00"
               },
               "deterministic": true
             },
@@ -10876,7 +10881,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026882+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937081+00:00"
           },
           "namespace": {
             "type": "string",
@@ -10891,16 +10896,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.044066+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.381698+00:00"
               },
               "deterministic": true
             },
@@ -10913,7 +10923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026909+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937096+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10952,7 +10962,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044122+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10965,7 +10975,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026960+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937127+00:00"
           },
           "uid": {
             "type": "string",
@@ -10982,7 +10992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044152+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10996,7 +11006,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.026987+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937143+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_setting is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -11203,7 +11213,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.044242+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381779+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11487,7 +11497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044399+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11581,7 +11591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.044472+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11682,7 +11692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044515+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11695,7 +11705,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027367+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937365+00:00"
           },
           "name": {
             "type": "string",
@@ -11712,23 +11722,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.044553+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.381906+00:00"
               },
               "deterministic": true
             },
@@ -11741,7 +11751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027393+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937381+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11758,16 +11768,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.044588+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.381922+00:00"
               },
               "deterministic": true
             },
@@ -11780,7 +11795,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027418+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937396+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11799,7 +11814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044626+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11813,7 +11828,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027444+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937412+00:00"
           },
           "uid": {
             "type": "string",
@@ -11832,7 +11847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044657+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11847,7 +11862,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027470+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937428+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11885,7 +11900,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044702+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11908,7 +11923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044742+00:00"
+                "validatedAt": "2026-05-05T18:40:12.381993+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11920,7 +11935,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027508+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937451+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11966,7 +11981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.044784+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382012+00:00"
               },
               "deterministic": true
             },
@@ -11992,7 +12007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044834+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382034+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12018,7 +12033,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044875+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12030,7 +12045,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027556+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937479+00:00"
           },
           "service_name": {
             "type": "string",
@@ -12047,7 +12062,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044922+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12080,7 +12095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.044966+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12092,7 +12107,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027593+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937500+00:00"
           },
           "type": {
             "type": "string",
@@ -12117,7 +12132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045004+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12205,7 +12220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045048+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12251,23 +12266,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045084+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382149+00:00"
               },
               "deterministic": true
             },
@@ -12280,7 +12295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027660+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937539+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -12398,7 +12413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.045197+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382200+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12414,7 +12429,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027718+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937573+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12468,23 +12483,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045240+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382219+00:00"
               },
               "deterministic": true
             },
@@ -12497,7 +12512,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027766+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937600+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12514,16 +12529,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045272+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382235+00:00"
               },
               "deterministic": true
             },
@@ -12536,7 +12556,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027794+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937622+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -12618,7 +12638,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.045378+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382280+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12634,7 +12654,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027834+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937645+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12690,23 +12710,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045420+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382299+00:00"
               },
               "deterministic": true
             },
@@ -12719,7 +12739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027880+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937672+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12736,16 +12756,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045452+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382314+00:00"
               },
               "deterministic": true
             },
@@ -12758,7 +12783,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027906+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937688+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12840,7 +12865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.045544+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382360+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12856,7 +12881,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027943+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937711+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12910,23 +12935,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045583+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382379+00:00"
               },
               "deterministic": true
             },
@@ -12939,7 +12964,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.027987+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937738+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12956,16 +12981,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.045612+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382394+00:00"
               },
               "deterministic": true
             },
@@ -12978,7 +13008,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028014+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937753+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -13023,7 +13053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045664+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13051,7 +13081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045713+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13079,7 +13109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045758+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13108,7 +13138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045802+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382478+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13135,7 +13165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045832+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13149,7 +13179,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028089+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937796+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -13165,7 +13195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045873+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382511+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13274,7 +13304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045926+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382534+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13286,7 +13316,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028157+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937829+00:00"
           },
           "status": {
             "type": "string",
@@ -13304,7 +13334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.045965+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13316,7 +13346,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028198+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937844+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -13358,7 +13388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046018+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13385,7 +13415,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046066+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13412,7 +13442,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046112+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13440,7 +13470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046163+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13505,7 +13535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046232+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13554,7 +13584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046284+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13567,7 +13597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028465+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937913+00:00"
           },
           "uid": {
             "type": "string",
@@ -13586,7 +13616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046313+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13600,7 +13630,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028565+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937929+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -13650,7 +13680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046358+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13662,7 +13692,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028630+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937946+00:00"
           },
           "name": {
             "type": "string",
@@ -13679,23 +13709,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.046391+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382747+00:00"
               },
               "deterministic": true
             },
@@ -13708,7 +13738,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028665+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937962+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13725,16 +13755,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:39.046425+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:12.382763+00:00"
               },
               "deterministic": true
             },
@@ -13747,7 +13782,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028691+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937978+00:00"
           },
           "uid": {
             "type": "string",
@@ -13764,7 +13799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:39.046454+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13778,7 +13813,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.028719+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.937994+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13835,7 +13870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.046515+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13897,7 +13932,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.046580+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13959,7 +13994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:39.046643+00:00"
+                "validatedAt": "2026-05-05T18:40:12.382871+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14000,7 +14035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.578990+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14025,7 +14060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579053+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14134,7 +14169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579143+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14185,7 +14220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579199+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14280,7 +14315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579308+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14322,7 +14357,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579386+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14368,7 +14403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579442+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14431,7 +14466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579519+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600266+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14472,7 +14507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579570+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14512,7 +14547,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579627+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14609,7 +14644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579734+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600365+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14762,7 +14797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.579849+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15006,7 +15041,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580005+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15079,7 +15114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:41.580086+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15104,7 +15139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580136+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600543+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15130,7 +15165,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580184+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600565+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15156,7 +15191,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580224+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600584+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15180,16 +15215,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.580265+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.600606+00:00"
               },
               "deterministic": true
             },
@@ -15202,7 +15242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078042+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.964921+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of request to GET learnt schema request for a given API endpoint.",
@@ -15261,7 +15301,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580338+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15520,7 +15560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580419+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15569,23 +15609,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.580460+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.600696+00:00"
               },
               "deterministic": true
             },
@@ -15598,7 +15638,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078185+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965001+00:00"
           }
         },
         "x-f5xc-example": "[EMAIL, CC]",
@@ -15736,7 +15776,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:41.580522+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15799,7 +15839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580572+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15824,7 +15864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580617+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600774+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15857,7 +15897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580669+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15981,7 +16021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580728+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16040,23 +16080,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.580768+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.600842+00:00"
               },
               "deterministic": true
             },
@@ -16069,7 +16109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078509+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965176+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16085,16 +16125,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.580801+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.600859+00:00"
               },
               "deterministic": true
             },
@@ -16107,7 +16152,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078536+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965192+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -16195,7 +16240,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.580882+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16373,7 +16418,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078678+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965277+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -16431,7 +16476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:41.581011+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16475,7 +16520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581060+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16499,7 +16544,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581108+00:00"
+                "validatedAt": "2026-05-05T18:40:13.600998+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16593,7 +16638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:41.581161+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601022+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16655,7 +16700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:41.581223+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16667,7 +16712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078805+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965352+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -16717,23 +16762,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.581265+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.601102+00:00"
               },
               "deterministic": true
             },
@@ -16746,7 +16791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078866+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965390+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16761,16 +16806,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.581297+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.601120+00:00"
               },
               "deterministic": true
             },
@@ -16783,7 +16833,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078891+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965406+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -16822,7 +16872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581362+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16835,7 +16885,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078943+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965437+00:00"
           },
           "uid": {
             "type": "string",
@@ -16852,7 +16902,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581392+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16866,7 +16916,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.078971+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965454+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of app_type is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -16918,7 +16968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581445+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601223+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16982,7 +17032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581497+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17006,16 +17056,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.581529+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.601398+00:00"
               },
               "deterministic": true
             },
@@ -17028,7 +17083,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079030+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965488+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of remove to remove override for API endpoints.",
@@ -17070,7 +17125,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079057+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965504+00:00"
           },
           "status_msg": {
             "type": "string",
@@ -17088,7 +17143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581580+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17135,7 +17190,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581631+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17159,16 +17214,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.581664+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.601472+00:00"
               },
               "deterministic": true
             },
@@ -17181,7 +17241,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079101+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965532+00:00"
           },
           "override_info": {
             "$ref": "#/components/schemas/app_typeOverrideInfo"
@@ -17227,7 +17287,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079137+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965554+00:00"
           },
           "status_msg": {
             "type": "string",
@@ -17245,7 +17305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581714+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17486,7 +17546,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:41.581839+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17632,7 +17692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581913+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17707,7 +17767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.581979+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17734,7 +17794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582022+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17758,7 +17818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582074+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17866,7 +17926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582126+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17892,7 +17952,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582174+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17918,7 +17978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582213+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17942,16 +18002,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.582247+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.601852+00:00"
               },
               "deterministic": true
             },
@@ -17964,7 +18029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079435+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965735+00:00"
           },
           "service_name": {
             "type": "string",
@@ -17981,7 +18046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582294+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18040,7 +18105,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:41.582362+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18065,7 +18130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582410+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18089,16 +18154,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.582443+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.601956+00:00"
               },
               "deterministic": true
             },
@@ -18111,7 +18181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079488+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965771+00:00"
           },
           "service_name": {
             "type": "string",
@@ -18128,7 +18198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582489+00:00"
+                "validatedAt": "2026-05-05T18:40:13.601992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18230,7 +18300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582566+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18254,7 +18324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.582614+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18357,7 +18427,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:41.583105+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18369,7 +18439,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079780+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965948+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -18399,23 +18469,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.583138+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.602340+00:00"
               },
               "deterministic": true
             },
@@ -18428,7 +18498,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.079814+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.965969+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Message Metadata\" MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -18471,7 +18541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.583514+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18484,7 +18554,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.080064+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.966120+00:00"
           },
           "name": {
             "type": "string",
@@ -18501,23 +18571,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.583548+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.602547+00:00"
               },
               "deterministic": true
             },
@@ -18530,7 +18600,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.080090+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.966136+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18547,16 +18617,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.583580+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.602564+00:00"
               },
               "deterministic": true
             },
@@ -18569,7 +18644,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.080116+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.966152+00:00"
           },
           "tenant": {
             "type": "string",
@@ -18588,7 +18663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.583620+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18602,7 +18677,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.080142+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.966168+00:00"
           },
           "uid": {
             "type": "string",
@@ -18621,7 +18696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.583649+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18636,7 +18711,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.080170+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.966184+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -18680,7 +18755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:41.583860+00:00"
+                "validatedAt": "2026-05-05T18:40:13.602710+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18704,23 +18779,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:41.583893+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:13.602726+00:00"
               },
               "deterministic": true
             },
@@ -18733,7 +18808,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.080316+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.966274+00:00"
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -18933,23 +19008,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:52.815174+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:21.316504+00:00"
               },
               "deterministic": true
             },
@@ -18962,7 +19037,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.908833+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952297+00:00"
           },
           "namespace": {
             "type": "string",
@@ -18978,16 +19053,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:52.815216+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:21.316523+00:00"
               },
               "deterministic": true
             },
@@ -19000,7 +19080,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.908862+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952313+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -19080,23 +19160,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "hostname",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.815303+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316562+00:00"
               },
               "deterministic": true
             },
@@ -19109,7 +19189,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.908919+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952347+00:00"
           },
           "refresh_interval": {
             "type": "integer",
@@ -19236,7 +19316,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.909016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952405+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -19285,7 +19365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815461+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19309,7 +19389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815522+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19333,7 +19413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815580+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19358,7 +19438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815635+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316722+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19382,7 +19462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815696+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316749+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19406,7 +19486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815756+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19431,7 +19511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.815815+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19589,7 +19669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:52.815891+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316836+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19651,7 +19731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:52.815953+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19663,7 +19743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.909187+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952504+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -19713,23 +19793,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:52.815995+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:21.316884+00:00"
               },
               "deterministic": true
             },
@@ -19742,7 +19822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.909249+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952540+00:00"
           },
           "namespace": {
             "type": "string",
@@ -19757,16 +19837,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:52.816028+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:21.316909+00:00"
               },
               "deterministic": true
             },
@@ -19779,7 +19864,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.909276+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952556+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -19818,7 +19903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.816084+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19831,7 +19916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.909337+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952586+00:00"
           },
           "uid": {
             "type": "string",
@@ -19848,7 +19933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.816114+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316948+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19862,7 +19947,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.909364+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.952603+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of endpoint is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -19993,7 +20078,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.816204+00:00"
+                "validatedAt": "2026-05-05T18:43:21.316991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20170,7 +20255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.816346+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20195,7 +20280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.816379+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20311,7 +20396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.817062+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317382+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20365,7 +20450,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.817123+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20433,7 +20518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.817183+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20492,7 +20577,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.817236+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317474+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20593,7 +20678,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.817804+00:00"
+                "validatedAt": "2026-05-05T18:43:21.317760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20664,7 +20749,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.818557+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20767,7 +20852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.818764+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318205+00:00"
               },
               "deterministic": true
             },
@@ -20832,7 +20917,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.818839+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20872,7 +20957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.818880+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318261+00:00"
               },
               "deterministic": true
             },
@@ -20903,7 +20988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.818923+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20987,7 +21072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.818996+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318316+00:00"
               },
               "deterministic": true
             },
@@ -21052,7 +21137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819068+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21092,7 +21177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819103+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318369+00:00"
               },
               "deterministic": true
             },
@@ -21123,7 +21208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.819146+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21207,7 +21292,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819219+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318423+00:00"
               },
               "deterministic": true
             },
@@ -21272,7 +21357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819291+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21312,7 +21397,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819337+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318477+00:00"
               },
               "deterministic": true
             },
@@ -21343,7 +21428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:52.819379+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21419,23 +21504,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819451+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318531+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21451,7 +21536,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.911059+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.953659+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21474,16 +21559,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819512+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318561+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -21499,7 +21589,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.911086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.953675+00:00"
           },
           "tenant": {
             "type": "string",
@@ -21528,7 +21618,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819579+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21542,7 +21632,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.911112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.953691+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -21599,7 +21689,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:52.819637+00:00"
+                "validatedAt": "2026-05-05T18:43:21.318630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21777,23 +21867,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:52.748430+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:17.936088+00:00"
               },
               "deterministic": true
             },
@@ -21806,7 +21896,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.354501+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.355790+00:00"
           },
           "namespace": {
             "type": "string",
@@ -21822,16 +21912,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:52.748464+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:17.936104+00:00"
               },
               "deterministic": true
             },
@@ -21844,7 +21939,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.354527+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.355806+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21971,7 +22066,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.748559+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22174,7 +22269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.748662+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22224,7 +22319,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.748729+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22264,7 +22359,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.748804+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22341,23 +22436,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:52.748848+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:17.936289+00:00"
               },
               "deterministic": true
             },
@@ -22370,7 +22465,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.354869+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356013+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22505,7 +22600,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.354963+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356068+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -22573,7 +22668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:52.748965+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22636,7 +22731,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:52.749025+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22648,7 +22743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355030+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356108+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -22698,23 +22793,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:52.749064+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:17.936386+00:00"
               },
               "deterministic": true
             },
@@ -22727,7 +22822,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355091+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356146+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22742,16 +22837,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:52.749096+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:17.936403+00:00"
               },
               "deterministic": true
             },
@@ -22764,7 +22864,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355117+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356162+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -22803,7 +22903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749150+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22816,7 +22916,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355170+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356194+00:00"
           },
           "uid": {
             "type": "string",
@@ -22833,7 +22933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749181+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22847,7 +22947,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355197+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356210+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of nfv_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -22974,7 +23074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749242+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23019,7 +23119,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.749304+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936503+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23046,7 +23146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749355+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936522+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23085,16 +23185,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:52.749401+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:17.936544+00:00"
               },
               "deterministic": true
             },
@@ -23107,7 +23212,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355292+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356265+00:00"
           },
           "start_time": {
             "type": "string",
@@ -23132,7 +23237,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749450+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23165,7 +23270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749487+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936582+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23242,7 +23347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749538+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23288,7 +23393,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749586+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23312,7 +23417,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749635+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936661+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23373,7 +23478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.749717+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23439,7 +23544,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.749772+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23622,7 +23727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.749858+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23682,7 +23787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.749904+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936793+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23694,7 +23799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355528+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356400+00:00"
           }
         },
         "x-f5xc-description-short": "Palo Alto Networks VM-Series next-generation firewall configuration.",
@@ -23756,7 +23861,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.749998+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23802,7 +23907,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750076+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23864,7 +23969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750153+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23901,7 +24006,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750220+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23933,7 +24038,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750296+00:00"
+                "validatedAt": "2026-05-05T18:45:17.936986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24047,7 +24152,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750396+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937031+00:00"
               },
               "deterministic": true
             },
@@ -24113,7 +24218,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750468+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24208,7 +24313,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750567+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24245,7 +24350,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750618+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24331,7 +24436,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750693+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24427,7 +24532,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750804+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24473,7 +24578,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.750877+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24508,7 +24613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.750928+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937296+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24581,7 +24686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.750994+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24625,7 +24730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.751058+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24648,7 +24753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.751088+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24704,7 +24809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.751225+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24742,7 +24847,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.751294+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24754,7 +24859,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.355985+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356681+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -24773,7 +24878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.751350+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24824,7 +24929,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.751392+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24836,7 +24941,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.356024+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356704+00:00"
           },
           "url": {
             "type": "string",
@@ -24874,7 +24979,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.751462+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937541+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -24968,7 +25073,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.751826+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25032,7 +25137,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.751928+00:00"
+                "validatedAt": "2026-05-05T18:45:17.937762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25044,7 +25149,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.356263+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.356845+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -25101,7 +25206,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.752470+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938030+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25219,7 +25324,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.753254+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938389+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25251,7 +25356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:52.753309+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25263,7 +25368,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.356991+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.357273+00:00"
           },
           "disable_ocsp_stapling": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -25365,7 +25470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:52.753377+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938443+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25377,7 +25482,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.357046+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.357307+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -25395,7 +25500,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.753425+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25423,7 +25528,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.753465+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25435,7 +25540,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.357089+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.357333+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -25710,7 +25815,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.357378+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.357502+00:00"
           },
           "value": {
             "type": "array",
@@ -25729,7 +25834,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.357410+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.357519+00:00"
           }
         },
         "x-f5xc-description-short": "Metric Type Data contains key/value pair that uniquely identifies the group_by labels specified in the request.",
@@ -25840,7 +25945,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.753884+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25868,7 +25973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.753933+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25898,7 +26003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.753988+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938755+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25924,7 +26029,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.754037+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25950,7 +26055,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.754083+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25973,7 +26078,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.754127+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26110,7 +26215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.754171+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26168,7 +26273,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.754267+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26237,7 +26342,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.754338+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26312,7 +26417,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.754405+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26410,7 +26515,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:52.754496+00:00"
+                "validatedAt": "2026-05-05T18:45:17.938997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26555,7 +26660,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:52.754574+00:00"
+                "validatedAt": "2026-05-05T18:45:17.939032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26636,7 +26741,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:18.179827+00:00"
+                "validatedAt": "2026-05-05T18:45:06.746609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26765,7 +26870,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:18.180763+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26843,7 +26948,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:18.180819+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26921,7 +27026,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:19:18.180878+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27039,23 +27144,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:18.181110+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:06.747259+00:00"
               },
               "deterministic": true
             },
@@ -27068,7 +27173,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025599+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27084,16 +27189,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:18.181142+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:06.747276+00:00"
               },
               "deterministic": true
             },
@@ -27106,7 +27216,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205149+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025622+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -27237,7 +27347,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205255+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025689+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -27333,7 +27443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:19:18.181257+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747326+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27396,7 +27506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:18.181316+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27408,7 +27518,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205350+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025741+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27458,23 +27568,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:18.181363+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:06.747374+00:00"
               },
               "deterministic": true
             },
@@ -27487,7 +27597,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205413+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025781+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27502,16 +27612,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:18.181395+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:06.747390+00:00"
               },
               "deterministic": true
             },
@@ -27524,7 +27639,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205439+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025797+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27563,7 +27678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:18.181449+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747414+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27576,7 +27691,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205489+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025828+00:00"
           },
           "uid": {
             "type": "string",
@@ -27593,7 +27708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:18.181479+00:00"
+                "validatedAt": "2026-05-05T18:45:06.747428+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27607,7 +27722,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:23.205517+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.025845+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of site_mesh_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -27914,7 +28029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:15.927767+00:00"
+                "validatedAt": "2026-05-05T18:46:04.673469+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27999,7 +28114,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.562753+00:00"
+                "validatedAt": "2026-05-05T18:46:27.564124+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28024,7 +28139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.562790+00:00"
+                "validatedAt": "2026-05-05T18:46:27.564142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28081,7 +28196,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.562849+00:00"
+                "validatedAt": "2026-05-05T18:46:27.564171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28197,7 +28312,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.467438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032142+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Route Target\" BGP Two-Octet AS Specific Route Target as per RFC 4360.",
@@ -28250,7 +28365,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.467474+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032165+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Four-Octet AS Specific Route Target\" BGP Four-Octet AS Specific Route Target as per RFC 5668.",
@@ -28287,7 +28402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.563475+00:00"
+                "validatedAt": "2026-05-05T18:46:27.564471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28314,7 +28429,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.467513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032187+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"IPv4 Address Specific Route Target\" BGP IPv4 Address Specific Route Target as per RFC 4360.",
@@ -28456,7 +28571,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.564654+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565040+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28518,23 +28633,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.564693+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565059+00:00"
               },
               "deterministic": true
             },
@@ -28547,7 +28662,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468215+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032620+00:00"
           },
           "namespace": {
             "type": "string",
@@ -28563,16 +28678,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.564725+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565076+00:00"
               },
               "deterministic": true
             },
@@ -28585,7 +28705,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468241+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032637+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -28688,7 +28808,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468336+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032690+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -28761,7 +28881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.564845+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565136+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28798,7 +28918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.564904+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28869,7 +28989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:22:02.564955+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28932,7 +29052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:22:02.565014+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28944,7 +29064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468456+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032763+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -28994,23 +29114,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565052+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565238+00:00"
               },
               "deterministic": true
             },
@@ -29023,7 +29143,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468523+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032803+00:00"
           },
           "namespace": {
             "type": "string",
@@ -29038,16 +29158,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565082+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565254+00:00"
               },
               "deterministic": true
             },
@@ -29060,7 +29185,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468548+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032819+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -29099,7 +29224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565134+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29112,7 +29237,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468598+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032850+00:00"
           },
           "uid": {
             "type": "string",
@@ -29129,7 +29254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565163+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29143,7 +29268,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468627+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032867+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of virtual_network is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -29259,7 +29384,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565228+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29385,7 +29510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565290+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29430,7 +29555,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565358+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565390+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29457,7 +29582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565399+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29496,16 +29621,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565448+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565432+00:00"
               },
               "deterministic": true
             },
@@ -29518,7 +29648,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468785+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.032958+00:00"
           },
           "range": {
             "type": "string",
@@ -29543,7 +29673,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565489+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565451+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29576,7 +29706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565539+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29609,7 +29739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565577+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565492+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29685,7 +29815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:02.565627+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29756,7 +29886,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468862+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.033002+00:00"
           },
           "value": {
             "type": "array",
@@ -29775,7 +29905,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468891+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.033020+00:00"
           }
         },
         "x-f5xc-description-short": "SID Counter Type Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -29863,16 +29993,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:02.565684+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.565544+00:00"
               },
               "deterministic": true
             },
@@ -29885,7 +30020,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.468942+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.033050+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Srv6 Network Namespace Parameters\" Configure the how namespace network is connected to srv6 network.",
@@ -29937,7 +30072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565743+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29976,7 +30111,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565815+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565611+00:00"
               },
               "deterministic": true
             },
@@ -30029,7 +30164,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565879+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565650+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30095,7 +30230,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.565934+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30134,7 +30269,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.566006+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565716+00:00"
               },
               "deterministic": true
             },
@@ -30187,7 +30322,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:22:02.566066+00:00"
+                "validatedAt": "2026-05-05T18:46:27.565747+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/statistics.json
+++ b/docs/specifications/api/statistics.json
@@ -19846,7 +19846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.442356+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19927,16 +19927,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.442445+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.213679+00:00"
               },
               "deterministic": true
             },
@@ -19949,7 +19954,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810453+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821049+00:00"
           }
         },
         "x-f5xc-description-short": "Request message for GetAlertPolicyMatch RPC, describing alert to match against alert policies.",
@@ -20116,7 +20121,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.442539+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20153,7 +20158,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.442596+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20216,7 +20221,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.442655+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20333,23 +20338,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.442708+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.213804+00:00"
               },
               "deterministic": true
             },
@@ -20362,7 +20367,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810629+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821153+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20378,16 +20383,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.442743+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.213821+00:00"
               },
               "deterministic": true
             },
@@ -20400,7 +20410,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810658+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821170+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20503,7 +20513,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810747+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821223+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -20565,7 +20575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.442867+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20602,7 +20612,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.442921+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20726,7 +20736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.442990+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20755,7 +20765,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443037+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20824,7 +20834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:28.443121+00:00"
+                "validatedAt": "2026-05-05T18:40:07.213979+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20887,7 +20897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:28.443210+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20899,7 +20909,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810874+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821298+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -20949,23 +20959,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.443255+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214025+00:00"
               },
               "deterministic": true
             },
@@ -20978,7 +20988,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810937+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821336+00:00"
           },
           "namespace": {
             "type": "string",
@@ -20993,16 +21003,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.443288+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214041+00:00"
               },
               "deterministic": true
             },
@@ -21015,7 +21030,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.810964+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821351+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -21054,7 +21069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443357+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21067,7 +21082,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811018+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821382+00:00"
           },
           "uid": {
             "type": "string",
@@ -21084,7 +21099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443388+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21098,7 +21113,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811045+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821399+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -21168,7 +21183,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443449+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21205,7 +21220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443497+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21245,7 +21260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443552+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21355,7 +21370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.443614+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21392,7 +21407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.443669+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21445,7 +21460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443723+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21654,7 +21669,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443816+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21677,7 +21692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443856+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21689,7 +21704,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811314+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821559+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -21735,7 +21750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.443897+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214312+00:00"
               },
               "deterministic": true
             },
@@ -21761,7 +21776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.443948+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214334+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21787,7 +21802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444010+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21799,7 +21814,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811371+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821587+00:00"
           },
           "service_name": {
             "type": "string",
@@ -21816,7 +21831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444058+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21849,7 +21864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444104+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214393+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21861,7 +21876,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811409+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821608+00:00"
           },
           "type": {
             "type": "string",
@@ -21886,7 +21901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444142+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21974,7 +21989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444188+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22020,23 +22035,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444224+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214447+00:00"
               },
               "deterministic": true
             },
@@ -22049,7 +22064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811475+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821653+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -22167,7 +22182,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.444345+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214500+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22183,7 +22198,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811534+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821688+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22237,23 +22252,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444388+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214519+00:00"
               },
               "deterministic": true
             },
@@ -22266,7 +22281,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811579+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821715+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22283,16 +22298,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444419+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214535+00:00"
               },
               "deterministic": true
             },
@@ -22305,7 +22325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811607+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821731+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -22387,7 +22407,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.444510+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214580+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22403,7 +22423,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811649+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821754+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22459,23 +22479,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444551+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214598+00:00"
               },
               "deterministic": true
             },
@@ -22488,7 +22508,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811696+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821781+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22505,16 +22525,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444581+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214619+00:00"
               },
               "deterministic": true
             },
@@ -22527,7 +22552,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811725+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821797+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -22572,7 +22597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444617+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22585,7 +22610,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811755+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821814+00:00"
           },
           "name": {
             "type": "string",
@@ -22602,23 +22627,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444651+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214653+00:00"
               },
               "deterministic": true
             },
@@ -22631,7 +22656,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811783+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821830+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22648,16 +22673,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444684+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214670+00:00"
               },
               "deterministic": true
             },
@@ -22670,7 +22700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811810+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821845+00:00"
           },
           "tenant": {
             "type": "string",
@@ -22689,7 +22719,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444723+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214688+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22703,7 +22733,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811834+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821861+00:00"
           },
           "uid": {
             "type": "string",
@@ -22722,7 +22752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444755+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22737,7 +22767,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811861+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821877+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -22819,7 +22849,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:28.444845+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214747+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -22835,7 +22865,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811901+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821900+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -22889,23 +22919,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444886+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214766+00:00"
               },
               "deterministic": true
             },
@@ -22918,7 +22948,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811944+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821927+00:00"
           },
           "namespace": {
             "type": "string",
@@ -22935,16 +22965,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.444917+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.214781+00:00"
               },
               "deterministic": true
             },
@@ -22957,7 +22992,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.811969+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821943+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -23002,7 +23037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.444969+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23030,7 +23065,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445017+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23058,7 +23093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445062+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23087,7 +23122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445107+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23114,7 +23149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445137+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23128,7 +23163,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812044+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.821986+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -23144,7 +23179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445179+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23253,7 +23288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445237+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23265,7 +23300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812102+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822019+00:00"
           },
           "status": {
             "type": "string",
@@ -23283,7 +23318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445276+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23295,7 +23330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812128+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822035+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -23337,7 +23372,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445340+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23364,7 +23399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445387+00:00"
+                "validatedAt": "2026-05-05T18:40:07.214986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23391,7 +23426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445432+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23419,7 +23454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445482+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23484,7 +23519,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445554+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23533,7 +23568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445609+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23546,7 +23581,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812242+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822104+00:00"
           },
           "uid": {
             "type": "string",
@@ -23565,7 +23600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445638+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23579,7 +23614,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812271+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822120+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -23629,7 +23664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445675+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23641,7 +23676,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812299+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822137+00:00"
           },
           "name": {
             "type": "string",
@@ -23658,23 +23693,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.445706+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.215131+00:00"
               },
               "deterministic": true
             },
@@ -23687,7 +23722,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812333+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822153+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23704,16 +23739,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:28.445737+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:07.215146+00:00"
               },
               "deterministic": true
             },
@@ -23726,7 +23766,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812359+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822169+00:00"
           },
           "uid": {
             "type": "string",
@@ -23743,7 +23783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:28.445769+00:00"
+                "validatedAt": "2026-05-05T18:40:07.215160+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23757,7 +23797,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.812385+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.822184+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -23829,7 +23869,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.643001+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23884,7 +23924,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.643071+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23929,23 +23969,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.643118+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.269483+00:00"
               },
               "deterministic": true
             },
@@ -23958,7 +23998,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856411+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.845767+00:00"
           },
           "namespace": {
             "type": "string",
@@ -23981,16 +24021,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.643161+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.269507+00:00"
               },
               "deterministic": true
             },
@@ -24003,7 +24048,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856442+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.845783+00:00"
           },
           "verification_code": {
             "type": "string",
@@ -24026,7 +24071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.643218+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24202,23 +24247,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.643273+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.269561+00:00"
               },
               "deterministic": true
             },
@@ -24231,7 +24276,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856596+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.845870+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24247,16 +24292,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.643307+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.269577+00:00"
               },
               "deterministic": true
             },
@@ -24269,7 +24319,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856622+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.845886+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -24322,7 +24372,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.643401+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269624+00:00"
               },
               "deterministic": true
             },
@@ -24432,7 +24482,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856720+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.845944+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -24617,7 +24667,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.643561+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24684,7 +24734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:30.643615+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24747,7 +24797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:30.643679+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24759,7 +24809,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856928+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846070+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -24809,23 +24859,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.643720+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.269764+00:00"
               },
               "deterministic": true
             },
@@ -24838,7 +24888,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.856994+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846106+00:00"
           },
           "namespace": {
             "type": "string",
@@ -24853,16 +24903,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.643753+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.269780+00:00"
               },
               "deterministic": true
             },
@@ -24875,7 +24930,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857022+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846122+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -24914,7 +24969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.643807+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24927,7 +24982,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857078+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846153+00:00"
           },
           "uid": {
             "type": "string",
@@ -24944,7 +24999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.643838+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24958,7 +25013,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857107+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846169+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of alert_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -25030,7 +25085,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.643901+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269853+00:00"
               },
               "deterministic": true
             },
@@ -25099,7 +25154,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.643959+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269884+00:00"
               },
               "deterministic": true
             },
@@ -25239,7 +25294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.644022+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25296,7 +25351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.644110+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25423,7 +25478,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.644203+00:00"
+                "validatedAt": "2026-05-05T18:40:08.269999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25481,23 +25536,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.644242+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.270017+00:00"
               },
               "deterministic": true
             },
@@ -25510,7 +25565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857371+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846315+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25533,16 +25588,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.644278+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.270034+00:00"
               },
               "deterministic": true
             },
@@ -25555,7 +25615,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857398+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846331+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25632,23 +25692,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.644316+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.270051+00:00"
               },
               "deterministic": true
             },
@@ -25661,7 +25721,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857439+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846354+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25684,16 +25744,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:30.644362+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:08.270068+00:00"
               },
               "deterministic": true
             },
@@ -25706,7 +25771,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857465+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846370+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25793,7 +25858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.644505+00:00"
+                "validatedAt": "2026-05-05T18:40:08.270130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25831,7 +25896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.644575+00:00"
+                "validatedAt": "2026-05-05T18:40:08.270164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25843,7 +25908,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857564+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846427+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -25862,7 +25927,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.644624+00:00"
+                "validatedAt": "2026-05-05T18:40:08.270185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25913,7 +25978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:30.644668+00:00"
+                "validatedAt": "2026-05-05T18:40:08.270204+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25925,7 +25990,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.857604+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.846449+00:00"
           },
           "url": {
             "type": "string",
@@ -25963,7 +26028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:30.644739+00:00"
+                "validatedAt": "2026-05-05T18:40:08.270238+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -26112,7 +26177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606333+00:00"
+                "validatedAt": "2026-05-05T18:40:09.206936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26138,7 +26203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606399+00:00"
+                "validatedAt": "2026-05-05T18:40:09.206964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26163,16 +26228,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:32.606440+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:09.206983+00:00"
               },
               "deterministic": true
             },
@@ -26185,7 +26255,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.903966+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871502+00:00"
           },
           "start_time": {
             "type": "string",
@@ -26210,7 +26280,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606492+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26277,7 +26347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606546+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26344,7 +26414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606609+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26373,7 +26443,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606656+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26419,16 +26489,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:32.606695+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:09.207092+00:00"
               },
               "deterministic": true
             },
@@ -26441,7 +26516,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904056+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871554+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -26459,7 +26534,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606741+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26529,7 +26604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606782+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207130+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26717,7 +26792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606864+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207163+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26815,7 +26890,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904218+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871653+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -26851,7 +26926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606931+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26900,7 +26975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.606971+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26939,7 +27014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:04:32.607020+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207232+00:00"
               },
               "deterministic": true
             },
@@ -27006,7 +27081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607073+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27051,7 +27126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607114+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207271+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27074,7 +27149,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607146+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27086,7 +27161,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904348+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871721+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -27179,7 +27254,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607206+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27203,7 +27278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607236+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27215,7 +27290,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904423+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871766+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -27257,7 +27332,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607276+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27281,7 +27356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607306+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207355+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27293,7 +27368,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904470+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871793+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -27331,7 +27406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607357+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27388,7 +27463,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607398+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27412,7 +27487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607428+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27424,7 +27499,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904527+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871828+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -27474,7 +27549,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904566+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871851+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -27531,7 +27606,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904604+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871873+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -27567,7 +27642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607498+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27678,7 +27753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607559+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27744,7 +27819,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904707+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871933+00:00"
           },
           "value": {
             "type": "number",
@@ -27760,7 +27835,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904733+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871948+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -27797,7 +27872,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607622+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27882,7 +27957,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:32.607696+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207528+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27894,7 +27969,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904785+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.871977+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -27909,7 +27984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607745+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27935,7 +28010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:32.607783+00:00"
+                "validatedAt": "2026-05-05T18:40:09.207566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27947,7 +28022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.904858+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.872004+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -27991,7 +28066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:31.499751+00:00"
+                "validatedAt": "2026-05-05T18:41:11.542370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28021,7 +28096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:31.499823+00:00"
+                "validatedAt": "2026-05-05T18:41:11.542401+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28403,7 +28478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425738+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28430,16 +28505,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:18.425804+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:34.380332+00:00"
               },
               "deterministic": true
             },
@@ -28452,7 +28532,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.833793+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.774727+00:00"
           },
           "range": {
             "type": "string",
@@ -28477,7 +28557,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425849+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28513,7 +28593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425900+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28546,7 +28626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425939+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28611,7 +28691,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425983+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28688,7 +28768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426024+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28767,7 +28847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426066+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28779,7 +28859,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.833937+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.774810+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the connectivity graph are tagged with labels listed in the enum Label.",
@@ -28930,7 +29010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426143+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29058,7 +29138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426192+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29099,7 +29179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426249+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29125,7 +29205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426294+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29276,7 +29356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426363+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29323,16 +29403,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:18.426417+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:34.380599+00:00"
               },
               "deterministic": true
             },
@@ -29345,7 +29430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834181+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.774951+00:00"
           },
           "range": {
             "type": "string",
@@ -29370,7 +29455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426463+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29403,7 +29488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426510+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29436,7 +29521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426549+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29501,7 +29586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426590+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29557,7 +29642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426637+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29617,16 +29702,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:18.426700+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:34.380735+00:00"
               },
               "deterministic": true
             },
@@ -29639,7 +29729,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775015+00:00"
           },
           "start_time": {
             "type": "string",
@@ -29664,7 +29754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426748+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29874,7 +29964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426836+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29886,7 +29976,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834386+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775061+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/graphHealthscoreType"
@@ -29908,7 +29998,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834423+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775083+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -30149,7 +30239,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.426994+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30278,7 +30368,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.427064+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30311,7 +30401,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.427118+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30344,7 +30434,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.427169+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30458,7 +30548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.427385+00:00"
+                "validatedAt": "2026-05-05T18:42:34.381049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30470,7 +30560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834713+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775250+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -30573,7 +30663,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.297967+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30607,7 +30697,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298033+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30640,7 +30730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298090+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -30740,23 +30830,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298145+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220836+00:00"
               },
               "deterministic": true
             },
@@ -30769,7 +30859,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.740911+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.841950+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30792,16 +30882,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298184+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220855+00:00"
               },
               "deterministic": true
             },
@@ -30814,7 +30909,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.740943+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.841967+00:00"
           },
           "tcp_lb_request": {
             "$ref": "#/components/schemas/discovered_serviceTCPLBRequest"
@@ -30885,23 +30980,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298229+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220875+00:00"
               },
               "deterministic": true
             },
@@ -30914,7 +31009,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.740993+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.841996+00:00"
           },
           "namespace": {
             "type": "string",
@@ -30937,16 +31032,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298263+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220893+00:00"
               },
               "deterministic": true
             },
@@ -30959,7 +31059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842012+00:00"
           }
         },
         "x-f5xc-description-short": "Disable visibility on the discovered service.",
@@ -31018,7 +31118,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741049+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842031+00:00"
           },
           "virtual_server_pool_members_health": {
             "$ref": "#/components/schemas/discovered_serviceVirtualServerPoolMemberHealth"
@@ -31066,23 +31166,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298318+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220918+00:00"
               },
               "deterministic": true
             },
@@ -31095,7 +31195,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842053+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31118,16 +31218,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298369+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220936+00:00"
               },
               "deterministic": true
             },
@@ -31140,7 +31245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842069+00:00"
           }
         },
         "x-f5xc-description-short": "Enable visibility of the discovered service in all workspaces like WAAP, App Connect, etc.",
@@ -31300,7 +31405,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298497+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31313,7 +31418,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741207+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842125+00:00"
           },
           "http": {
             "$ref": "#/components/schemas/discovered_serviceProxyTypeHttp"
@@ -31346,23 +31451,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298539+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221014+00:00"
               },
               "deterministic": true
             },
@@ -31375,7 +31480,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741259+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842157+00:00"
           },
           "skip_server_verification": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -31436,7 +31541,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298596+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31470,7 +31575,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298644+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31503,7 +31608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298696+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31571,7 +31676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:44.298746+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31634,7 +31739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:44.298810+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31646,7 +31751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741393+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842225+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -31696,23 +31801,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298849+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221164+00:00"
               },
               "deterministic": true
             },
@@ -31725,7 +31830,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741455+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842262+00:00"
           },
           "namespace": {
             "type": "string",
@@ -31740,16 +31845,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298881+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221182+00:00"
               },
               "deterministic": true
             },
@@ -31762,7 +31872,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741483+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842278+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -31785,7 +31895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298921+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31798,7 +31908,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741529+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842303+00:00"
           },
           "uid": {
             "type": "string",
@@ -31816,7 +31926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298951+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31830,7 +31940,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741556+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842320+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -31900,7 +32010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:44.299000+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31964,7 +32074,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:44.299059+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -31976,7 +32086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741616+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842355+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -32026,23 +32136,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299098+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221282+00:00"
               },
               "deterministic": true
             },
@@ -32055,7 +32165,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741677+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842392+00:00"
           },
           "namespace": {
             "type": "string",
@@ -32070,16 +32180,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299129+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221297+00:00"
               },
               "deterministic": true
             },
@@ -32092,7 +32207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741704+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842408+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -32131,7 +32246,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.299182+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32144,7 +32259,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741759+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842439+00:00"
           },
           "uid": {
             "type": "string",
@@ -32162,7 +32277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.299214+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32176,7 +32291,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741789+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842455+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered services is returned in 'List'.",
@@ -32238,7 +32353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299284+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221372+00:00"
               },
               "deterministic": true
             },
@@ -32280,7 +32395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299376+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32306,7 +32421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.299429+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32350,7 +32465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299474+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221453+00:00"
               },
               "deterministic": true
             },
@@ -32391,7 +32506,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299552+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32488,7 +32603,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299612+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32591,7 +32706,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299707+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32625,7 +32740,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299785+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32649,16 +32764,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299821+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221630+00:00"
               },
               "deterministic": true
             },
@@ -32671,7 +32791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741979+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842564+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -32735,7 +32855,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299891+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32748,7 +32868,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842596+00:00"
           },
           "listen_port": {
             "type": "integer",
@@ -32797,23 +32917,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299948+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221692+00:00"
               },
               "deterministic": true
             },
@@ -32826,7 +32946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742069+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842624+00:00"
           },
           "no_sni": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -32863,7 +32983,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300026+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32955,7 +33075,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300102+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -32989,7 +33109,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300178+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33033,7 +33153,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300250+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221842+00:00"
               },
               "deterministic": true
             },
@@ -33068,7 +33188,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300328+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33106,7 +33226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300365+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221895+00:00"
               },
               "deterministic": true
             },
@@ -33138,7 +33258,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300436+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33172,7 +33292,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300506+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33249,23 +33369,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.300541+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221981+00:00"
               },
               "deterministic": true
             },
@@ -33278,7 +33398,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742219+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842715+00:00"
           },
           "status": {
             "type": "array",
@@ -33298,7 +33418,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742245+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842731+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -33400,7 +33520,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300602+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33425,7 +33545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300643+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33488,7 +33608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300680+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222044+00:00"
               },
               "deterministic": true
             },
@@ -33522,7 +33642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300723+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33600,7 +33720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300779+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33613,7 +33733,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742344+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842786+00:00"
           },
           "name": {
             "type": "string",
@@ -33630,23 +33750,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.300814+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222105+00:00"
               },
               "deterministic": true
             },
@@ -33659,7 +33779,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842802+00:00"
           },
           "namespace": {
             "type": "string",
@@ -33676,16 +33796,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.300847+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222121+00:00"
               },
               "deterministic": true
             },
@@ -33698,7 +33823,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742396+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842818+00:00"
           },
           "tenant": {
             "type": "string",
@@ -33717,7 +33842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300887+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33731,7 +33856,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742421+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842834+00:00"
           },
           "uid": {
             "type": "string",
@@ -33750,7 +33875,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300917+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33765,7 +33890,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742449+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842850+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -33826,7 +33951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301402+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -33838,7 +33963,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742708+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842998+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -33962,7 +34087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:44.302607+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34011,7 +34136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:44.302662+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34023,7 +34148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743425+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843424+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -34041,7 +34166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302706+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34103,7 +34228,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302763+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34161,7 +34286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302819+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34219,23 +34344,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302891+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223072+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34251,7 +34376,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743494+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843464+00:00"
           },
           "namespace": {
             "type": "string",
@@ -34274,16 +34399,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302951+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223103+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -34299,7 +34429,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743520+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843480+00:00"
           },
           "tenant": {
             "type": "string",
@@ -34328,7 +34458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303017+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34342,7 +34472,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743545+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843496+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -34393,7 +34523,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303072+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34497,7 +34627,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303134+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34637,7 +34767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303173+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223217+00:00"
               },
               "deterministic": true
             },
@@ -34684,7 +34814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303251+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34807,7 +34937,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303342+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34842,7 +34972,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303413+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -34907,7 +35037,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303466+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35020,7 +35150,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.888177+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.481458+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -35068,7 +35198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:44.660867+00:00"
+                "validatedAt": "2026-05-05T18:43:47.619500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35138,7 +35268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:11:44.660979+00:00"
+                "validatedAt": "2026-05-05T18:43:47.619547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35201,7 +35331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:11:44.661085+00:00"
+                "validatedAt": "2026-05-05T18:43:47.619579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35213,7 +35343,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.888271+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.481510+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -35263,23 +35393,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:44.661141+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:47.619600+00:00"
               },
               "deterministic": true
             },
@@ -35292,7 +35422,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.888350+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.481547+00:00"
           },
           "namespace": {
             "type": "string",
@@ -35307,16 +35437,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:44.661176+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:47.619625+00:00"
               },
               "deterministic": true
             },
@@ -35329,7 +35464,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.888379+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.481562+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -35368,7 +35503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:44.661235+00:00"
+                "validatedAt": "2026-05-05T18:43:47.619658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35381,7 +35516,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.888433+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.481593+00:00"
           },
           "uid": {
             "type": "string",
@@ -35398,7 +35533,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:44.661267+00:00"
+                "validatedAt": "2026-05-05T18:43:47.619673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35412,7 +35547,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.888461+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.481609+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of flow_anomaly is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -35552,7 +35687,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168382+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35580,7 +35715,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168451+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35639,7 +35774,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168527+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35699,7 +35834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168597+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336893+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35772,7 +35907,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168680+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35881,7 +36016,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168761+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -35952,7 +36087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168826+00:00"
+                "validatedAt": "2026-05-05T18:43:50.336997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36036,7 +36171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168889+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36088,7 +36223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.168947+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36118,16 +36253,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:11:50.168990+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:50.337075+00:00"
               },
               "deterministic": true
             },
@@ -36140,7 +36280,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:13.959627+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.520198+00:00"
           },
           "node": {
             "type": "string",
@@ -36169,7 +36309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:50.169069+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337114+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36196,7 +36336,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.169101+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36266,7 +36406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.169162+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337157+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36291,7 +36431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.169192+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36339,7 +36479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:50.169237+00:00"
+                "validatedAt": "2026-05-05T18:43:50.337192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36491,7 +36631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313120+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36518,7 +36658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313199+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36563,7 +36703,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313271+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36590,7 +36730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313318+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36631,7 +36771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313382+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36656,7 +36796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313439+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -36748,7 +36888,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.027605+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.559886+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -37001,7 +37141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313560+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37029,7 +37169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313613+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37079,7 +37219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313679+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37110,7 +37250,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313733+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37169,7 +37309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313787+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37213,7 +37353,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.313855+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37247,7 +37387,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.313930+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37283,7 +37423,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.313984+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37318,7 +37458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:54.314031+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37368,7 +37508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314093+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37461,7 +37601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314158+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37505,7 +37645,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.314224+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37532,7 +37672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314264+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37583,7 +37723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:54.314331+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37633,7 +37773,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314392+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37838,7 +37978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.678067+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933200+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37887,7 +38027,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.678201+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -37931,7 +38071,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.678299+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38032,7 +38172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.678417+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38106,7 +38246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.678508+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38147,13 +38287,18 @@
               "pattern": "^[A-Za-z0-9][A-Za-z0-9-]+[A-Za-z0-9]$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.678592+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933454+00:00"
               },
               "deterministic": true
             },
@@ -38165,7 +38310,7 @@
             },
             "x-original-maxLength": 63,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.379971+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.739563+00:00"
           }
         },
         "x-f5xc-description-short": "Azure Event Hubs Configuration for Global Log Receiver.",
@@ -38281,7 +38426,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.678691+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933526+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38539,7 +38684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:12:13.678758+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933562+00:00"
               },
               "deterministic": true
             },
@@ -38578,7 +38723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.678797+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933580+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38647,23 +38792,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.678842+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.933604+00:00"
               },
               "deterministic": true
             },
@@ -38676,7 +38821,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.380387+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.739797+00:00"
           },
           "namespace": {
             "type": "string",
@@ -38692,16 +38837,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.678876+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.933629+00:00"
               },
               "deterministic": true
             },
@@ -38714,7 +38864,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.380414+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.739814+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -38764,7 +38914,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.678971+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38843,7 +38993,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.679061+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -38966,7 +39116,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.380584+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.739910+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -39171,7 +39321,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.679207+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39222,7 +39372,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.679277+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39253,16 +39403,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.679316+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.933838+00:00"
               },
               "deterministic": true
             },
@@ -39275,7 +39430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.380829+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740190+00:00"
           },
           "start_time": {
             "type": "string",
@@ -39300,7 +39455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.679377+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933860+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39333,7 +39488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.679415+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39407,7 +39562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.679469+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39485,7 +39640,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.679533+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39550,7 +39705,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.679609+00:00"
+                "validatedAt": "2026-05-05T18:44:01.933971+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39627,7 +39782,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.679672+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39673,7 +39828,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.679767+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934050+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39736,7 +39891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.679810+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934069+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39748,7 +39903,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381053+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740322+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the global log receiver are tagged with labels listed in the enum Label.",
@@ -39809,7 +39964,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:12:13.679863+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39872,7 +40027,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:13.679925+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -39884,7 +40039,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381117+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740357+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -39934,23 +40089,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.679965+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.934139+00:00"
               },
               "deterministic": true
             },
@@ -39963,7 +40118,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381177+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740394+00:00"
           },
           "namespace": {
             "type": "string",
@@ -39978,16 +40133,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.679997+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.934155+00:00"
               },
               "deterministic": true
             },
@@ -40000,7 +40160,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381203+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740410+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -40039,7 +40199,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.680052+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40052,7 +40212,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381253+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740440+00:00"
           },
           "uid": {
             "type": "string",
@@ -40070,7 +40230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.680082+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40084,7 +40244,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381281+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740456+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of global_log_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -40149,7 +40309,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.680140+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40249,7 +40409,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.680204+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934253+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40452,7 +40612,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:13.680268+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40497,7 +40657,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.680370+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40573,7 +40733,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.680441+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934362+00:00"
               },
               "deterministic": true
             },
@@ -40796,7 +40956,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.680582+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934427+00:00"
               },
               "deterministic": true
             },
@@ -40887,7 +41047,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:12:13.680669+00:00"
+                "validatedAt": "2026-05-05T18:44:01.934467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -40941,23 +41101,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.680704+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.934483+00:00"
               },
               "deterministic": true
             },
@@ -40970,7 +41130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381819+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740778+00:00"
           },
           "namespace": {
             "type": "string",
@@ -40993,16 +41153,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:12:13.680739+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:01.934501+00:00"
               },
               "deterministic": true
             },
@@ -41015,7 +41180,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.381845+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.740794+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41237,23 +41402,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.302113+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:58.481545+00:00"
               },
               "deterministic": true
             },
@@ -41266,7 +41431,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557488+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907083+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41282,16 +41447,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.302146+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:58.481562+00:00"
               },
               "deterministic": true
             },
@@ -41304,7 +41474,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557515+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907098+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -41407,7 +41577,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557603+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907151+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -41485,7 +41655,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.302256+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481610+00:00"
               },
               "deterministic": true
             },
@@ -41510,7 +41680,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:12.302301+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41558,7 +41728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.302362+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481664+00:00"
               },
               "deterministic": true
             },
@@ -41587,7 +41757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.302394+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481680+00:00"
               },
               "deterministic": true
             },
@@ -41655,7 +41825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:12.302446+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41718,7 +41888,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:12.302508+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41730,7 +41900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557735+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907224+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -41780,23 +41950,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.302548+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:58.481754+00:00"
               },
               "deterministic": true
             },
@@ -41809,7 +41979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557797+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907261+00:00"
           },
           "namespace": {
             "type": "string",
@@ -41824,16 +41994,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.302579+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:58.481771+00:00"
               },
               "deterministic": true
             },
@@ -41846,7 +42021,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557826+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907277+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -41885,7 +42060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:12.302633+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41898,7 +42073,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557877+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907307+00:00"
           },
           "uid": {
             "type": "string",
@@ -41915,7 +42090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:12.302665+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481809+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -41929,7 +42104,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.557903+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907324+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of log_receiver is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -42180,7 +42355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.302765+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481856+00:00"
               },
               "deterministic": true
             },
@@ -42219,7 +42394,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.302845+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481896+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42283,7 +42458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.302941+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481942+00:00"
               },
               "deterministic": true
             },
@@ -42362,7 +42537,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.302981+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481960+00:00"
               },
               "deterministic": true
             },
@@ -42407,7 +42582,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.303057+00:00"
+                "validatedAt": "2026-05-05T18:44:58.481997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42445,7 +42620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.303140+00:00"
+                "validatedAt": "2026-05-05T18:44:58.482037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42502,23 +42677,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.303177+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:58.482053+00:00"
               },
               "deterministic": true
             },
@@ -42531,7 +42706,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.558153+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907467+00:00"
           },
           "namespace": {
             "type": "string",
@@ -42554,16 +42729,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:12.303213+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:58.482071+00:00"
               },
               "deterministic": true
             },
@@ -42576,7 +42756,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.558180+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.907482+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -42648,7 +42828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.303254+00:00"
+                "validatedAt": "2026-05-05T18:44:58.482090+00:00"
               },
               "deterministic": true
             },
@@ -42687,7 +42867,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:12.303338+00:00"
+                "validatedAt": "2026-05-05T18:44:58.482126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42919,7 +43099,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.409611+00:00"
+                "validatedAt": "2026-05-05T18:45:00.879916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -42943,16 +43123,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.409679+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.879948+00:00"
               },
               "deterministic": true
             },
@@ -42965,7 +43150,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961574+00:00"
           },
           "query": {
             "type": "string",
@@ -42985,7 +43170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.409732+00:00"
+                "validatedAt": "2026-05-05T18:45:00.879973+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43018,7 +43203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.409784+00:00"
+                "validatedAt": "2026-05-05T18:45:00.879996+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43090,7 +43275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.409836+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43119,7 +43304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.409883+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43143,16 +43328,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.409920+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880058+00:00"
               },
               "deterministic": true
             },
@@ -43165,7 +43355,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961630+00:00"
           },
           "query": {
             "type": "string",
@@ -43185,7 +43375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.409970+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880082+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43238,7 +43428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410022+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43312,7 +43502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410076+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43336,16 +43526,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.410112+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880145+00:00"
               },
               "deterministic": true
             },
@@ -43358,7 +43553,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660719+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961682+00:00"
           },
           "query": {
             "type": "string",
@@ -43378,7 +43573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410161+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43411,7 +43606,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410207+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880190+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43483,7 +43678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410256+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43512,7 +43707,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410295+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43535,16 +43730,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.410341+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880249+00:00"
               },
               "deterministic": true
             },
@@ -43557,7 +43757,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.660796+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961727+00:00"
           },
           "query": {
             "type": "string",
@@ -43577,7 +43777,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410391+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43630,7 +43830,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410444+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43690,7 +43890,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410690+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880408+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43716,7 +43916,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410740+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43754,7 +43954,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:17.410808+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43789,7 +43989,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.410855+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880486+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43813,16 +44013,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.410890+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880502+00:00"
               },
               "deterministic": true
             },
@@ -43835,7 +44040,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661010+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.961850+00:00"
           },
           "site": {
             "type": "string",
@@ -43852,7 +44057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410925+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43885,7 +44090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.410975+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43959,7 +44164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411381+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -43983,16 +44188,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.411416+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880758+00:00"
               },
               "deterministic": true
             },
@@ -44005,7 +44215,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661304+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962029+00:00"
           },
           "query": {
             "type": "string",
@@ -44025,7 +44235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411466+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44058,7 +44268,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411515+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44130,7 +44340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411566+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44159,7 +44369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411606+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44183,16 +44393,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.411639+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880861+00:00"
               },
               "deterministic": true
             },
@@ -44205,7 +44420,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661391+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962074+00:00"
           },
           "query": {
             "type": "string",
@@ -44225,7 +44440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411689+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44278,7 +44493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411738+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44352,7 +44567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411788+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880929+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44376,16 +44591,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.411822+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.880945+00:00"
               },
               "deterministic": true
             },
@@ -44398,7 +44618,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661478+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962123+00:00"
           },
           "query": {
             "type": "string",
@@ -44418,7 +44638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.411870+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44443,7 +44663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411905+00:00"
+                "validatedAt": "2026-05-05T18:45:00.880984+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44476,7 +44696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.411953+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881005+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44549,7 +44769,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412002+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44578,7 +44798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412041+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44602,16 +44822,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412074+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881061+00:00"
               },
               "deterministic": true
             },
@@ -44624,7 +44849,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661562+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962173+00:00"
           },
           "query": {
             "type": "string",
@@ -44644,7 +44869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412123+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881083+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44686,7 +44911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412159+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44722,7 +44947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412208+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881121+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44797,7 +45022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412258+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44821,16 +45046,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412293+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881160+00:00"
               },
               "deterministic": true
             },
@@ -44843,7 +45073,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661655+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962227+00:00"
           },
           "query": {
             "type": "string",
@@ -44863,7 +45093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412350+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881182+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44888,7 +45118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412384+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44921,7 +45151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412432+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -44994,7 +45224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412482+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45023,7 +45253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412520+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45047,16 +45277,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412554+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881278+00:00"
               },
               "deterministic": true
             },
@@ -45069,7 +45304,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661735+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962279+00:00"
           },
           "query": {
             "type": "string",
@@ -45089,7 +45324,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.412603+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45131,7 +45366,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412640+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45167,7 +45402,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412690+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45236,7 +45471,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:17.412765+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45248,7 +45483,7 @@
             "x-original-maxLength": 256,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661824+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962332+00:00"
           }
         },
         "x-f5xc-description-short": "Label Filter is used to filter th that match the logs specified label key/value and the operator.",
@@ -45305,7 +45540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412818+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45387,7 +45622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412875+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881423+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45416,7 +45651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412918+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881444+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45464,16 +45699,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.412955+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881461+00:00"
               },
               "deterministic": true
             },
@@ -45486,7 +45726,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.661912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962384+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -45504,7 +45744,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.412999+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45575,7 +45815,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413198+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45599,16 +45839,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413232+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881583+00:00"
               },
               "deterministic": true
             },
@@ -45621,7 +45866,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662163+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962541+00:00"
           },
           "query": {
             "type": "string",
@@ -45641,7 +45886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413280+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45674,7 +45919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413336+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45746,7 +45991,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413386+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45790,7 +46035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413426+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45813,16 +46058,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413459+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881690+00:00"
               },
               "deterministic": true
             },
@@ -45835,7 +46085,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962591+00:00"
           },
           "query": {
             "type": "string",
@@ -45855,7 +46105,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413506+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45908,7 +46158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413557+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -45983,7 +46233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413658+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46007,16 +46257,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413692+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881797+00:00"
               },
               "deterministic": true
             },
@@ -46029,7 +46284,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662372+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962663+00:00"
           },
           "query": {
             "type": "string",
@@ -46049,7 +46304,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413739+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46082,7 +46337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413786+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46154,7 +46409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.413834+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46183,7 +46438,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413872+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881880+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46207,16 +46462,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.413906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881897+00:00"
               },
               "deterministic": true
             },
@@ -46229,7 +46489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662448+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962708+00:00"
           },
           "query": {
             "type": "string",
@@ -46249,7 +46509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.413953+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46302,7 +46562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414002+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881942+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46377,7 +46637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414050+00:00"
+                "validatedAt": "2026-05-05T18:45:00.881963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46401,16 +46661,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.414082+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.881979+00:00"
               },
               "deterministic": true
             },
@@ -46423,7 +46688,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662530+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962757+00:00"
           },
           "query": {
             "type": "string",
@@ -46443,7 +46708,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.414129+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46476,7 +46741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414175+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46548,7 +46813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414223+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46577,7 +46842,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.414260+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46601,16 +46866,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:17.414292+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:00.882077+00:00"
               },
               "deterministic": true
             },
@@ -46623,7 +46893,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.662601+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.962801+00:00"
           },
           "query": {
             "type": "string",
@@ -46643,7 +46913,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:14:17.414348+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46696,7 +46966,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414397+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46769,7 +47039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414437+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -46927,7 +47197,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414492+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47064,7 +47334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414544+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47184,7 +47454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414595+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47228,7 +47498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414631+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47334,7 +47604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414680+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882258+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47436,7 +47706,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414728+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47480,7 +47750,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:17.414764+00:00"
+                "validatedAt": "2026-05-05T18:45:00.882297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47636,7 +47906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:39.608684+00:00"
+                "validatedAt": "2026-05-05T18:45:11.616388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47700,7 +47970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240441+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47725,7 +47995,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240487+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47751,7 +48021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240534+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47776,7 +48046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240578+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677538+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47856,7 +48126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240649+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677570+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -47983,7 +48253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240712+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677600+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48100,7 +48370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240776+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677637+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48131,7 +48401,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240823+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48303,7 +48573,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240926+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48329,7 +48599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.240970+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48365,7 +48635,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241018+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48432,7 +48702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241074+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48466,7 +48736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241124+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48542,7 +48812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241173+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48663,7 +48933,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241231+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48690,7 +48960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241260+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48766,7 +49036,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241291+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48796,7 +49066,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241348+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48851,7 +49121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241394+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677923+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48883,7 +49153,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241444+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48914,16 +49184,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:09.241485+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:25.677967+00:00"
               },
               "deterministic": true
             },
@@ -48936,7 +49211,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.826444+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.718565+00:00"
           },
           "report_frequency": {
             "$ref": "#/components/schemas/reportReportFrequency"
@@ -48963,7 +49238,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241537+00:00"
+                "validatedAt": "2026-05-05T18:46:25.677990+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -48995,7 +49270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241586+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49028,7 +49303,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241633+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49060,7 +49335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241681+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49171,7 +49446,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241741+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678085+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49309,7 +49584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241802+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49438,7 +49713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241883+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49496,7 +49771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:09.241953+00:00"
+                "validatedAt": "2026-05-05T18:46:25.678179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49694,7 +49969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:13.936430+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49706,7 +49981,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.941832+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850581+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -49756,23 +50031,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936473+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911676+00:00"
               },
               "deterministic": true
             },
@@ -49785,7 +50060,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.941897+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850633+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49800,16 +50075,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936507+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911692+00:00"
               },
               "deterministic": true
             },
@@ -49822,7 +50102,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.941923+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850651+00:00"
           },
           "object": {
             "$ref": "#/components/schemas/schemareportObject"
@@ -49848,7 +50128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.936548+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49861,7 +50141,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.941974+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850683+00:00"
           },
           "uid": {
             "type": "string",
@@ -49878,7 +50158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.936577+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911725+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49892,7 +50172,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942002+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850700+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of report is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -49955,23 +50235,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936615+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911743+00:00"
               },
               "deterministic": true
             },
@@ -49984,7 +50264,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942041+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850727+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50000,16 +50280,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936649+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911760+00:00"
               },
               "deterministic": true
             },
@@ -50022,7 +50307,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942068+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850743+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50067,23 +50352,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936687+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911777+00:00"
               },
               "deterministic": true
             },
@@ -50096,7 +50381,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942095+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850800+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50119,16 +50404,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936722+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911798+00:00"
               },
               "deterministic": true
             },
@@ -50141,7 +50431,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942122+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850817+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -50259,7 +50549,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942211+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850889+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -50333,16 +50623,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.936823+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911843+00:00"
               },
               "deterministic": true
             },
@@ -50355,7 +50650,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942258+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.850919+00:00"
           },
           "report_config_names": {
             "$ref": "#/components/schemas/report_configReportConfigurationNamesList"
@@ -50401,7 +50696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:13.936861+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50524,7 +50819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:13.936934+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50587,7 +50882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:13.936993+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50599,7 +50894,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.851049+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -50649,23 +50944,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.937030+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911945+00:00"
               },
               "deterministic": true
             },
@@ -50678,7 +50973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942447+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.851262+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50693,16 +50988,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.937063+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.911962+00:00"
               },
               "deterministic": true
             },
@@ -50715,7 +51015,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942474+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.851307+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -50754,7 +51054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.937114+00:00"
+                "validatedAt": "2026-05-05T18:46:27.911987+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50767,7 +51067,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942527+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.851382+00:00"
           },
           "uid": {
             "type": "string",
@@ -50784,7 +51084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.937143+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912002+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50798,7 +51098,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.942554+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.851437+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of report_config is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -50866,7 +51166,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937208+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50993,7 +51293,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937269+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912068+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51051,7 +51351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937383+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51113,7 +51413,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937483+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51176,7 +51476,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937574+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51314,7 +51614,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937629+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51428,7 +51728,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937698+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51467,7 +51767,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.937751+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51494,7 +51794,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.937794+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51584,7 +51884,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.938571+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912707+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -51600,7 +51900,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943207+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852017+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -51656,23 +51956,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.938612+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.912726+00:00"
               },
               "deterministic": true
             },
@@ -51685,7 +51985,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852045+00:00"
           },
           "namespace": {
             "type": "string",
@@ -51702,16 +52002,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:13.938642+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:27.912741+00:00"
               },
               "deterministic": true
             },
@@ -51724,7 +52029,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943283+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852062+00:00"
           },
           "uid": {
             "type": "string",
@@ -51743,7 +52048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.938672+00:00"
+                "validatedAt": "2026-05-05T18:46:27.912754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51758,7 +52063,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943310+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852078+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -51805,7 +52110,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939590+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51833,7 +52138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939637+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913199+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51862,7 +52167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939685+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51889,7 +52194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939728+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913240+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51918,7 +52223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939780+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51943,7 +52248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939828+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52008,7 +52313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.939897+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52046,7 +52351,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:13.939954+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52058,7 +52363,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943840+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852498+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -52099,7 +52404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940008+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52143,7 +52448,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940049+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52157,7 +52462,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943902+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852552+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -52176,7 +52481,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940093+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913409+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52203,7 +52508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940122+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52218,7 +52523,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.943937+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.852584+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -52233,7 +52538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940162+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913441+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52332,7 +52637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940500+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52358,7 +52663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940545+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913618+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52394,7 +52699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940592+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52471,7 +52776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940646+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913666+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52507,7 +52812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:13.940693+00:00"
+                "validatedAt": "2026-05-05T18:46:27.913687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52692,7 +52997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643072+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52743,7 +53048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643149+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52838,7 +53143,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643256+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52880,7 +53185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643315+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52926,7 +53231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643386+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52989,7 +53294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643462+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53030,7 +53335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643511+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53070,7 +53375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643564+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53151,7 +53456,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643656+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53303,7 +53608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643768+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53655,7 +53960,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643914+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54073,7 +54378,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.644253+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54124,7 +54429,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.644317+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54202,7 +54507,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644371+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54227,7 +54532,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644413+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54251,16 +54556,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.644450+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.284716+00:00"
               },
               "deterministic": true
             },
@@ -54273,7 +54583,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163351+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623314+00:00"
           },
           "service": {
             "type": "string",
@@ -54291,7 +54601,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644492+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54317,7 +54627,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644527+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54342,7 +54652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644573+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54429,7 +54739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644622+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54462,7 +54772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644668+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54495,7 +54805,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644733+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54521,7 +54831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644769+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54554,7 +54864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644818+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54675,16 +54985,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.645070+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.284994+00:00"
               },
               "deterministic": true
             },
@@ -54697,7 +55012,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163586+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623451+00:00"
           }
         },
         "x-f5xc-description-short": "List of application types for a namespace.",
@@ -54823,7 +55138,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163661+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623496+00:00"
           }
         },
         "x-f5xc-description-short": "CdnMetricData contains the metric type and the corresponding metric value(s).",
@@ -55030,7 +55345,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645181+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55057,16 +55372,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.645227+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285057+00:00"
               },
               "deterministic": true
             },
@@ -55079,7 +55399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163810+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623587+00:00"
           },
           "range": {
             "type": "string",
@@ -55104,7 +55424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645271+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55140,7 +55460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645332+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55173,7 +55493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645380+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55238,7 +55558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645438+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55372,7 +55692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645557+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55398,7 +55718,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645603+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55422,16 +55742,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.645658+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285202+00:00"
               },
               "deterministic": true
             },
@@ -55444,7 +55769,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163949+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623680+00:00"
           },
           "service": {
             "type": "string",
@@ -55462,7 +55787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645724+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55488,7 +55813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645781+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55513,7 +55838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645841+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55539,7 +55864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645871+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55564,7 +55889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645921+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55683,7 +56008,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645972+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55713,16 +56038,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646007+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285329+00:00"
               },
               "deterministic": true
             },
@@ -55735,7 +56065,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164064+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623750+00:00"
           },
           "range": {
             "type": "string",
@@ -55760,7 +56090,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646047+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55793,7 +56123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646095+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55826,7 +56156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646132+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55889,7 +56219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646172+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55981,7 +56311,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646234+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56042,16 +56372,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646297+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285460+00:00"
               },
               "deterministic": true
             },
@@ -56064,7 +56399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623820+00:00"
           },
           "range": {
             "type": "string",
@@ -56089,7 +56424,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646352+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56122,7 +56457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646399+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56155,7 +56490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646435+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56219,7 +56554,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646475+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56275,7 +56610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646520+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56336,7 +56671,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.646600+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56381,7 +56716,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.646662+00:00"
+                "validatedAt": "2026-05-05T18:46:57.286977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56405,16 +56740,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646694+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.287003+00:00"
               },
               "deterministic": true
             },
@@ -56427,7 +56767,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164291+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623884+00:00"
           },
           "start_time": {
             "type": "string",
@@ -56452,7 +56792,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646742+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56485,7 +56825,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646780+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56561,7 +56901,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646829+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56614,7 +56954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646869+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56626,7 +56966,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623933+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the service graph are tagged with labels listed in the enum Label.",
@@ -56760,7 +57100,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646920+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56790,16 +57130,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646954+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.287137+00:00"
               },
               "deterministic": true
             },
@@ -56812,7 +57157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164491+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.624003+00:00"
           },
           "range": {
             "type": "string",
@@ -56837,7 +57182,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646993+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56870,7 +57215,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647039+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56903,7 +57248,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647075+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56967,7 +57312,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647114+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57023,7 +57368,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647159+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57100,16 +57445,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.647220+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.287264+00:00"
               },
               "deterministic": true
             },
@@ -57122,7 +57472,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164606+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.624073+00:00"
           },
           "range": {
             "type": "string",
@@ -57147,7 +57497,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647259+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57180,7 +57530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647304+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57213,7 +57563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647351+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57278,7 +57628,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647390+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57327,7 +57677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647432+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57360,7 +57710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647478+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57387,7 +57737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647513+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57412,7 +57762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647541+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57445,7 +57795,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647590+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57496,7 +57846,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:39.736867+00:00"
+                "validatedAt": "2026-05-05T18:47:13.463955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57514,29 +57864,29 @@
             "x-ves-example": "API1:2023",
             "x-f5xc-example": "API1:2023",
             "x-f5xc-description-short": "The name of the OWASP API security category.",
-            "maxLength": 16,
+            "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:39.736906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:13.463973+00:00"
               },
               "deterministic": true
             },
@@ -57545,11 +57895,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "x-original-maxLength": 1024,
-            "minLength": 6,
-            "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.970298+00:00"
+            }
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",
@@ -57718,7 +58064,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:41.243050+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171117+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57797,7 +58143,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:41.243136+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57870,23 +58216,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.243393+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.171272+00:00"
               },
               "deterministic": true
             },
@@ -57899,7 +58245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.957931+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.110901+00:00"
           },
           "sli_address": {
             "type": "string",
@@ -57914,7 +58260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.243440+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171293+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57937,7 +58283,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.243488+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58155,7 +58501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.243543+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58288,7 +58634,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:41.243642+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58365,7 +58711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.243704+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58508,23 +58854,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.243973+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.171549+00:00"
               },
               "deterministic": true
             },
@@ -58537,7 +58883,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.958309+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111131+00:00"
           }
         },
         "x-f5xc-description-short": "BondMembersType represents the bond interface members along with the corresponding link state.",
@@ -58636,7 +58982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244026+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58658,23 +59004,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.244061+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.171590+00:00"
               },
               "deterministic": true
             },
@@ -58687,7 +59033,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.958440+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111203+00:00"
           },
           "network_name": {
             "type": "string",
@@ -58704,7 +59050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244108+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58940,7 +59286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244183+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58964,7 +59310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244236+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58991,7 +59337,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:20:41.244277+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171694+00:00"
               },
               "deterministic": true
             },
@@ -59033,7 +59379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244333+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59055,23 +59401,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.244366+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.171730+00:00"
               },
               "deterministic": true
             },
@@ -59084,7 +59430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.958642+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111319+00:00"
           },
           "resource_id": {
             "type": "string",
@@ -59101,7 +59447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.244412+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59126,7 +59472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244460+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59149,7 +59495,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244507+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59219,7 +59565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244553+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59244,7 +59590,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.244600+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171837+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59269,7 +59615,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244647+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59292,7 +59638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244694+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59316,7 +59662,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244731+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59381,7 +59727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244793+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59425,7 +59771,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244835+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59460,7 +59806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.244877+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171963+00:00"
               },
               "deterministic": true
             },
@@ -59518,7 +59864,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244920+00:00"
+                "validatedAt": "2026-05-05T18:45:48.171983+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59541,7 +59887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.244974+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59672,7 +60018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245042+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59736,7 +60082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245099+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172061+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59760,7 +60106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245142+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59814,7 +60160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:41.245186+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172103+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59863,7 +60209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245234+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172126+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59889,7 +60235,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.245274+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172145+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59914,7 +60260,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245317+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60031,7 +60377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245392+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60054,7 +60400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245442+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172216+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60091,7 +60437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245500+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172243+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60114,7 +60460,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245548+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60152,7 +60498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245606+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172291+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60175,7 +60521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245656+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60199,7 +60545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245706+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60222,7 +60568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245755+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60246,7 +60592,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245804+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60343,7 +60689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245862+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60368,23 +60714,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.245897+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.172423+00:00"
               },
               "deterministic": true
             },
@@ -60397,7 +60743,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959073+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111574+00:00"
           },
           "src_id": {
             "type": "string",
@@ -60415,7 +60761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.245937+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60473,7 +60819,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:41.245978+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60592,7 +60938,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246023+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172479+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60614,23 +60960,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.246056+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.172495+00:00"
               },
               "deterministic": true
             },
@@ -60643,7 +60989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959191+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111646+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60699,7 +61045,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246095+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60721,23 +61067,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.246128+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.172530+00:00"
               },
               "deterministic": true
             },
@@ -60750,7 +61096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959237+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111674+00:00"
           },
           "owner_id": {
             "type": "string",
@@ -60765,7 +61111,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246169+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60792,7 +61138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246212+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60816,7 +61162,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246251+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60828,7 +61174,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959291+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111706+00:00"
           },
           "tags": {
             "type": "object",
@@ -60940,7 +61286,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:41.246332+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172630+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60973,7 +61319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246378+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61006,7 +61352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:41.246427+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172681+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61039,7 +61385,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246476+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61072,7 +61418,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246515+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61122,23 +61468,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.246550+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.172738+00:00"
               },
               "deterministic": true
             },
@@ -61151,7 +61497,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959421+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111781+00:00"
           },
           "private_addresses": {
             "type": "array",
@@ -61212,7 +61558,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246631+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61224,7 +61570,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959473+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111813+00:00"
           },
           "subnet": {
             "type": "array",
@@ -61401,7 +61747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246733+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61463,7 +61809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246802+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172853+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61490,7 +61836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.246832+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172866+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61512,23 +61858,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.246864+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.172882+00:00"
               },
               "deterministic": true
             },
@@ -61541,7 +61887,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959598+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111886+00:00"
           },
           "network_type": {
             "$ref": "#/components/schemas/topologyCloudNetworkType"
@@ -61755,7 +62101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247019+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61784,7 +62130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.247075+00:00"
+                "validatedAt": "2026-05-05T18:45:48.172975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61796,7 +62142,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959723+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111956+00:00"
           },
           "level": {
             "type": "integer",
@@ -61827,23 +62173,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.247119+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.172995+00:00"
               },
               "deterministic": true
             },
@@ -61856,7 +62202,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959757+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.111977+00:00"
           },
           "owner_id": {
             "type": "string",
@@ -61873,7 +62219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247159+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61901,7 +62247,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247201+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61913,7 +62259,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.959800+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.112003+00:00"
           },
           "tags": {
             "type": "object",
@@ -62418,7 +62764,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247341+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62442,23 +62788,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.247371+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.173103+00:00"
               },
               "deterministic": true
             },
@@ -62471,7 +62817,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.960026+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.112138+00:00"
           },
           "tags": {
             "type": "object",
@@ -62629,7 +62975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.247458+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62775,7 +63121,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247553+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173184+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62804,7 +63150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247595+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173203+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62834,7 +63180,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247650+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62998,7 +63344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247764+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63205,7 +63551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247882+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63231,7 +63577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247919+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63337,7 +63683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.247995+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63360,23 +63706,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:41.248028+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:48.173396+00:00"
               },
               "deterministic": true
             },
@@ -63389,7 +63735,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.960456+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.112388+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63464,7 +63810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.248096+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173425+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63525,7 +63871,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.248163+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63667,7 +64013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:41.248250+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63760,7 +64106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:41.248310+00:00"
+                "validatedAt": "2026-05-05T18:45:48.173525+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63926,7 +64272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390468+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838670+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63950,16 +64296,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.390535+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.838703+00:00"
               },
               "deterministic": true
             },
@@ -63972,7 +64323,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365011+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524457+00:00"
           },
           "network_id": {
             "type": "string",
@@ -63989,7 +64340,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390582+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64019,7 +64370,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390630+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64127,7 +64478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390700+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64152,7 +64503,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390752+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64177,16 +64528,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.390787+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.838817+00:00"
               },
               "deterministic": true
             },
@@ -64199,7 +64555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365113+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524528+00:00"
           },
           "sort": {
             "$ref": "#/components/schemas/l3l4MitigationSeriesSort"
@@ -64223,7 +64579,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390834+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64333,7 +64689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390908+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64357,16 +64713,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.390946+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.838889+00:00"
               },
               "deterministic": true
             },
@@ -64379,7 +64740,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365200+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524590+00:00"
           },
           "network_id": {
             "type": "string",
@@ -64396,7 +64757,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.390991+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64426,7 +64787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391036+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64534,7 +64895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391103+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64558,16 +64919,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.391138+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.838976+00:00"
               },
               "deterministic": true
             },
@@ -64580,7 +64946,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365286+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524653+00:00"
           },
           "network_id": {
             "type": "string",
@@ -64597,7 +64963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391183+00:00"
+                "validatedAt": "2026-05-05T18:46:51.838997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64630,7 +64996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391230+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64738,7 +65104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391294+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64762,16 +65128,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.391342+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.839065+00:00"
               },
               "deterministic": true
             },
@@ -64784,7 +65155,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365387+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524707+00:00"
           },
           "network_id": {
             "type": "string",
@@ -64802,7 +65173,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391386+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64832,7 +65203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391431+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64859,7 +65230,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391468+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839122+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64946,7 +65317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391525+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64971,7 +65342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391565+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65004,7 +65375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.391617+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839189+00:00"
               },
               "deterministic": true
             },
@@ -65060,7 +65431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.391668+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839212+00:00"
               },
               "deterministic": true
             },
@@ -65086,7 +65457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391707+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839229+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65098,7 +65469,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365491+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524767+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -65134,23 +65505,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.391743+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.839246+00:00"
               },
               "deterministic": true
             },
@@ -65163,7 +65534,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365520+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524785+00:00"
           },
           "values": {
             "type": "array",
@@ -65262,7 +65633,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391786+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65286,7 +65657,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391815+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65311,7 +65682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391844+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65362,7 +65733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391887+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65386,16 +65757,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:47.391922+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:51.839330+00:00"
               },
               "deterministic": true
             },
@@ -65408,7 +65784,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:27.365597+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.524830+00:00"
           },
           "network_id": {
             "type": "string",
@@ -65425,7 +65801,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.391966+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65455,7 +65831,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:47.392012+00:00"
+                "validatedAt": "2026-05-05T18:46:51.839372+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/support.json
+++ b/docs/specifications/api/support.json
@@ -13160,23 +13160,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:27.642582+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:09.625051+00:00"
               },
               "deterministic": true
             },
@@ -13189,7 +13189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.505468+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:01.346374+00:00",
             "x-f5xc-conflicts-with": [
               "uid"
             ]
@@ -13208,16 +13208,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:27.642626+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:09.625072+00:00"
               },
               "deterministic": true
             },
@@ -13230,7 +13235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.505498+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.346390+00:00"
           },
           "site": {
             "type": "string",
@@ -13248,7 +13253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:27.642666+00:00"
+                "validatedAt": "2026-05-05T18:41:09.625090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13272,7 +13277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:27.642696+00:00"
+                "validatedAt": "2026-05-05T18:41:09.625104+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13286,7 +13291,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.505538+00:00",
+            "x-reconciled-at": "2026-05-05T18:47:01.346412+00:00",
             "x-f5xc-conflicts-with": [
               "name"
             ]
@@ -13330,7 +13335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:27.642738+00:00"
+                "validatedAt": "2026-05-05T18:41:09.625123+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13342,7 +13347,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.505568+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.346429+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -13383,7 +13388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.883411+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13409,7 +13414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.883488+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377280+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13435,7 +13440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.883532+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13461,7 +13466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.883571+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377317+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13511,23 +13516,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.883618+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377338+00:00"
               },
               "deterministic": true
             },
@@ -13540,7 +13545,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959532+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13556,16 +13561,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.883658+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377356+00:00"
               },
               "deterministic": true
             },
@@ -13578,7 +13588,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185139+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959549+00:00"
           }
         },
         "x-f5xc-description-short": "Closes an open existing customer support ticket.",
@@ -13662,7 +13672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:32.883731+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13686,23 +13696,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.883766+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377407+00:00"
               },
               "deterministic": true
             },
@@ -13715,7 +13725,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185196+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959584+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13731,16 +13741,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.883799+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377424+00:00"
               },
               "deterministic": true
             },
@@ -13753,7 +13768,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185222+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959600+00:00"
           }
         },
         "x-f5xc-description-short": "Adds a new comment to an existing customer support ticket.",
@@ -13853,7 +13868,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.883882+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13878,7 +13893,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.883930+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13911,7 +13926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.883982+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377504+00:00"
               },
               "deterministic": true
             },
@@ -13938,7 +13953,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.884018+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13963,7 +13978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.884064+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14070,23 +14085,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884107+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377561+00:00"
               },
               "deterministic": true
             },
@@ -14099,7 +14114,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959700+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14115,16 +14130,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884139+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377577+00:00"
               },
               "deterministic": true
             },
@@ -14137,7 +14157,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185408+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959717+00:00"
           }
         },
         "x-f5xc-description-short": "Changes priority of an existing customer support ticket.",
@@ -14261,7 +14281,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185500+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959774+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -14328,7 +14348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:32.884256+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377634+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14391,7 +14411,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:32.884333+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377663+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14403,7 +14423,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185572+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959818+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -14453,23 +14473,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884374+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377682+00:00"
               },
               "deterministic": true
             },
@@ -14482,7 +14502,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185635+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959857+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14497,16 +14517,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884408+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377697+00:00"
               },
               "deterministic": true
             },
@@ -14519,7 +14544,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185662+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959873+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -14558,7 +14583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.884463+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14571,7 +14596,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185715+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959906+00:00"
           },
           "uid": {
             "type": "string",
@@ -14589,7 +14614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.884492+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14603,7 +14628,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185743+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959923+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_support is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -14674,7 +14699,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:32.884564+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14719,7 +14744,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:32.884622+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14731,7 +14756,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185780+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959946+00:00"
           }
         },
         "x-f5xc-description-short": "Input message of the 'ListCTSupportTickets' RPC. Fields can be used to control scope and filtering of collection.",
@@ -14791,7 +14816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:32.884672+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14837,23 +14862,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884711+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377838+00:00"
               },
               "deterministic": true
             },
@@ -14866,7 +14891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185830+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959979+00:00"
           },
           "namespace": {
             "type": "string",
@@ -14882,16 +14907,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884745+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377855+00:00"
               },
               "deterministic": true
             },
@@ -14904,7 +14934,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185857+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.959996+00:00"
           },
           "priority": {
             "$ref": "#/components/schemas/customer_supportSupportTicketPriority"
@@ -14989,7 +15019,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.884813+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15037,23 +15067,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884849+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377901+00:00"
               },
               "deterministic": true
             },
@@ -15066,7 +15096,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185932+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960043+00:00"
           }
         },
         "x-f5xc-description-short": "Any error that may occurred during tax status verification request.",
@@ -15105,23 +15135,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884883+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377918+00:00"
               },
               "deterministic": true
             },
@@ -15134,7 +15164,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185961+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960060+00:00"
           },
           "namespace": {
             "type": "string",
@@ -15150,16 +15180,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.884914+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.377934+00:00"
               },
               "deterministic": true
             },
@@ -15172,7 +15207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.185987+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960076+00:00"
           }
         },
         "x-f5xc-description-short": "Reopens a closed existing customer support ticket.",
@@ -15494,7 +15529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.884990+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15517,7 +15552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885028+00:00"
+                "validatedAt": "2026-05-05T18:42:41.377986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15529,7 +15564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186071+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960127+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -15575,7 +15610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885069+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378006+00:00"
               },
               "deterministic": true
             },
@@ -15601,7 +15636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885120+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15628,7 +15663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885160+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15640,7 +15675,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186119+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960155+00:00"
           },
           "service_name": {
             "type": "string",
@@ -15657,7 +15692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885209+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15690,7 +15725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885255+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378088+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15702,7 +15737,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186154+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960178+00:00"
           },
           "type": {
             "type": "string",
@@ -15727,7 +15762,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885293+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378105+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15785,7 +15820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885347+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378125+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15831,23 +15866,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885383+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378142+00:00"
               },
               "deterministic": true
             },
@@ -15860,7 +15895,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186221+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960218+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -15978,7 +16013,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:32.885494+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378195+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -15994,7 +16029,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186282+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960254+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16048,23 +16083,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885536+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378215+00:00"
               },
               "deterministic": true
             },
@@ -16077,7 +16112,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186351+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960285+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16094,16 +16129,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885567+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378230+00:00"
               },
               "deterministic": true
             },
@@ -16116,7 +16156,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186379+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960301+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -16198,7 +16238,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:32.885659+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378275+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -16214,7 +16254,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186420+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960325+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -16270,23 +16310,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885700+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378294+00:00"
               },
               "deterministic": true
             },
@@ -16299,7 +16339,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186464+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960354+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16316,16 +16356,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885731+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378309+00:00"
               },
               "deterministic": true
             },
@@ -16338,7 +16383,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186491+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960372+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -16383,7 +16428,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885767+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16396,7 +16441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186522+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960390+00:00"
           },
           "name": {
             "type": "string",
@@ -16413,23 +16458,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885802+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378343+00:00"
               },
               "deterministic": true
             },
@@ -16442,7 +16487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186547+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960406+00:00"
           },
           "namespace": {
             "type": "string",
@@ -16459,16 +16504,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.885833+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378360+00:00"
               },
               "deterministic": true
             },
@@ -16481,7 +16531,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186573+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960422+00:00"
           },
           "tenant": {
             "type": "string",
@@ -16500,7 +16550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885872+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16514,7 +16564,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186601+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960438+00:00"
           },
           "uid": {
             "type": "string",
@@ -16533,7 +16583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885901+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16548,7 +16598,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186629+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960455+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -16593,7 +16643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.885953+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378415+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16621,7 +16671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886002+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378437+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16649,7 +16699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886048+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16678,7 +16728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886092+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378475+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16705,7 +16755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886123+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16719,7 +16769,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186703+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960499+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -16735,7 +16785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886163+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16844,7 +16894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886220+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16856,7 +16906,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186760+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960533+00:00"
           },
           "status": {
             "type": "string",
@@ -16874,7 +16924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886259+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378549+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16886,7 +16936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186789+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960549+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -16928,7 +16978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886311+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16955,7 +17005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886368+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16982,7 +17032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886411+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378620+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17010,7 +17060,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886463+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17075,7 +17125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886534+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17124,7 +17174,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886590+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17137,7 +17187,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960647+00:00"
           },
           "uid": {
             "type": "string",
@@ -17156,7 +17206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886618+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17170,7 +17220,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186941+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960665+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -17220,7 +17270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886653+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17232,7 +17282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186971+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960683+00:00"
           },
           "name": {
             "type": "string",
@@ -17249,23 +17299,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.886688+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378747+00:00"
               },
               "deterministic": true
             },
@@ -17278,7 +17328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.186997+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960699+00:00"
           },
           "namespace": {
             "type": "string",
@@ -17295,16 +17345,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.886720+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:41.378763+00:00"
               },
               "deterministic": true
             },
@@ -17317,7 +17372,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.187024+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960715+00:00"
           },
           "uid": {
             "type": "string",
@@ -17334,7 +17389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886749+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17348,7 +17403,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.187053+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960733+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -17392,7 +17447,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886791+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378797+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17438,7 +17493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:32.886860+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17450,7 +17505,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.187103+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960763+00:00"
           },
           "ongoing": {
             "type": "boolean",
@@ -17483,7 +17538,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886909+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378851+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17528,7 +17583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.886965+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378876+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17553,7 +17608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887006+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17581,7 +17636,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887045+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378912+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17670,7 +17725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887095+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17698,7 +17753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887136+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378954+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17747,7 +17802,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:32.887200+00:00"
+                "validatedAt": "2026-05-05T18:42:41.378983+00:00"
               },
               "deterministic": true
             },
@@ -17796,7 +17851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:32.887268+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17808,7 +17863,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:11.187273+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.960873+00:00"
           },
           "escalated": {
             "type": "boolean",
@@ -17871,7 +17926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887341+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17916,7 +17971,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887427+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17945,7 +18000,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:09:32.887477+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379083+00:00"
               },
               "deterministic": true
             },
@@ -17971,7 +18026,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887534+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17999,7 +18054,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887572+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18029,7 +18084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:32.887617+00:00"
+                "validatedAt": "2026-05-05T18:42:41.379138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18122,7 +18177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:59.425002+00:00"
+                "validatedAt": "2026-05-05T18:42:54.201665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18147,7 +18202,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:59.425083+00:00"
+                "validatedAt": "2026-05-05T18:42:54.201695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18211,7 +18266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903300+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18242,7 +18297,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903384+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18267,7 +18322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903447+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18298,7 +18353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903506+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259550+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18349,7 +18404,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903564+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18389,7 +18444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903612+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18415,7 +18470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903655+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18529,7 +18584,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903713+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259651+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18591,7 +18646,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903777+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259680+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18615,16 +18670,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.903815+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.259699+00:00"
               },
               "deterministic": true
             },
@@ -18637,7 +18697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.551713+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731095+00:00"
           },
           "node": {
             "type": "string",
@@ -18654,7 +18714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903851+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18679,7 +18739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903887+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259731+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18729,7 +18789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.903927+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18794,7 +18854,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.903983+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259777+00:00"
               },
               "deterministic": true
             },
@@ -18825,7 +18885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.904023+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259795+00:00"
               },
               "deterministic": true
             },
@@ -18879,7 +18939,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904074+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18903,7 +18963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904119+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18941,7 +19001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904179+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18968,7 +19028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904222+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18980,7 +19040,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.551871+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731188+00:00"
           },
           "wifi_support": {
             "type": "boolean",
@@ -19043,7 +19103,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:33.904268+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19069,7 +19129,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904303+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19097,7 +19157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:10:33.904361+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259942+00:00"
               },
               "deterministic": true
             },
@@ -19137,16 +19197,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.904406+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.259963+00:00"
               },
               "deterministic": true
             },
@@ -19159,7 +19224,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.551948+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731232+00:00"
           },
           "node": {
             "type": "string",
@@ -19176,7 +19241,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904443+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19201,7 +19266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904477+00:00"
+                "validatedAt": "2026-05-05T18:43:11.259997+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19252,7 +19317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904521+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260017+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19278,7 +19343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904563+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260035+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19318,7 +19383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904614+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260057+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19343,7 +19408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904655+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19400,7 +19465,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904722+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19486,7 +19551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904768+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19530,16 +19595,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.904804+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.260146+00:00"
               },
               "deterministic": true
             },
@@ -19552,7 +19622,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552085+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731314+00:00"
           },
           "node": {
             "type": "string",
@@ -19569,7 +19639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904839+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19594,7 +19664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904874+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260178+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19656,23 +19726,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.904912+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.260195+00:00"
               },
               "deterministic": true
             },
@@ -19685,7 +19755,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552131+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731342+00:00"
           },
           "node": {
             "type": "string",
@@ -19702,7 +19772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904949+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19727,7 +19797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.904986+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260227+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19739,7 +19809,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552166+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731364+00:00"
           }
         },
         "x-f5xc-description-short": "Name and formal displayed name of the service.",
@@ -19778,16 +19848,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.905022+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.260243+00:00"
               },
               "deterministic": true
             },
@@ -19800,7 +19875,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731381+00:00"
           },
           "node": {
             "type": "string",
@@ -19817,7 +19892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905058+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260260+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19842,7 +19917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905099+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19867,7 +19942,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905134+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19932,7 +20007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905177+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19955,23 +20030,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.905211+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.260330+00:00"
               },
               "deterministic": true
             },
@@ -19984,7 +20059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552257+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731419+00:00"
           },
           "node": {
             "type": "string",
@@ -20001,7 +20076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905245+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20026,7 +20101,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905284+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260363+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20038,7 +20113,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552292+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731440+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20081,7 +20156,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552333+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731458+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20148,7 +20223,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905450+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20186,7 +20261,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:33.905527+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20198,7 +20273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552415+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731505+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -20217,7 +20292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905577+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260495+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20268,7 +20343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905620+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260513+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20280,7 +20355,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552451+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731527+00:00"
           },
           "url": {
             "type": "string",
@@ -20318,7 +20393,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:33.905698+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260552+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -20427,7 +20502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.905746+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260575+00:00"
               },
               "deterministic": true
             },
@@ -20454,7 +20529,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905785+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20480,7 +20555,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905824+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260611+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20492,7 +20567,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552531+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731572+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20532,7 +20607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905869+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20556,23 +20631,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.905902+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.260654+00:00"
               },
               "deterministic": true
             },
@@ -20585,7 +20660,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552570+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731594+00:00"
           },
           "serial": {
             "type": "string",
@@ -20603,7 +20678,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905940+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20629,7 +20704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.905980+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20655,7 +20730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906020+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20667,7 +20742,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552612+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731626+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20709,7 +20784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906066+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260727+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20735,7 +20810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906105+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260745+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20777,7 +20852,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906155+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20803,7 +20878,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906195+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20815,7 +20890,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552674+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731664+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -20901,7 +20976,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906266+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20956,7 +21031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906358+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21007,7 +21082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906406+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21032,7 +21107,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906456+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21095,7 +21170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906500+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260909+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21120,7 +21195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906542+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21145,7 +21220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906591+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260947+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21192,7 +21267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906639+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260968+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21217,7 +21292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906680+00:00"
+                "validatedAt": "2026-05-05T18:43:11.260986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21242,7 +21317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906719+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261004+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21254,7 +21329,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552842+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731762+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21376,7 +21451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906779+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21423,7 +21498,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906820+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261052+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21475,7 +21550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.906879+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261082+00:00"
               },
               "deterministic": true
             },
@@ -21499,23 +21574,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.906913+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.261097+00:00"
               },
               "deterministic": true
             },
@@ -21528,7 +21603,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552940+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731822+00:00"
           },
           "port": {
             "type": "string",
@@ -21547,7 +21622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.906949+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261113+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21614,7 +21689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907007+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261139+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21637,23 +21712,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.907040+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.261155+00:00"
               },
               "deterministic": true
             },
@@ -21666,7 +21741,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.552994+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731855+00:00"
           },
           "release": {
             "type": "string",
@@ -21683,7 +21758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907079+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21708,7 +21783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907117+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261191+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21733,7 +21808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907156+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21745,7 +21820,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.553035+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731881+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -21810,7 +21885,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:33.907205+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21843,7 +21918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:33.907267+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -21935,23 +22010,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.907336+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.261289+00:00"
               },
               "deterministic": true
             },
@@ -21964,7 +22039,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.553173+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731966+00:00"
           },
           "serial": {
             "type": "string",
@@ -21983,7 +22058,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907376+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22008,7 +22083,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907418+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261325+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22034,7 +22109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907458+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261342+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22046,7 +22121,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.553217+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.731992+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -22086,7 +22161,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907499+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22111,7 +22186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907537+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261378+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22134,23 +22209,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:33.907572+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:11.261393+00:00"
               },
               "deterministic": true
             },
@@ -22163,7 +22238,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.553263+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.732019+00:00"
           },
           "serial": {
             "type": "string",
@@ -22180,7 +22255,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907610+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22220,7 +22295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907661+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22286,7 +22361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907722+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261458+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22312,7 +22387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907771+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261480+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22338,7 +22413,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907820+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22378,7 +22453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907880+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22403,7 +22478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.907919+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22448,7 +22523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:33.907983+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261573+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22460,7 +22535,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.553396+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.732093+00:00"
           },
           "i_manufacturer": {
             "type": "string",
@@ -22477,7 +22552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908031+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261593+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22502,7 +22577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908075+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22528,7 +22603,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908118+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22554,7 +22629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908164+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261662+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22579,7 +22654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908209+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261682+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22609,7 +22684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:33.908244+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261697+00:00"
               },
               "deterministic": true
             },
@@ -22636,7 +22711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908294+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261720+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22662,7 +22737,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908340+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261736+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22691,7 +22766,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:33.908386+00:00"
+                "validatedAt": "2026-05-05T18:43:11.261757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22778,7 +22853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.647975+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22790,7 +22865,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.603254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.760714+00:00"
           },
           "value": {
             "type": "string",
@@ -22805,7 +22880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648032+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22817,7 +22892,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.603285+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.760732+00:00"
           }
         },
         "x-f5xc-description-short": "DHCP Option information as a (key, value) pair.",
@@ -22856,7 +22931,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648081+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22884,7 +22959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:35.648143+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092338+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22896,7 +22971,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.603338+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.760756+00:00"
           },
           "expiry": {
             "type": "string",
@@ -22913,7 +22988,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648186+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22943,7 +23018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:35.648227+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092379+00:00"
               },
               "deterministic": true
             },
@@ -22968,7 +23043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648292+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -22993,7 +23068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648341+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23018,7 +23093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648398+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23043,7 +23118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648429+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23082,7 +23157,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648484+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23216,7 +23291,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648588+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23240,7 +23315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:35.648626+00:00"
+                "validatedAt": "2026-05-05T18:43:12.092539+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23344,7 +23419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:57.561757+00:00"
+                "validatedAt": "2026-05-05T18:43:23.675272+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23427,7 +23502,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.004811+00:00"
+                "validatedAt": "2026-05-05T18:44:56.493964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23452,7 +23527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.004885+00:00"
+                "validatedAt": "2026-05-05T18:44:56.493999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23529,7 +23604,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.004939+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494023+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23554,7 +23629,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.004981+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23579,7 +23654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005011+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494065+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23626,7 +23701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005060+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23674,16 +23749,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:08.005099+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:56.494113+00:00"
               },
               "deterministic": true
             },
@@ -23696,7 +23776,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.497539+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.875771+00:00"
           },
           "node": {
             "type": "string",
@@ -23713,7 +23793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005136+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23738,7 +23818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005174+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494149+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23850,16 +23930,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:08.005220+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:56.494173+00:00"
               },
               "deterministic": true
             },
@@ -23872,7 +23957,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.497620+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.875818+00:00"
           },
           "node": {
             "type": "string",
@@ -23889,7 +23974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005256+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -23914,7 +23999,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005291+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24087,7 +24172,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005403+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24113,7 +24198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005464+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494269+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24137,7 +24222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:08.005522+00:00"
+                "validatedAt": "2026-05-05T18:44:56.494288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24210,7 +24295,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:12.937955+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001244+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24249,7 +24334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:16:12.938023+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001266+00:00"
               },
               "deterministic": true
             },
@@ -24277,16 +24362,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:12.938080+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:58.001288+00:00"
               },
               "deterministic": true
             },
@@ -24299,7 +24389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.831993+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.170822+00:00"
           },
           "node": {
             "type": "string",
@@ -24331,7 +24421,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:12.938208+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24380,7 +24470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:12.938284+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24433,7 +24523,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:12.938344+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001372+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24458,7 +24548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:12.938378+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24498,7 +24588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:12.938429+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24523,7 +24613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:12.938470+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001431+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24578,7 +24668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:12.938539+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24662,7 +24752,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:12.938611+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001504+00:00"
               },
               "deterministic": true
             },
@@ -24700,7 +24790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:12.938671+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24766,7 +24856,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:12.938741+00:00"
+                "validatedAt": "2026-05-05T18:45:58.001568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24859,7 +24949,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.635804+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24901,7 +24991,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.635866+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -24943,7 +25033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.635927+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25036,16 +25126,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:09.635975+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:32.427364+00:00"
               },
               "deterministic": true
             },
@@ -25058,7 +25153,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.358121+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.781212+00:00"
           },
           "node": {
             "type": "string",
@@ -25090,7 +25185,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.636048+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25116,7 +25211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636084+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25168,7 +25263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636140+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25219,16 +25314,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:09.636178+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:32.427467+00:00"
               },
               "deterministic": true
             },
@@ -25241,7 +25341,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.358196+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.781256+00:00"
           },
           "node": {
             "type": "string",
@@ -25273,7 +25373,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.636247+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25299,7 +25399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636283+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25411,7 +25511,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:09.636378+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427548+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25461,16 +25561,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:09.636434+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:32.427574+00:00"
               },
               "deterministic": true
             },
@@ -25483,7 +25588,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.358280+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.781306+00:00"
           },
           "node": {
             "type": "string",
@@ -25515,7 +25620,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.636503+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25553,7 +25658,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:09.636573+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25579,7 +25684,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636610+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427674+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25635,7 +25740,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:09.636650+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25681,7 +25786,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636712+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25707,7 +25812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636750+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427738+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25732,7 +25837,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:09.636791+00:00"
+                "validatedAt": "2026-05-05T18:45:32.427756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -25744,7 +25849,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.358394+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.781364+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -25850,7 +25955,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:34.203952+00:00"
+                "validatedAt": "2026-05-05T18:45:44.766684+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -25866,7 +25971,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798569+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021167+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -25920,23 +26025,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.203994+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.766703+00:00"
               },
               "deterministic": true
             },
@@ -25949,7 +26054,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798613+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021194+00:00"
           },
           "namespace": {
             "type": "string",
@@ -25966,16 +26071,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.204026+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.766719+00:00"
               },
               "deterministic": true
             },
@@ -25988,7 +26098,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798640+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021210+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -26029,7 +26139,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204516+00:00"
+                "validatedAt": "2026-05-05T18:45:44.766935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26041,7 +26151,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798884+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021353+00:00"
           },
           "location": {
             "type": "string",
@@ -26057,7 +26167,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204559+00:00"
+                "validatedAt": "2026-05-05T18:45:44.766955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26069,7 +26179,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798913+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021369+00:00"
           },
           "provider": {
             "type": "string",
@@ -26086,7 +26196,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204601+00:00"
+                "validatedAt": "2026-05-05T18:45:44.766974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26098,7 +26208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798940+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021385+00:00"
           },
           "secret_encoding": {
             "$ref": "#/components/schemas/schemaSecretEncodingType"
@@ -26120,7 +26230,7 @@
             "maxLength": 1,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.798977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021406+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Vault Secret\" VaultSecretInfoType specifies information about the Secret managed by Hashicorp Vault.",
@@ -26158,23 +26268,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.204782+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767059+00:00"
               },
               "deterministic": true
             },
@@ -26187,7 +26297,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021489+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Wingman Secret\" WingmanSecretInfoType specifies the handle to the wingman secret.",
@@ -26225,7 +26335,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204826+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767078+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26252,7 +26362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204870+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767098+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26279,7 +26389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204897+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767110+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26303,23 +26413,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.204930+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767127+00:00"
               },
               "deterministic": true
             },
@@ -26332,7 +26442,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799166+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021522+00:00"
           }
         },
         "x-f5xc-description-short": "Issue (ticket) type information that's specific to Jira - modeled after the JIRA REST API response format.",
@@ -26376,7 +26486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.204960+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26417,7 +26527,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.205002+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767161+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26429,7 +26539,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799213+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021549+00:00"
           },
           "name": {
             "type": "string",
@@ -26445,23 +26555,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.205036+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767176+00:00"
               },
               "deterministic": true
             },
@@ -26474,7 +26584,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799239+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021565+00:00"
           }
         },
         "x-f5xc-description-short": "Contains fields and information that are specific to Jira projects - modeled after the JIRA REST API response format.",
@@ -26607,23 +26717,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.205081+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767197+00:00"
               },
               "deterministic": true
             },
@@ -26636,7 +26746,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799341+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021630+00:00"
           },
           "namespace": {
             "type": "string",
@@ -26652,16 +26762,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.205112+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767213+00:00"
               },
               "deterministic": true
             },
@@ -26674,7 +26789,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799367+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021646+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -26843,7 +26958,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:34.205251+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767282+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26878,7 +26993,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:34.205332+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767319+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26919,7 +27034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:34.205417+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767358+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -26989,7 +27104,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.205471+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767383+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27048,7 +27163,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.205537+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27114,7 +27229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:34.205590+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27177,7 +27292,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:34.205649+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27189,7 +27304,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799576+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021772+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -27240,23 +27355,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.205688+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767481+00:00"
               },
               "deterministic": true
             },
@@ -27269,7 +27384,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799638+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021810+00:00"
           },
           "namespace": {
             "type": "string",
@@ -27284,16 +27399,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:34.205720+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:44.767497+00:00"
               },
               "deterministic": true
             },
@@ -27306,7 +27426,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799663+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021826+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -27329,7 +27449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.205759+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767515+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27342,7 +27462,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799705+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021852+00:00"
           },
           "uid": {
             "type": "string",
@@ -27360,7 +27480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:34.205787+00:00"
+                "validatedAt": "2026-05-05T18:45:44.767529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27374,7 +27494,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.799731+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.021868+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of ticket_tracking_system is returned in 'List'.",
@@ -27553,16 +27673,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:57.709065+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.926511+00:00"
               },
               "deterministic": true
             },
@@ -27575,7 +27700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.283441+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.286460+00:00"
           },
           "node": {
             "type": "string",
@@ -27592,7 +27717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709101+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27620,7 +27745,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:57.709142+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926547+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27645,7 +27770,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709179+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27696,7 +27821,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:57.709217+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27775,16 +27900,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:57.709257+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.926600+00:00"
               },
               "deterministic": true
             },
@@ -27797,7 +27927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.283522+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.286505+00:00"
           },
           "node": {
             "type": "string",
@@ -27814,7 +27944,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709291+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27842,7 +27972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:57.709341+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27867,7 +27997,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709376+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27918,7 +28048,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:57.709411+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -27986,16 +28116,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:57.709449+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.926697+00:00"
               },
               "deterministic": true
             },
@@ -28008,7 +28143,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.283597+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.286549+00:00"
           },
           "node": {
             "type": "string",
@@ -28025,7 +28160,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709482+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28050,7 +28185,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709517+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28116,7 +28251,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:57.709565+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28163,16 +28298,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:57.709598+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:55.926771+00:00"
               },
               "deterministic": true
             },
@@ -28185,7 +28325,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.283671+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.286592+00:00"
           },
           "node": {
             "type": "string",
@@ -28202,7 +28342,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709632+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926787+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28227,7 +28367,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709666+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926804+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28291,7 +28431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709717+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926827+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28317,7 +28457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709769+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926850+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28343,7 +28483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709821+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28369,7 +28509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709863+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28395,7 +28535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709908+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926913+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28420,7 +28560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:57.709952+00:00"
+                "validatedAt": "2026-05-05T18:45:55.926933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28498,7 +28638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.561574+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28590,7 +28730,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.561735+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154728+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28663,7 +28803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.561820+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154753+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28712,16 +28852,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:26.561883+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.154778+00:00"
               },
               "deterministic": true
             },
@@ -28734,7 +28879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.989016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.323396+00:00"
           },
           "node": {
             "type": "string",
@@ -28751,7 +28896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.561932+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28776,7 +28921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.561969+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154813+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -28890,7 +29035,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.562013+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154833+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29013,7 +29158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.562077+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154863+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29060,16 +29205,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:22:26.562114+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.154882+00:00"
               },
               "deterministic": true
             },
@@ -29082,7 +29232,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:26.989141+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:14.323465+00:00"
           },
           "node": {
             "type": "string",
@@ -29099,7 +29249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.562152+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -29124,7 +29274,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:26.562187+00:00"
+                "validatedAt": "2026-05-05T18:46:41.154916+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/telemetry_and_insights.json
+++ b/docs/specifications/api/telemetry_and_insights.json
@@ -6179,7 +6179,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425738+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6206,16 +6206,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:18.425804+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:34.380332+00:00"
               },
               "deterministic": true
             },
@@ -6228,7 +6233,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.833793+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.774727+00:00"
           },
           "range": {
             "type": "string",
@@ -6253,7 +6258,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425849+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6289,7 +6294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425900+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6322,7 +6327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425939+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6387,7 +6392,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.425983+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380413+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6464,7 +6469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426024+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6543,7 +6548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426066+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6555,7 +6560,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.833937+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.774810+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used in the connectivity graph are tagged with labels listed in the enum Label.",
@@ -6706,7 +6711,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426143+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6834,7 +6839,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426192+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380506+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6875,7 +6880,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426249+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6901,7 +6906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426294+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7052,7 +7057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426363+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7099,16 +7104,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:18.426417+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:34.380599+00:00"
               },
               "deterministic": true
             },
@@ -7121,7 +7131,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834181+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.774951+00:00"
           },
           "range": {
             "type": "string",
@@ -7146,7 +7156,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426463+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7179,7 +7189,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426510+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380647+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7212,7 +7222,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426549+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7277,7 +7287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426590+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380686+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7333,7 +7343,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426637+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7393,16 +7403,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:18.426700+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:34.380735+00:00"
               },
               "deterministic": true
             },
@@ -7415,7 +7430,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775015+00:00"
           },
           "start_time": {
             "type": "string",
@@ -7440,7 +7455,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426748+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380756+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7650,7 +7665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.426836+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7662,7 +7677,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834386+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775061+00:00"
           },
           "type": {
             "$ref": "#/components/schemas/graphHealthscoreType"
@@ -7684,7 +7699,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834423+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775083+00:00"
           }
         },
         "x-f5xc-description-short": "HealthScoreTypeData contains healthscore type and the corresponding value.",
@@ -7925,7 +7940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.426994+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8054,7 +8069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.427064+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380906+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8087,7 +8102,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.427118+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380933+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8120,7 +8135,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:09:18.427169+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380959+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8197,7 +8212,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:18.427230+00:00"
+                "validatedAt": "2026-05-05T18:42:34.380986+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8209,7 +8224,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834618+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775197+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -8227,7 +8242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.427277+00:00"
+                "validatedAt": "2026-05-05T18:42:34.381007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8255,7 +8270,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.427316+00:00"
+                "validatedAt": "2026-05-05T18:42:34.381024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8267,7 +8282,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834665+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775223+00:00"
           }
         },
         "x-f5xc-description-short": "Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -8374,7 +8389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:18.427385+00:00"
+                "validatedAt": "2026-05-05T18:42:34.381049+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8386,7 +8401,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.834713+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.775250+00:00"
           }
         },
         "x-f5xc-description-short": "Each metric value consists of a timestamp and a value. Timestamp in the Metric Value is based on the start_time, end_time and step in the request.",
@@ -8489,7 +8504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.297967+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8523,7 +8538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298033+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8556,7 +8571,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298090+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220811+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8656,23 +8671,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298145+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220836+00:00"
               },
               "deterministic": true
             },
@@ -8685,7 +8700,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.740911+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.841950+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8708,16 +8723,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298184+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220855+00:00"
               },
               "deterministic": true
             },
@@ -8730,7 +8750,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.740943+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.841967+00:00"
           },
           "tcp_lb_request": {
             "$ref": "#/components/schemas/discovered_serviceTCPLBRequest"
@@ -8801,23 +8821,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298229+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220875+00:00"
               },
               "deterministic": true
             },
@@ -8830,7 +8850,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.740993+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.841996+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8853,16 +8873,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298263+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220893+00:00"
               },
               "deterministic": true
             },
@@ -8875,7 +8900,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842012+00:00"
           }
         },
         "x-f5xc-description-short": "Disable visibility on the discovered service.",
@@ -8934,7 +8959,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741049+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842031+00:00"
           },
           "virtual_server_pool_members_health": {
             "$ref": "#/components/schemas/discovered_serviceVirtualServerPoolMemberHealth"
@@ -8982,23 +9007,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298318+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220918+00:00"
               },
               "deterministic": true
             },
@@ -9011,7 +9036,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741086+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842053+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9034,16 +9059,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298369+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.220936+00:00"
               },
               "deterministic": true
             },
@@ -9056,7 +9086,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741112+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842069+00:00"
           }
         },
         "x-f5xc-description-short": "Enable visibility of the discovered service in all workspaces like WAAP, App Connect, etc.",
@@ -9216,7 +9246,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298497+00:00"
+                "validatedAt": "2026-05-05T18:43:16.220995+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9229,7 +9259,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741207+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842125+00:00"
           },
           "http": {
             "$ref": "#/components/schemas/discovered_serviceProxyTypeHttp"
@@ -9262,23 +9292,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298539+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221014+00:00"
               },
               "deterministic": true
             },
@@ -9291,7 +9321,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741259+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842157+00:00"
           },
           "skip_server_verification": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -9352,7 +9382,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298596+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221044+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9386,7 +9416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.298644+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221070+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9419,7 +9449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298696+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9487,7 +9517,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:44.298746+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221116+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9550,7 +9580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:44.298810+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221147+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9562,7 +9592,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741393+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842225+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9612,23 +9642,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298849+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221164+00:00"
               },
               "deterministic": true
             },
@@ -9641,7 +9671,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741455+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842262+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9656,16 +9686,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.298881+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221182+00:00"
               },
               "deterministic": true
             },
@@ -9678,7 +9713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741483+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842278+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -9701,7 +9736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298921+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9714,7 +9749,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741529+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842303+00:00"
           },
           "uid": {
             "type": "string",
@@ -9732,7 +9767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.298951+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9746,7 +9781,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741556+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842320+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered_service is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -9816,7 +9851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:44.299000+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221238+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9880,7 +9915,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:44.299059+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221265+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9892,7 +9927,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741616+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842355+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -9942,23 +9977,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299098+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221282+00:00"
               },
               "deterministic": true
             },
@@ -9971,7 +10006,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741677+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842392+00:00"
           },
           "namespace": {
             "type": "string",
@@ -9986,16 +10021,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299129+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221297+00:00"
               },
               "deterministic": true
             },
@@ -10008,7 +10048,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741704+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842408+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -10047,7 +10087,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.299182+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10060,7 +10100,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741759+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842439+00:00"
           },
           "uid": {
             "type": "string",
@@ -10078,7 +10118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.299214+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10092,7 +10132,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741789+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842455+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of discovered services is returned in 'List'.",
@@ -10154,7 +10194,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299284+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221372+00:00"
               },
               "deterministic": true
             },
@@ -10196,7 +10236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299376+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10222,7 +10262,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.299429+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10266,7 +10306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299474+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221453+00:00"
               },
               "deterministic": true
             },
@@ -10307,7 +10347,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299552+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10404,7 +10444,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299612+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10507,7 +10547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299707+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221567+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10541,7 +10581,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299785+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10565,16 +10605,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299821+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221630+00:00"
               },
               "deterministic": true
             },
@@ -10587,7 +10632,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.741979+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842564+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -10651,7 +10696,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.299891+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10664,7 +10709,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842596+00:00"
           },
           "listen_port": {
             "type": "integer",
@@ -10713,23 +10758,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.299948+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221692+00:00"
               },
               "deterministic": true
             },
@@ -10742,7 +10787,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742069+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842624+00:00"
           },
           "no_sni": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -10779,7 +10824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300026+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221732+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10871,7 +10916,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300102+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10905,7 +10950,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300178+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221807+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10949,7 +10994,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300250+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221842+00:00"
               },
               "deterministic": true
             },
@@ -10984,7 +11029,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300328+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221878+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11022,7 +11067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300365+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221895+00:00"
               },
               "deterministic": true
             },
@@ -11054,7 +11099,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300436+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221931+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11088,7 +11133,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300506+00:00"
+                "validatedAt": "2026-05-05T18:43:16.221965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11165,23 +11210,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.300541+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.221981+00:00"
               },
               "deterministic": true
             },
@@ -11194,7 +11239,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742219+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842715+00:00"
           },
           "status": {
             "type": "array",
@@ -11214,7 +11259,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742245+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842731+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -11316,7 +11361,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300602+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11341,7 +11386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300643+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222026+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11404,7 +11449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.300680+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222044+00:00"
               },
               "deterministic": true
             },
@@ -11438,7 +11483,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300723+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222064+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11532,7 +11577,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300779+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11545,7 +11590,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742344+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842786+00:00"
           },
           "name": {
             "type": "string",
@@ -11562,23 +11607,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.300814+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222105+00:00"
               },
               "deterministic": true
             },
@@ -11591,7 +11636,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842802+00:00"
           },
           "namespace": {
             "type": "string",
@@ -11608,16 +11653,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.300847+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222121+00:00"
               },
               "deterministic": true
             },
@@ -11630,7 +11680,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742396+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842818+00:00"
           },
           "tenant": {
             "type": "string",
@@ -11649,7 +11699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300887+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11663,7 +11713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742421+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842834+00:00"
           },
           "uid": {
             "type": "string",
@@ -11682,7 +11732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300917+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11697,7 +11747,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742449+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842850+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -11735,7 +11785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.300961+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222175+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11758,7 +11808,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301000+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11770,7 +11820,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742491+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842873+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -11816,7 +11866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.301038+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222212+00:00"
               },
               "deterministic": true
             },
@@ -11842,7 +11892,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301087+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11869,7 +11919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301125+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11881,7 +11931,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742539+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842900+00:00"
           },
           "service_name": {
             "type": "string",
@@ -11898,7 +11948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301170+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222273+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11931,7 +11981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301211+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222292+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11943,7 +11993,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742576+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842921+00:00"
           },
           "type": {
             "type": "string",
@@ -11968,7 +12018,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301249+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12056,7 +12106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301290+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222329+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12102,23 +12152,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.301334+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222345+00:00"
               },
               "deterministic": true
             },
@@ -12131,7 +12181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742640+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842960+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -12229,7 +12279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301402+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222374+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12241,7 +12291,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742708+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.842998+00:00"
           }
         },
         "x-f5xc-description-short": "Metric data contains timestamp and the value.",
@@ -12320,7 +12370,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.301494+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222418+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -12336,7 +12386,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742747+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843021+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -12392,23 +12442,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.301533+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222438+00:00"
               },
               "deterministic": true
             },
@@ -12421,7 +12471,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742794+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843048+00:00"
           },
           "namespace": {
             "type": "string",
@@ -12438,16 +12488,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.301565+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222453+00:00"
               },
               "deterministic": true
             },
@@ -12460,7 +12515,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742820+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843064+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -12505,7 +12560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301616+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222476+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12533,7 +12588,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301663+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12561,7 +12616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301707+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12590,7 +12645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301750+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12617,7 +12672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301779+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12631,7 +12686,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843106+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -12647,7 +12702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301819+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12756,7 +12811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301871+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222594+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12768,7 +12823,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742948+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843140+00:00"
           },
           "status": {
             "type": "string",
@@ -12786,7 +12841,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301910+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12798,7 +12853,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.742977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843156+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -12840,7 +12895,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.301962+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12867,7 +12922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302009+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222665+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12894,7 +12949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302056+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222685+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12922,7 +12977,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302104+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12987,7 +13042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302173+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13036,7 +13091,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302226+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222762+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13049,7 +13104,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843227+00:00"
           },
           "uid": {
             "type": "string",
@@ -13068,7 +13123,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302255+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222776+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13082,7 +13137,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743122+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843244+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -13132,7 +13187,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302443+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222858+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13144,7 +13199,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743221+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843304+00:00"
           },
           "name": {
             "type": "string",
@@ -13161,23 +13216,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.302475+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222874+00:00"
               },
               "deterministic": true
             },
@@ -13190,7 +13245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743247+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843320+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13207,16 +13262,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:10:44.302506+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:43:16.222890+00:00"
               },
               "deterministic": true
             },
@@ -13229,7 +13289,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743272+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843336+00:00"
           },
           "uid": {
             "type": "string",
@@ -13246,7 +13306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302535+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222903+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13260,7 +13320,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743298+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843352+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -13385,7 +13445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:10:44.302607+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13434,7 +13494,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:10:44.302662+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13446,7 +13506,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743425+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843424+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -13464,7 +13524,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:10:44.302706+00:00"
+                "validatedAt": "2026-05-05T18:43:16.222981+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13526,7 +13586,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302763+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223009+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13584,7 +13644,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302819+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13642,23 +13702,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302891+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223072+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13674,7 +13734,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743494+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843464+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13697,16 +13757,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.302951+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223103+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13722,7 +13787,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743520+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843480+00:00"
           },
           "tenant": {
             "type": "string",
@@ -13751,7 +13816,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303017+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13765,7 +13830,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:12.743545+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:04.843496+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -13816,7 +13881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303072+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223164+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13920,7 +13985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303134+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223198+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14060,7 +14125,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303173+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223217+00:00"
               },
               "deterministic": true
             },
@@ -14107,7 +14172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303251+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223255+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14230,7 +14295,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303342+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223294+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14265,7 +14330,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303413+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223330+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14330,7 +14395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:10:44.303466+00:00"
+                "validatedAt": "2026-05-05T18:43:16.223359+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14384,7 +14449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313120+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326055+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14411,7 +14476,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313199+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326090+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14456,7 +14521,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313271+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326120+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14483,7 +14548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313318+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326143+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14524,7 +14589,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313382+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326167+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14549,7 +14614,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313439+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14641,7 +14706,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:14.027605+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:05.559886+00:00"
           }
         },
         "x-f5xc-description-short": "Field Data contains key/value pairs that uniquely identifies the group_by labels specified in the request.",
@@ -14894,7 +14959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313560+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14922,7 +14987,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313613+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14972,7 +15037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313679+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15003,7 +15068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313733+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15062,7 +15127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.313787+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15106,7 +15171,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.313855+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326385+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15140,7 +15205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.313930+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326421+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15176,7 +15241,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.313984+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326450+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15211,7 +15276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:54.314031+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15261,7 +15326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314093+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326501+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15354,7 +15419,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314158+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326529+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15398,7 +15463,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:11:54.314224+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15425,7 +15490,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314264+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326579+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15476,7 +15541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:11:54.314331+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326604+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15526,7 +15591,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:11:54.314392+00:00"
+                "validatedAt": "2026-05-05T18:43:52.326639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15790,7 +15855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643072+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15841,7 +15906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643149+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284127+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15936,7 +16001,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643256+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284173+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -15978,7 +16043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643315+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284201+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16024,7 +16089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643386+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284228+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16087,7 +16152,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643462+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16128,7 +16193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643511+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284284+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16168,7 +16233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643564+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284309+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16249,7 +16314,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643656+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16401,7 +16466,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643768+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -16753,7 +16818,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.643914+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17171,7 +17236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.644253+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284624+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17222,7 +17287,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.644317+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17300,7 +17365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644371+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284678+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17325,7 +17390,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644413+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17349,16 +17414,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.644450+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.284716+00:00"
               },
               "deterministic": true
             },
@@ -17371,7 +17441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163351+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623314+00:00"
           },
           "service": {
             "type": "string",
@@ -17389,7 +17459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644492+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17415,7 +17485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644527+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284752+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17440,7 +17510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644573+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284773+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17527,7 +17597,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644622+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284795+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17560,7 +17630,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644668+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17593,7 +17663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644733+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17619,7 +17689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644769+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17652,7 +17722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.644818+00:00"
+                "validatedAt": "2026-05-05T18:46:57.284877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -17773,16 +17843,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.645070+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.284994+00:00"
               },
               "deterministic": true
             },
@@ -17795,7 +17870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163586+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623451+00:00"
           }
         },
         "x-f5xc-description-short": "List of application types for a namespace.",
@@ -17921,7 +17996,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163661+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623496+00:00"
           }
         },
         "x-f5xc-description-short": "CdnMetricData contains the metric type and the corresponding metric value(s).",
@@ -18128,7 +18203,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645181+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285041+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18155,16 +18230,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.645227+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285057+00:00"
               },
               "deterministic": true
             },
@@ -18177,7 +18257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163810+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623587+00:00"
           },
           "range": {
             "type": "string",
@@ -18202,7 +18282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645271+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285075+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18238,7 +18318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645332+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18271,7 +18351,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645380+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18336,7 +18416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645438+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18470,7 +18550,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645557+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285165+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18496,7 +18576,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645603+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18520,16 +18600,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.645658+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285202+00:00"
               },
               "deterministic": true
             },
@@ -18542,7 +18627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.163949+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623680+00:00"
           },
           "service": {
             "type": "string",
@@ -18560,7 +18645,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645724+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285220+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18586,7 +18671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645781+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285236+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18611,7 +18696,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645841+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18637,7 +18722,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645871+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18662,7 +18747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645921+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285289+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18781,7 +18866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.645972+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18811,16 +18896,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646007+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285329+00:00"
               },
               "deterministic": true
             },
@@ -18833,7 +18923,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164064+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623750+00:00"
           },
           "range": {
             "type": "string",
@@ -18858,7 +18948,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646047+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18891,7 +18981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646095+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285368+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18924,7 +19014,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646132+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285387+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -18987,7 +19077,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646172+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19079,7 +19169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646234+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19140,16 +19230,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646297+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.285460+00:00"
               },
               "deterministic": true
             },
@@ -19162,7 +19257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623820+00:00"
           },
           "range": {
             "type": "string",
@@ -19187,7 +19282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646352+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19220,7 +19315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646399+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285500+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19253,7 +19348,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646435+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285517+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19317,7 +19412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646475+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19373,7 +19468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646520+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19434,7 +19529,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.646600+00:00"
+                "validatedAt": "2026-05-05T18:46:57.285595+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19479,7 +19574,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:09.646662+00:00"
+                "validatedAt": "2026-05-05T18:46:57.286977+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19503,16 +19598,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646694+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.287003+00:00"
               },
               "deterministic": true
             },
@@ -19525,7 +19625,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164291+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623884+00:00"
           },
           "start_time": {
             "type": "string",
@@ -19550,7 +19650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646742+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287029+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19583,7 +19683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646780+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287048+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19659,7 +19759,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646829+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287074+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19712,7 +19812,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646869+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19724,7 +19824,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.623933+00:00"
           }
         },
         "x-f5xc-description-short": "Metrics used to render the service graph are tagged with labels listed in the enum Label.",
@@ -19858,7 +19958,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646920+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19888,16 +19988,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.646954+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.287137+00:00"
               },
               "deterministic": true
             },
@@ -19910,7 +20015,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164491+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.624003+00:00"
           },
           "range": {
             "type": "string",
@@ -19935,7 +20040,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.646993+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -19968,7 +20073,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647039+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287177+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20001,7 +20106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647075+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20065,7 +20170,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647114+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20121,7 +20226,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647159+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20198,16 +20303,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:09.647220+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:57.287264+00:00"
               },
               "deterministic": true
             },
@@ -20220,7 +20330,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.164606+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:10.624073+00:00"
           },
           "range": {
             "type": "string",
@@ -20245,7 +20355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647259+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20278,7 +20388,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647304+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20311,7 +20421,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647351+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287322+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20376,7 +20486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647390+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287341+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20425,7 +20535,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647432+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287360+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20458,7 +20568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647478+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287381+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20485,7 +20595,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647513+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287398+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20510,7 +20620,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647541+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287411+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20543,7 +20653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:09.647590+00:00"
+                "validatedAt": "2026-05-05T18:46:57.287433+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20594,7 +20704,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:39.736867+00:00"
+                "validatedAt": "2026-05-05T18:47:13.463955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -20612,29 +20722,29 @@
             "x-ves-example": "API1:2023",
             "x-f5xc-example": "API1:2023",
             "x-f5xc-description-short": "The name of the OWASP API security category.",
-            "maxLength": 16,
+            "maxLength": 1024,
             "x-f5xc-constraints": {
               "constraintType": "string",
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:39.736906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:47:13.463973+00:00"
               },
               "deterministic": true
             },
@@ -20643,11 +20753,7 @@
               "create": false,
               "update": false,
               "read": false
-            },
-            "x-original-maxLength": 1024,
-            "minLength": 6,
-            "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:21.970298+00:00"
+            }
           }
         },
         "x-f5xc-description-short": "Represents a category of vulnerability as defined in the OWASP API Top 10.",

--- a/docs/specifications/api/tenant_and_identity.json
+++ b/docs/specifications/api/tenant_and_identity.json
@@ -48977,23 +48977,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.711643+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212077+00:00"
               },
               "deterministic": true
             },
@@ -49006,7 +49006,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937240+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888586+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49022,16 +49022,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.711689+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212104+00:00"
               },
               "deterministic": true
             },
@@ -49044,7 +49049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937270+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888602+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -49132,7 +49137,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.711768+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49231,7 +49236,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.711834+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212174+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49266,7 +49271,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.711920+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49381,7 +49386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.711968+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49394,7 +49399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937394+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888682+00:00"
           },
           "name": {
             "type": "string",
@@ -49411,23 +49416,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712008+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212252+00:00"
               },
               "deterministic": true
             },
@@ -49440,7 +49445,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937423+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888699+00:00"
           },
           "namespace": {
             "type": "string",
@@ -49457,16 +49462,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712042+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212270+00:00"
               },
               "deterministic": true
             },
@@ -49479,7 +49489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937449+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888714+00:00"
           },
           "tenant": {
             "type": "string",
@@ -49498,7 +49508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712082+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212288+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49512,7 +49522,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937475+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888730+00:00"
           },
           "uid": {
             "type": "string",
@@ -49531,7 +49541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712114+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49546,7 +49556,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937505+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888746+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -49584,7 +49594,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712160+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49607,7 +49617,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712201+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49619,7 +49629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937543+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888769+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -49665,7 +49675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712243+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212364+00:00"
               },
               "deterministic": true
             },
@@ -49691,7 +49701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712294+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49717,7 +49727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712362+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49729,7 +49739,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937590+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888796+00:00"
           },
           "service_name": {
             "type": "string",
@@ -49746,7 +49756,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712413+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49779,7 +49789,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712460+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49791,7 +49801,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937625+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888817+00:00"
           },
           "type": {
             "type": "string",
@@ -49816,7 +49826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712501+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49904,7 +49914,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.712546+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -49950,23 +49960,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712586+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212502+00:00"
               },
               "deterministic": true
             },
@@ -49979,7 +49989,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937689+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888858+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -50097,7 +50107,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.712699+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212556+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50113,7 +50123,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937747+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888893+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50167,23 +50177,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712743+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212576+00:00"
               },
               "deterministic": true
             },
@@ -50196,7 +50206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937792+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888919+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50213,16 +50223,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712776+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212591+00:00"
               },
               "deterministic": true
             },
@@ -50235,7 +50250,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937817+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888935+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -50317,7 +50332,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.712868+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212644+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50333,7 +50348,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937857+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888958+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50389,23 +50404,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712911+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212664+00:00"
               },
               "deterministic": true
             },
@@ -50418,7 +50433,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937906+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.888985+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50435,16 +50450,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.712944+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212680+00:00"
               },
               "deterministic": true
             },
@@ -50457,7 +50477,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937933+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889000+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -50539,7 +50559,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.713040+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212723+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -50555,7 +50575,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.937972+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889023+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -50609,23 +50629,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.713081+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212742+00:00"
               },
               "deterministic": true
             },
@@ -50638,7 +50658,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938017+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889050+00:00"
           },
           "namespace": {
             "type": "string",
@@ -50655,16 +50675,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.713114+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.212758+00:00"
               },
               "deterministic": true
             },
@@ -50677,7 +50702,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938043+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889065+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -50722,7 +50747,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713170+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50750,7 +50775,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713218+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50778,7 +50803,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713264+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50807,7 +50832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713310+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212843+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50834,7 +50859,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713353+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50848,7 +50873,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938120+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889108+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -50864,7 +50889,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713395+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212877+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50973,7 +50998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713454+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212902+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -50985,7 +51010,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938179+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889140+00:00"
           },
           "status": {
             "type": "string",
@@ -51003,7 +51028,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713496+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212920+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51015,7 +51040,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938208+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889156+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -51057,7 +51082,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713549+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212944+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51084,7 +51109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713596+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212965+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51111,7 +51136,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713641+00:00"
+                "validatedAt": "2026-05-05T18:40:10.212985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51139,7 +51164,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713692+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213007+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51204,7 +51229,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713766+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213042+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51253,7 +51278,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713822+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213066+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51266,7 +51291,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938336+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889225+00:00"
           },
           "uid": {
             "type": "string",
@@ -51285,7 +51310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713851+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51299,7 +51324,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938367+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889241+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -51349,7 +51374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713888+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213096+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51361,7 +51386,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938397+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889258+00:00"
           },
           "name": {
             "type": "string",
@@ -51378,23 +51403,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.713922+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.213112+00:00"
               },
               "deterministic": true
             },
@@ -51407,7 +51432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938425+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889273+00:00"
           },
           "namespace": {
             "type": "string",
@@ -51424,16 +51449,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.713955+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.213128+00:00"
               },
               "deterministic": true
             },
@@ -51446,7 +51476,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938453+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889289+00:00"
           },
           "uid": {
             "type": "string",
@@ -51463,7 +51493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.713985+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213141+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51477,7 +51507,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938482+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889305+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -51530,23 +51560,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714056+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213176+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -51562,7 +51592,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938512+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889321+00:00"
           },
           "namespace": {
             "type": "string",
@@ -51585,16 +51615,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714119+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213208+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -51610,7 +51645,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938539+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889337+00:00"
           },
           "tenant": {
             "type": "string",
@@ -51639,7 +51674,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714188+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213242+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51653,7 +51688,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938565+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889353+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -51789,7 +51824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714255+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213276+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51824,7 +51859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714341+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213312+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -51937,7 +51972,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938719+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889447+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -51999,7 +52034,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714463+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213369+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52037,7 +52072,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:34.714534+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52106,7 +52141,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:04:34.714588+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213429+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52169,7 +52204,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:34.714647+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52181,7 +52216,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938818+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889503+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -52231,23 +52266,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.714684+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.213476+00:00"
               },
               "deterministic": true
             },
@@ -52260,7 +52295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938877+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889540+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52275,16 +52310,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:34.714717+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:10.213492+00:00"
               },
               "deterministic": true
             },
@@ -52297,7 +52337,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938904+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889555+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -52336,7 +52376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.714771+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52349,7 +52389,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938954+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889586+00:00"
           },
           "uid": {
             "type": "string",
@@ -52366,7 +52406,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:34.714800+00:00"
+                "validatedAt": "2026-05-05T18:40:10.213530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52380,7 +52420,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:03.938982+00:00"
+            "x-reconciled-at": "2026-05-05T18:46:59.889602+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of allowed_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -52682,23 +52722,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:00.053224+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:22.706376+00:00"
               },
               "deterministic": true
             },
@@ -52711,7 +52751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658560+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.303835+00:00"
           },
           "namespace": {
             "type": "string",
@@ -52727,16 +52767,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:00.053265+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:22.706397+00:00"
               },
               "deterministic": true
             },
@@ -52749,7 +52794,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658589+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.303852+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -52852,7 +52897,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658679+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.303905+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -52938,7 +52983,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.053415+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706456+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -52975,7 +53020,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.053473+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53061,7 +53106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:00.053529+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53124,7 +53169,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:00.053597+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706544+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53136,7 +53181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658803+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.303978+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -53186,23 +53231,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:00.053640+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:22.706563+00:00"
               },
               "deterministic": true
             },
@@ -53215,7 +53260,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658865+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.304015+00:00"
           },
           "namespace": {
             "type": "string",
@@ -53230,16 +53275,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:00.053674+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:22.706580+00:00"
               },
               "deterministic": true
             },
@@ -53252,7 +53302,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658892+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.304031+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -53291,7 +53341,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.053731+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53304,7 +53354,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658944+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.304061+00:00"
           },
           "uid": {
             "type": "string",
@@ -53321,7 +53371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.053763+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706628+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53335,7 +53385,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.658972+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.304078+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of authentication is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -53403,7 +53453,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.053861+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53446,7 +53496,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.053948+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53489,7 +53539,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.054034+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706808+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53557,7 +53607,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.054119+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53599,7 +53649,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.054205+00:00"
+                "validatedAt": "2026-05-05T18:40:22.706898+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53777,7 +53827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.054572+00:00"
+                "validatedAt": "2026-05-05T18:40:22.707072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53815,7 +53865,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.054645+00:00"
+                "validatedAt": "2026-05-05T18:40:22.707108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53827,7 +53877,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.659316+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.304292+00:00"
           },
           "store_provider": {
             "type": "string",
@@ -53846,7 +53896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.054696+00:00"
+                "validatedAt": "2026-05-05T18:40:22.707131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53897,7 +53947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:00.054739+00:00"
+                "validatedAt": "2026-05-05T18:40:22.707154+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -53909,7 +53959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.659368+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.304314+00:00"
           },
           "url": {
             "type": "string",
@@ -53947,7 +53997,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:00.054810+00:00"
+                "validatedAt": "2026-05-05T18:40:22.707195+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -54115,7 +54165,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:03.819235+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643521+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54173,23 +54223,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.819314+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.643550+00:00"
               },
               "deterministic": true
             },
@@ -54202,7 +54252,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708093+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.330863+00:00"
           },
           "namespace": {
             "type": "string",
@@ -54218,16 +54268,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.819364+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.643567+00:00"
               },
               "deterministic": true
             },
@@ -54240,7 +54295,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708124+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.330880+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -54343,7 +54398,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708213+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.330933+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -54403,7 +54458,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:03.819512+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54433,7 +54488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:03.819568+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643668+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54501,7 +54556,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:05:03.819624+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643694+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54564,7 +54619,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:05:03.819690+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54576,7 +54631,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708329+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.330990+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -54626,23 +54681,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.819731+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.643742+00:00"
               },
               "deterministic": true
             },
@@ -54655,7 +54710,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708395+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331028+00:00"
           },
           "namespace": {
             "type": "string",
@@ -54670,16 +54725,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.819766+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.643758+00:00"
               },
               "deterministic": true
             },
@@ -54692,7 +54752,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708420+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331044+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -54731,7 +54791,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:03.819821+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54744,7 +54804,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708472+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331075+00:00"
           },
           "uid": {
             "type": "string",
@@ -54762,7 +54822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:03.819854+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643799+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -54776,7 +54836,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708502+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331092+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of authorization_server is returned in 'List'.",
@@ -54879,7 +54939,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:05:03.819930+00:00"
+                "validatedAt": "2026-05-05T18:40:24.643838+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55006,23 +55066,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.819996+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.643867+00:00"
               },
               "deterministic": true
             },
@@ -55035,7 +55095,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708591+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331147+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55050,16 +55110,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.820029+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.643884+00:00"
               },
               "deterministic": true
             },
@@ -55072,7 +55137,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.708616+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331163+00:00"
           }
         },
         "x-f5xc-description-short": "Request message for UpdateAuthorizationServer API.",
@@ -55130,7 +55195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:03.820856+00:00"
+                "validatedAt": "2026-05-05T18:40:24.644263+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55143,7 +55208,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.709081+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331434+00:00"
           },
           "name": {
             "type": "string",
@@ -55160,23 +55225,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.820889+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.644279+00:00"
               },
               "deterministic": true
             },
@@ -55189,7 +55254,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.709106+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331450+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55206,16 +55271,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:05:03.820921+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:24.644294+00:00"
               },
               "deterministic": true
             },
@@ -55228,7 +55298,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.709133+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331466+00:00"
           },
           "tenant": {
             "type": "string",
@@ -55247,7 +55317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:03.820961+00:00"
+                "validatedAt": "2026-05-05T18:40:24.644313+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55261,7 +55331,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.709159+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331482+00:00"
           },
           "uid": {
             "type": "string",
@@ -55280,7 +55350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:05:03.820992+00:00"
+                "validatedAt": "2026-05-05T18:40:24.644327+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55295,7 +55365,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.709187+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.331498+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -55346,7 +55416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.074655+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55386,7 +55456,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.074749+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363327+00:00"
               },
               "deterministic": true
             },
@@ -55419,7 +55489,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.074826+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55451,7 +55521,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.074900+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55512,23 +55582,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.074945+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.363420+00:00"
               },
               "deterministic": true
             },
@@ -55541,7 +55611,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.867186+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.542226+00:00"
           },
           "namespace": {
             "type": "string",
@@ -55557,16 +55627,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.074983+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.363438+00:00"
               },
               "deterministic": true
             },
@@ -55579,7 +55654,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.867217+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.542243+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -55634,7 +55709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075046+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363466+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55735,7 +55810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075134+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55897,7 +55972,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075230+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55923,7 +55998,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075279+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55949,7 +56024,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075334+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363588+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -55975,7 +56050,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075372+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56109,7 +56184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075453+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363655+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56134,7 +56209,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075499+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363676+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56167,7 +56242,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.075552+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363704+00:00"
               },
               "deterministic": true
             },
@@ -56194,7 +56269,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075590+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56219,7 +56294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.075634+00:00"
+                "validatedAt": "2026-05-05T18:41:22.363741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56568,7 +56643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077632+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56593,7 +56668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077672+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364695+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56618,7 +56693,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077708+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364712+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56646,7 +56721,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077750+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364735+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56671,7 +56746,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077789+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56697,7 +56772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077835+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56722,7 +56797,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077872+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56747,7 +56822,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077914+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364819+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56772,7 +56847,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.077955+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364839+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56886,7 +56961,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078002+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56932,7 +57007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:52.078071+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -56944,7 +57019,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.868781+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543143+00:00"
           },
           "ongoing": {
             "type": "boolean",
@@ -56977,7 +57052,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078120+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57022,7 +57097,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078173+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364941+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57047,7 +57122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078213+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364960+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57075,7 +57150,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078252+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57164,7 +57239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078299+00:00"
+                "validatedAt": "2026-05-05T18:41:22.364999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57192,7 +57267,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078348+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57241,7 +57316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.078416+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365048+00:00"
               },
               "deterministic": true
             },
@@ -57290,7 +57365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:52.078483+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57302,7 +57377,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.868946+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543240+00:00"
           },
           "escalated": {
             "type": "boolean",
@@ -57365,7 +57440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078548+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365107+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57410,7 +57485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078600+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57439,7 +57514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:06:52.078637+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365149+00:00"
               },
               "deterministic": true
             },
@@ -57465,7 +57540,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078677+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365168+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57493,7 +57568,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078714+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365185+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57523,7 +57598,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078756+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57639,7 +57714,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:52.078827+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57651,7 +57726,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869127+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543349+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -57701,23 +57776,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.078867+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.365256+00:00"
               },
               "deterministic": true
             },
@@ -57730,7 +57805,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869191+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543385+00:00"
           },
           "namespace": {
             "type": "string",
@@ -57745,16 +57820,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.078898+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.365272+00:00"
               },
               "deterministic": true
             },
@@ -57767,7 +57847,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869219+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543401+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -57806,7 +57886,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078950+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365295+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57819,7 +57899,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869274+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543432+00:00"
           },
           "uid": {
             "type": "string",
@@ -57837,7 +57917,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.078979+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365308+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -57851,7 +57931,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869300+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543448+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of customer_support is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -57979,7 +58059,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:52.079070+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58005,7 +58085,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.079105+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365366+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58058,7 +58138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.079143+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365384+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58125,23 +58205,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.079405+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.365509+00:00"
               },
               "deterministic": true
             },
@@ -58154,7 +58234,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869508+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543567+00:00"
           },
           "support_request_count": {
             "$ref": "#/components/schemas/tenant_managementSupportTicketInfo"
@@ -58240,7 +58320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.079479+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58284,7 +58364,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.079541+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58418,7 +58498,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.079619+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365612+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58485,7 +58565,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:52.079666+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58558,7 +58638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.079706+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365660+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58694,7 +58774,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.079789+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365698+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58744,7 +58824,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.079861+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -58755,7 +58835,7 @@
             },
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869765+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543724+00:00"
           },
           "tenant_profile": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -58896,7 +58976,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869861+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543782+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -58953,7 +59033,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.079994+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59006,7 +59086,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.080064+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365835+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59017,7 +59097,7 @@
             },
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.869940+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543828+00:00"
           },
           "status": {
             "$ref": "#/components/schemas/tenant_managementchild_tenantFSMState"
@@ -59088,7 +59168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:52.080113+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365857+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59151,7 +59231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:52.080174+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365883+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59163,7 +59243,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.870014+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543872+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -59213,23 +59293,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.080212+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.365901+00:00"
               },
               "deterministic": true
             },
@@ -59242,7 +59322,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.870077+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543909+00:00"
           },
           "namespace": {
             "type": "string",
@@ -59257,16 +59337,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:52.080245+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:22.365917+00:00"
               },
               "deterministic": true
             },
@@ -59279,7 +59364,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.870103+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543924+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -59318,7 +59403,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.080299+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365940+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59331,7 +59416,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.870153+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543955+00:00"
           },
           "uid": {
             "type": "string",
@@ -59348,7 +59433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:52.080342+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365953+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59362,7 +59447,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.870180+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.543971+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of child_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -59419,7 +59504,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.080421+00:00"
+                "validatedAt": "2026-05-05T18:41:22.365991+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59540,7 +59625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.080516+00:00"
+                "validatedAt": "2026-05-05T18:41:22.366036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59573,23 +59658,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:52.080580+00:00"
+                "validatedAt": "2026-05-05T18:41:22.366069+00:00"
               },
               "deterministic": true
             },
@@ -59601,7 +59686,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:06.870268+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.544025+00:00"
           }
         },
         "x-f5xc-description-short": "LinkRefType This message defines a reference to hyperlink that can be accessed via web.",
@@ -59638,7 +59723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.469795+00:00"
+                "validatedAt": "2026-05-05T18:41:24.464908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59664,7 +59749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.469847+00:00"
+                "validatedAt": "2026-05-05T18:41:24.464930+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59702,7 +59787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.469893+00:00"
+                "validatedAt": "2026-05-05T18:41:24.464950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59714,7 +59799,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001281+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614056+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -59774,7 +59859,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:56.469968+00:00"
+                "validatedAt": "2026-05-05T18:41:24.464985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59841,7 +59926,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:56.470038+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -59853,7 +59938,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001360+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614093+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -59903,23 +59988,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.470083+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.465037+00:00"
               },
               "deterministic": true
             },
@@ -59932,7 +60017,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001427+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614129+00:00"
           },
           "namespace": {
             "type": "string",
@@ -59947,16 +60032,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.470118+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.465054+00:00"
               },
               "deterministic": true
             },
@@ -59969,7 +60059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001454+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614145+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -60008,7 +60098,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.470177+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465079+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60021,7 +60111,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001506+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614175+00:00"
           },
           "uid": {
             "type": "string",
@@ -60038,7 +60128,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.470209+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60052,7 +60142,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001534+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614192+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60113,23 +60203,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.470248+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.465111+00:00"
               },
               "deterministic": true
             },
@@ -60142,7 +60232,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001573+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614213+00:00"
           },
           "namespace": {
             "type": "string",
@@ -60158,16 +60248,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.470282+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.465127+00:00"
               },
               "deterministic": true
             },
@@ -60180,7 +60275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001601+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614229+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -60239,7 +60334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:56.470353+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60296,23 +60391,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.470394+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.465168+00:00"
               },
               "deterministic": true
             },
@@ -60325,7 +60420,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.001660+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.614262+00:00"
           }
         },
         "x-f5xc-description-short": "Request to migrate child tenants to a specified child tenant manager.",
@@ -60363,7 +60458,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.470450+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60504,7 +60599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.471080+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60536,7 +60631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.471129+00:00"
+                "validatedAt": "2026-05-05T18:41:24.465491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60651,7 +60746,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:56.473575+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60808,7 +60903,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:56.473690+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60879,7 +60974,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:06:56.473739+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60942,7 +61037,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:06:56.473798+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488623+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -60954,7 +61049,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.003394+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.615271+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -61004,23 +61099,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.473837+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.488663+00:00"
               },
               "deterministic": true
             },
@@ -61033,7 +61128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.003454+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.615307+00:00"
           },
           "namespace": {
             "type": "string",
@@ -61048,16 +61143,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:06:56.473872+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:41:24.488691+00:00"
               },
               "deterministic": true
             },
@@ -61070,7 +61170,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.003479+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.615323+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -61093,7 +61193,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.473913+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488715+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61106,7 +61206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.003522+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.615349+00:00"
           },
           "uid": {
             "type": "string",
@@ -61124,7 +61224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:06:56.473945+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488730+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61138,7 +61238,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:07.003548+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:01.615365+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of child_tenant_manager is returned in 'List'.",
@@ -61204,7 +61304,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:06:56.474008+00:00"
+                "validatedAt": "2026-05-05T18:41:24.488770+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61249,7 +61349,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:05.892483+00:00"
+                "validatedAt": "2026-05-05T18:41:28.925465+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61274,7 +61374,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:05.892545+00:00"
+                "validatedAt": "2026-05-05T18:41:28.925489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61344,7 +61444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:07:51.178598+00:00"
+                "validatedAt": "2026-05-05T18:41:51.622754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61462,7 +61562,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699429+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362339+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61486,7 +61586,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699498+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61510,7 +61610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699538+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362386+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61537,7 +61637,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699582+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362405+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61561,7 +61661,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699622+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362424+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61586,7 +61686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699674+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61610,7 +61710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699712+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61634,7 +61734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699756+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362487+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61658,7 +61758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699800+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362507+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61725,23 +61825,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:22.699852+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:36.362531+00:00"
               },
               "deterministic": true
             },
@@ -61754,7 +61854,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.902912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815347+00:00"
           },
           "namespace": {
             "type": "string",
@@ -61770,16 +61870,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:22.699888+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:36.362549+00:00"
               },
               "deterministic": true
             },
@@ -61792,7 +61897,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.902941+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815364+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -61895,7 +62000,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.903031+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815416+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -61942,7 +62047,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.699999+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61966,7 +62071,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700042+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -61990,7 +62095,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700078+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62017,7 +62122,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700120+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62041,7 +62146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700163+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362683+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62066,7 +62171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700211+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62090,7 +62195,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700250+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362723+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62114,7 +62219,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700294+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62138,7 +62243,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700347+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62213,7 +62318,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:09:22.700402+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62275,7 +62380,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:09:22.700471+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362820+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62287,7 +62392,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.903192+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815515+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -62337,23 +62442,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:22.700513+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:36.362840+00:00"
               },
               "deterministic": true
             },
@@ -62366,7 +62471,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.903254+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815560+00:00"
           },
           "namespace": {
             "type": "string",
@@ -62381,16 +62486,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:09:22.700545+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:42:36.362857+00:00"
               },
               "deterministic": true
             },
@@ -62403,7 +62513,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.903280+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815580+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -62442,7 +62552,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700600+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62455,7 +62565,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.903343+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815627+00:00"
           },
           "uid": {
             "type": "string",
@@ -62472,7 +62582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700632+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362897+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62486,7 +62596,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:10.903370+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:03.815648+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of contact is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -62576,7 +62686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700680+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362917+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62600,7 +62710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700723+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362937+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62624,7 +62734,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700759+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362955+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62651,7 +62761,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700800+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62675,7 +62785,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700839+00:00"
+                "validatedAt": "2026-05-05T18:42:36.362992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62700,7 +62810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700890+00:00"
+                "validatedAt": "2026-05-05T18:42:36.363014+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62724,7 +62834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700928+00:00"
+                "validatedAt": "2026-05-05T18:42:36.363031+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62748,7 +62858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.700973+00:00"
+                "validatedAt": "2026-05-05T18:42:36.363053+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62772,7 +62882,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:09:22.701015+00:00"
+                "validatedAt": "2026-05-05T18:42:36.363072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -62895,23 +63005,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:25.647935+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:04.939993+00:00"
               },
               "deterministic": true
             },
@@ -62924,7 +63034,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.852816+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.067537+00:00"
           },
           "namespace": {
             "type": "string",
@@ -62940,16 +63050,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:25.647967+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:04.940010+00:00"
               },
               "deterministic": true
             },
@@ -62962,7 +63077,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.852841+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.067554+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -63017,7 +63132,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:25.648027+00:00"
+                "validatedAt": "2026-05-05T18:45:04.940036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63113,7 +63228,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:25.648117+00:00"
+                "validatedAt": "2026-05-05T18:45:04.940077+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63138,7 +63253,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:25.648160+00:00"
+                "validatedAt": "2026-05-05T18:45:04.940097+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63249,23 +63364,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:25.648240+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:04.940133+00:00"
               },
               "deterministic": true
             },
@@ -63278,7 +63393,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.852977+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.067645+00:00"
           },
           "tenant_status": {
             "$ref": "#/components/schemas/tenant_managementTenantStatus"
@@ -63432,7 +63547,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:25.651773+00:00"
+                "validatedAt": "2026-05-05T18:45:04.941766+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63465,7 +63580,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:25.651844+00:00"
+                "validatedAt": "2026-05-05T18:45:04.941803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63578,7 +63693,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.855066+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.068919+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -63641,7 +63756,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:25.651961+00:00"
+                "validatedAt": "2026-05-05T18:45:04.941859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63677,7 +63792,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:25.652035+00:00"
+                "validatedAt": "2026-05-05T18:45:04.941895+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63746,7 +63861,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:14:25.652086+00:00"
+                "validatedAt": "2026-05-05T18:45:04.941919+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63809,7 +63924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:14:25.652143+00:00"
+                "validatedAt": "2026-05-05T18:45:04.941946+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63821,7 +63936,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.855160+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.068975+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -63871,23 +63986,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:25.652181+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:04.941963+00:00"
               },
               "deterministic": true
             },
@@ -63900,7 +64015,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.855220+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.069013+00:00"
           },
           "namespace": {
             "type": "string",
@@ -63915,16 +64030,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:14:25.652214+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:04.941979+00:00"
               },
               "deterministic": true
             },
@@ -63937,7 +64057,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.855248+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.069028+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -63976,7 +64096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:25.652267+00:00"
+                "validatedAt": "2026-05-05T18:45:04.942003+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -63989,7 +64109,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.855297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.069060+00:00"
           },
           "uid": {
             "type": "string",
@@ -64006,7 +64126,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:14:25.652295+00:00"
+                "validatedAt": "2026-05-05T18:45:04.942016+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64020,7 +64140,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.855332+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.069076+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of managed_tenant is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -64085,7 +64205,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:14:25.652358+00:00"
+                "validatedAt": "2026-05-05T18:45:04.942045+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64192,7 +64312,7 @@
             "maxLength": 43,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.710618+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542196+00:00"
           },
           "status": {
             "type": "string",
@@ -64214,7 +64334,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.112962+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64226,7 +64346,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.710650+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542214+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -64340,7 +64460,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.113252+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240722+00:00"
               },
               "deterministic": true
             },
@@ -64366,7 +64486,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.113294+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64416,7 +64536,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:16.113346+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240761+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64441,7 +64561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.113387+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240781+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64505,7 +64625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.113431+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240802+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64532,7 +64652,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:16.113480+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240825+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64582,7 +64702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.113522+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240844+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64612,7 +64732,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:16.113568+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -64879,16 +64999,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.113679+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.240915+00:00"
               },
               "deterministic": true
             },
@@ -64901,7 +65026,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711045+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542448+00:00"
           }
         },
         "x-f5xc-description-short": "Request shape for GET API Endpoints Stats All Namespaces.",
@@ -64938,16 +65063,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.113712+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.240932+00:00"
               },
               "deterministic": true
             },
@@ -64960,7 +65090,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711077+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542464+00:00"
           },
           "vhosts_filter": {
             "type": "array",
@@ -65008,7 +65138,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.113779+00:00"
+                "validatedAt": "2026-05-05T18:45:30.240966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65158,16 +65288,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.113887+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241015+00:00"
               },
               "deterministic": true
             },
@@ -65180,7 +65315,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542533+00:00"
           },
           "nginx_one_server_filter": {
             "$ref": "#/components/schemas/namespaceNGINXOneServerInventoryFilterType"
@@ -65447,7 +65582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:16.114043+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241081+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65459,7 +65594,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711427+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542665+00:00"
           },
           "host_name": {
             "type": "string",
@@ -65475,7 +65610,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114088+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241101+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65497,23 +65632,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.114121+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241117+00:00"
               },
               "deterministic": true
             },
@@ -65526,7 +65661,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711466+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542686+00:00"
           },
           "server_name": {
             "type": "string",
@@ -65542,7 +65677,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114167+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241138+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65566,7 +65701,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114206+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65578,7 +65713,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711502+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542708+00:00"
           },
           "waf_enforcement_mode": {
             "type": "string",
@@ -65593,7 +65728,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114257+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241180+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65617,7 +65752,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114309+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241202+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65671,7 +65806,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114376+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65697,7 +65832,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114423+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241247+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65723,7 +65858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114469+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241267+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65749,7 +65884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.114517+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241287+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65797,23 +65932,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.114554+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241304+00:00"
               },
               "deterministic": true
             },
@@ -65826,7 +65961,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711587+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542756+00:00"
           }
         },
         "x-f5xc-description-short": "CascadeDeleteRequest contains the name of the namespace that has to be deleted along with the objects configured under the namespace.",
@@ -65868,7 +66003,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:16.114589+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -65981,7 +66116,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.114654+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241353+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66005,16 +66140,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.114686+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241370+00:00"
               },
               "deterministic": true
             },
@@ -66027,7 +66167,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711687+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542816+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -66111,7 +66251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.114767+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241407+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -66425,7 +66565,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.711858+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.542916+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -67274,7 +67414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115271+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241621+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67297,7 +67437,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115333+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67364,7 +67504,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115398+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241673+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67391,7 +67531,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115433+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241690+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67420,7 +67560,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115489+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241714+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67460,7 +67600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115557+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67494,23 +67634,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.115595+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241762+00:00"
               },
               "deterministic": true
             },
@@ -67523,7 +67663,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712556+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543338+00:00"
           },
           "namespace": {
             "type": "string",
@@ -67537,16 +67677,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.115627+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241779+00:00"
               },
               "deterministic": true
             },
@@ -67559,7 +67704,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712584+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543354+00:00"
           },
           "namespace_service_policy_enabled": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -67598,7 +67743,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115681+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241803+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67627,7 +67772,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115724+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67653,7 +67798,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.115778+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67690,7 +67835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.115839+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241879+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67779,23 +67924,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.115875+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241896+00:00"
               },
               "deterministic": true
             },
@@ -67808,7 +67953,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712746+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543452+00:00"
           },
           "namespace": {
             "type": "string",
@@ -67822,16 +67967,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.115905+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241911+00:00"
               },
               "deterministic": true
             },
@@ -67844,7 +67994,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712776+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543468+00:00"
           }
         },
         "x-f5xc-description-short": "HTTP Loadbalancer WAF Filter Inventory Results.",
@@ -67903,7 +68053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:16.115953+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67965,7 +68115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:16.116012+00:00"
+                "validatedAt": "2026-05-05T18:45:30.241961+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -67977,7 +68127,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712837+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543503+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -68027,23 +68177,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.116050+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241978+00:00"
               },
               "deterministic": true
             },
@@ -68056,7 +68206,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712899+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543540+00:00"
           },
           "namespace": {
             "type": "string",
@@ -68071,16 +68221,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.116082+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.241994+00:00"
               },
               "deterministic": true
             },
@@ -68093,7 +68248,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712924+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543555+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -68132,7 +68287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116136+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68145,7 +68300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.712976+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543586+00:00"
           },
           "uid": {
             "type": "string",
@@ -68162,7 +68317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116166+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68176,7 +68331,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713005+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543602+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of namespace is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -68226,16 +68381,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.116200+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242048+00:00"
               },
               "deterministic": true
             },
@@ -68248,7 +68408,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713033+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543626+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of LookupUserRoles request.",
@@ -68439,7 +68599,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116306+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242093+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68462,23 +68622,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.116348+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242110+00:00"
               },
               "deterministic": true
             },
@@ -68491,7 +68651,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713133+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543686+00:00"
           },
           "nginx_one_object_id": {
             "type": "string",
@@ -68506,7 +68666,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116399+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242132+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68532,7 +68692,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116452+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242156+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68557,7 +68717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116506+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68594,7 +68754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116574+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242207+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68618,7 +68778,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116626+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242230+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68649,7 +68809,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116687+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242262+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68673,7 +68833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.116736+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242285+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68768,7 +68928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.116813+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -68792,16 +68952,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.116847+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242342+00:00"
               },
               "deterministic": true
             },
@@ -68814,7 +68979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713256+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543759+00:00"
           }
         },
         "x-f5xc-description-short": "NamespaceAPIListReq holds the namespace and its associated APIs.",
@@ -68867,16 +69032,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.116894+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242365+00:00"
               },
               "deterministic": true
             },
@@ -68889,7 +69059,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713293+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543784+00:00"
           }
         },
         "x-f5xc-description-short": "NamespaceAPIListResp holds the namespace and its associated APIs.",
@@ -69124,7 +69294,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.117035+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242430+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69147,16 +69317,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117066+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242446+00:00"
               },
               "deterministic": true
             },
@@ -69169,7 +69344,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713416+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543851+00:00"
           }
         },
         "x-f5xc-description-short": "SetActiveAlertPoliciesRequest is the shape of the request for SetActiveAlertPolicies.",
@@ -69223,16 +69398,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117099+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242463+00:00"
               },
               "deterministic": true
             },
@@ -69245,7 +69425,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713445+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543869+00:00"
           },
           "network_policies": {
             "type": "array",
@@ -69271,7 +69451,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.117155+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242491+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69333,16 +69513,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117189+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242508+00:00"
               },
               "deterministic": true
             },
@@ -69355,7 +69540,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713484+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543891+00:00"
           },
           "service_policies": {
             "type": "array",
@@ -69382,7 +69567,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.117245+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69456,7 +69641,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.117303+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242566+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69479,16 +69664,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117347+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242585+00:00"
               },
               "deterministic": true
             },
@@ -69501,7 +69691,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713532+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543918+00:00"
           }
         },
         "x-f5xc-description-short": "SetFastACLsForInternetVIPsRequest contains list of FastACLs refs that should be applied to the Internet VIPs.",
@@ -69590,7 +69780,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.117430+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242632+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69624,7 +69814,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:16.117508+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242671+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -69648,16 +69838,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117540+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242688+00:00"
               },
               "deterministic": true
             },
@@ -69670,7 +69865,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713582+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.543947+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -69916,23 +70111,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117681+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242748+00:00"
               },
               "deterministic": true
             },
@@ -69945,7 +70140,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713721+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544027+00:00"
           },
           "namespace": {
             "type": "string",
@@ -69959,16 +70154,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117713+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242764+00:00"
               },
               "deterministic": true
             },
@@ -69981,7 +70181,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713747+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544043+00:00"
           },
           "namespace_service_policy": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -70128,23 +70328,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117791+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242798+00:00"
               },
               "deterministic": true
             },
@@ -70157,7 +70357,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713866+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544113+00:00"
           }
         },
         "x-f5xc-description-short": "Third Party Application Inventory Results.",
@@ -70307,23 +70507,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117879+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242836+00:00"
               },
               "deterministic": true
             },
@@ -70336,7 +70536,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713944+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544157+00:00"
           },
           "namespace": {
             "type": "string",
@@ -70350,16 +70550,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117911+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242851+00:00"
               },
               "deterministic": true
             },
@@ -70372,7 +70577,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.713971+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544178+00:00"
           },
           "private_advertisement": {
             "$ref": "#/components/schemas/ioschemaEmpty"
@@ -70420,16 +70625,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117948+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242868+00:00"
               },
               "deterministic": true
             },
@@ -70442,7 +70652,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.714023+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544210+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of UpdateAllowAdvertiseOnPublic request.",
@@ -70514,16 +70724,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:16.117985+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:30.242886+00:00"
               },
               "deterministic": true
             },
@@ -70536,7 +70751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.714061+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544232+00:00"
           },
           "validator_evaluation": {
             "type": "object",
@@ -70568,7 +70783,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.118025+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242904+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70580,7 +70795,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.714096+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544254+00:00"
           }
         },
         "x-f5xc-description-short": "Request body of ValidateRulesReq request.",
@@ -70619,7 +70834,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.118065+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242922+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70694,7 +70909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.118125+00:00"
+                "validatedAt": "2026-05-05T18:45:30.242949+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70854,7 +71069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:16.119973+00:00"
+                "validatedAt": "2026-05-05T18:45:30.243800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70903,7 +71118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:16.120035+00:00"
+                "validatedAt": "2026-05-05T18:45:30.243826+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70915,7 +71130,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.715166+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544946+00:00"
           },
           "ref_value": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -70933,7 +71148,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.120081+00:00"
+                "validatedAt": "2026-05-05T18:45:30.243847+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70962,7 +71177,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.120125+00:00"
+                "validatedAt": "2026-05-05T18:45:30.243867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -70974,7 +71189,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.715209+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544972+00:00"
           },
           "value": {
             "type": "string",
@@ -70990,7 +71205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:16.120164+00:00"
+                "validatedAt": "2026-05-05T18:45:30.243885+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71002,7 +71217,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.715235+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.544989+00:00"
           }
         },
         "x-f5xc-description-short": "Tuple with a suggested value and it's description.",
@@ -71131,7 +71346,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870581+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632530+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -71182,16 +71397,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:20.739609+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:32.449354+00:00"
               },
               "deterministic": true
             },
@@ -71204,7 +71424,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870627+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632554+00:00"
           },
           "role": {
             "type": "array",
@@ -71235,7 +71455,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:20.739678+00:00"
+                "validatedAt": "2026-05-05T18:45:32.449392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71273,7 +71493,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:20.739737+00:00"
+                "validatedAt": "2026-05-05T18:45:32.449422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71341,7 +71561,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:15:20.739790+00:00"
+                "validatedAt": "2026-05-05T18:45:32.449447+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71404,7 +71624,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:15:20.739856+00:00"
+                "validatedAt": "2026-05-05T18:45:32.449477+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71416,7 +71636,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870707+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632600+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -71466,23 +71686,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:20.739901+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:32.449498+00:00"
               },
               "deterministic": true
             },
@@ -71495,7 +71715,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870770+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632644+00:00"
           },
           "namespace": {
             "type": "string",
@@ -71510,16 +71730,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:20.739936+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:32.449515+00:00"
               },
               "deterministic": true
             },
@@ -71532,7 +71757,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870795+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632661+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -71571,7 +71796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:20.739992+00:00"
+                "validatedAt": "2026-05-05T18:45:32.449540+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71584,7 +71809,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870848+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632692+00:00"
           },
           "uid": {
             "type": "string",
@@ -71601,7 +71826,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:20.740023+00:00"
+                "validatedAt": "2026-05-05T18:45:32.449555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71615,7 +71840,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:17.870878+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.632708+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of namespace_role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -71744,7 +71969,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:15:41.964353+00:00"
+                "validatedAt": "2026-05-05T18:45:43.221084+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71766,16 +71991,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:41.964388+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:43.221103+00:00"
               },
               "deterministic": true
             },
@@ -71788,7 +72018,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.212675+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.824948+00:00"
           },
           "request_body": {
             "$ref": "#/components/schemas/protobufAny"
@@ -71866,7 +72096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:41.968011+00:00"
+                "validatedAt": "2026-05-05T18:45:43.222785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -71887,23 +72117,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:41.968044+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:43.222802+00:00"
               },
               "deterministic": true
             },
@@ -71916,7 +72146,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.215297+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.826521+00:00"
           },
           "namespace": {
             "type": "string",
@@ -71929,16 +72159,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:15:41.968079+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:43.222819+00:00"
               },
               "deterministic": true
             },
@@ -71951,7 +72186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:18.215334+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:07.826538+00:00"
           },
           "vip_type": {
             "type": "string",
@@ -71965,7 +72200,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:15:41.968121+00:00"
+                "validatedAt": "2026-05-05T18:45:43.222841+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72072,7 +72307,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.461725+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.506589+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -72138,7 +72373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:16:51.296653+00:00"
+                "validatedAt": "2026-05-05T18:46:17.015901+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72201,7 +72436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:16:51.296718+00:00"
+                "validatedAt": "2026-05-05T18:46:17.015932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72213,7 +72448,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.461794+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.506637+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -72263,23 +72498,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:51.296760+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:17.015952+00:00"
               },
               "deterministic": true
             },
@@ -72292,7 +72527,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.461855+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.506677+00:00"
           },
           "namespace": {
             "type": "string",
@@ -72307,16 +72542,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:16:51.296793+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:17.015968+00:00"
               },
               "deterministic": true
             },
@@ -72329,7 +72569,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.461881+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.506693+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -72368,7 +72608,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:51.296847+00:00"
+                "validatedAt": "2026-05-05T18:46:17.015992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72381,7 +72621,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.461934+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.506725+00:00"
           },
           "uid": {
             "type": "string",
@@ -72398,7 +72638,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:51.296876+00:00"
+                "validatedAt": "2026-05-05T18:46:17.016006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72412,7 +72652,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:19.461961+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.506741+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of rbac_policy is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -72459,7 +72699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:16:51.296921+00:00"
+                "validatedAt": "2026-05-05T18:46:17.016027+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72573,7 +72813,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:16:51.298412+00:00"
+                "validatedAt": "2026-05-05T18:46:17.016746+00:00"
               },
               "deterministic": true
             },
@@ -72705,7 +72945,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:18.160547+00:00"
+                "validatedAt": "2026-05-05T18:46:30.443751+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72731,16 +72971,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.160611+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.443782+00:00"
               },
               "deterministic": true
             },
@@ -72753,7 +72998,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032207+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.947853+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/roleCreateSpecType"
@@ -72844,7 +73089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:18.160701+00:00"
+                "validatedAt": "2026-05-05T18:46:30.443818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72903,7 +73148,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:18.160763+00:00"
+                "validatedAt": "2026-05-05T18:46:30.443859+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -72926,23 +73171,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.160802+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.443880+00:00"
               },
               "deterministic": true
             },
@@ -72955,7 +73200,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032289+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.947928+00:00"
           },
           "namespace": {
             "type": "string",
@@ -72970,16 +73215,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.160836+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.443897+00:00"
               },
               "deterministic": true
             },
@@ -72992,7 +73242,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032317+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.947955+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/roleReplaceSpecType"
@@ -73047,23 +73297,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.160873+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.443922+00:00"
               },
               "deterministic": true
             },
@@ -73076,7 +73326,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032373+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948001+00:00"
           },
           "namespace": {
             "type": "string",
@@ -73092,16 +73342,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.160906+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.443940+00:00"
               },
               "deterministic": true
             },
@@ -73114,7 +73369,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032399+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948028+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -73217,7 +73472,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032488+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948118+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -73278,7 +73533,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:18.161027+00:00"
+                "validatedAt": "2026-05-05T18:46:30.443999+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73336,7 +73591,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:18.161083+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73403,7 +73658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:18.161131+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444060+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73465,7 +73720,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:18.161194+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73477,7 +73732,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032578+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948204+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -73526,23 +73781,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.161236+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.444111+00:00"
               },
               "deterministic": true
             },
@@ -73555,7 +73810,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032642+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948258+00:00"
           },
           "namespace": {
             "type": "string",
@@ -73570,16 +73825,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.161269+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.444128+00:00"
               },
               "deterministic": true
             },
@@ -73592,7 +73852,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032669+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948280+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -73631,7 +73891,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.161347+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73644,7 +73904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032721+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948325+00:00"
           },
           "uid": {
             "type": "string",
@@ -73661,7 +73921,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.161379+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444169+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73675,7 +73935,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032748+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948348+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of role is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -73846,23 +74106,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.161437+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.444198+00:00"
               },
               "deterministic": true
             },
@@ -73875,7 +74135,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032849+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948435+00:00"
           },
           "namespace": {
             "type": "string",
@@ -73890,16 +74150,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.161469+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.444215+00:00"
               },
               "deterministic": true
             },
@@ -73912,7 +74177,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032875+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948458+00:00"
           },
           "tenant": {
             "type": "string",
@@ -73929,7 +74194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.161507+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444241+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73942,7 +74207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032900+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948480+00:00"
           },
           "uid": {
             "type": "string",
@@ -73959,7 +74224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.161538+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -73973,7 +74238,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.032929+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948503+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -74134,7 +74399,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:18.162347+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444927+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -74150,7 +74415,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.033407+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.948959+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -74206,23 +74471,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.162387+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.444952+00:00"
               },
               "deterministic": true
             },
@@ -74235,7 +74500,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.033454+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.949004+00:00"
           },
           "namespace": {
             "type": "string",
@@ -74252,16 +74517,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:18.162419+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:30.444975+00:00"
               },
               "deterministic": true
             },
@@ -74274,7 +74544,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.033481+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.949030+00:00"
           },
           "uid": {
             "type": "string",
@@ -74293,7 +74563,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.162449+00:00"
+                "validatedAt": "2026-05-05T18:46:30.444994+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74308,7 +74578,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.033509+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.949058+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -74355,7 +74625,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163538+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445609+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74383,7 +74653,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163585+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445644+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74412,7 +74682,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163634+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74439,7 +74709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163678+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445699+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74468,7 +74738,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163728+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74493,7 +74763,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163775+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445748+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74558,7 +74828,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163845+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445786+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74596,7 +74866,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:18.163902+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445818+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74608,7 +74878,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.034184+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.949717+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -74649,7 +74919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.163958+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74693,7 +74963,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.164000+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445865+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74707,7 +74977,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.034244+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.949770+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -74726,7 +74996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.164045+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445886+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74753,7 +75023,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.164074+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74768,7 +75038,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.034279+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:08.949800+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -74783,7 +75053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:18.164113+00:00"
+                "validatedAt": "2026-05-05T18:46:30.445925+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -74887,16 +75157,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.348136+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.659592+00:00"
               },
               "deterministic": true
             },
@@ -74909,7 +75184,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.461572+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441356+00:00"
           }
         },
         "x-f5xc-description-short": "RecreateScimTokenRequest is the request format for generating SCIM API credential.",
@@ -74957,7 +75232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348206+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659629+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75004,7 +75279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348257+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659652+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75038,7 +75313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348308+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75077,7 +75352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:38.348408+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659716+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75104,7 +75379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348452+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659737+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75130,7 +75405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348495+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659757+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75156,7 +75431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348539+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659778+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75192,7 +75467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348587+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659800+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75218,7 +75493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348638+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659823+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75307,7 +75582,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348692+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75341,7 +75616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348742+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659869+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75368,7 +75643,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348791+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75427,7 +75702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.348838+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659913+00:00"
               },
               "deterministic": true
             },
@@ -75480,7 +75755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348891+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659939+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75513,7 +75788,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348948+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659963+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75560,7 +75835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.348997+00:00"
+                "validatedAt": "2026-05-05T18:46:41.659985+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75594,7 +75869,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349050+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75633,7 +75908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:38.349132+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75676,7 +75951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:17:38.349174+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75703,7 +75978,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349230+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660091+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75730,7 +76005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349270+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660109+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75756,7 +76031,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349314+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75782,7 +76057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349369+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75845,7 +76120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349421+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660171+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75871,7 +76146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349473+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660193+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -75957,7 +76232,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349531+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660218+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76004,7 +76279,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349580+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76038,7 +76313,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349631+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76077,7 +76352,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:17:38.349714+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660299+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76104,7 +76379,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349755+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660318+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76130,7 +76405,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349796+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76156,7 +76431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349840+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76192,7 +76467,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349888+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660379+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76218,7 +76493,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.349935+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660400+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76323,23 +76598,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.349975+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.660418+00:00"
               },
               "deterministic": true
             },
@@ -76352,7 +76627,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.462028+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441695+00:00"
           },
           "namespace": {
             "type": "string",
@@ -76367,16 +76642,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.350010+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.660434+00:00"
               },
               "deterministic": true
             },
@@ -76389,7 +76669,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.462056+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441714+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/schemaoidc_providerCustomCreateSpecType"
@@ -76455,7 +76735,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.350062+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76514,23 +76794,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.350098+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.660475+00:00"
               },
               "deterministic": true
             },
@@ -76543,7 +76823,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.462124+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441757+00:00"
           },
           "namespace": {
             "type": "string",
@@ -76559,16 +76839,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.350129+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.660491+00:00"
               },
               "deterministic": true
             },
@@ -76581,7 +76866,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.462151+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441778+00:00"
           },
           "oidc_mappers": {
             "$ref": "#/components/schemas/oidc_providerOIDCMappers"
@@ -76623,23 +76908,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.350163+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.660508+00:00"
               },
               "deterministic": true
             },
@@ -76652,7 +76937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.462188+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441813+00:00"
           },
           "namespace": {
             "type": "string",
@@ -76667,16 +76952,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.350195+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.660525+00:00"
               },
               "deterministic": true
             },
@@ -76689,7 +76979,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.462214+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.441839+00:00"
           },
           "scim_enabled": {
             "type": "boolean",
@@ -76779,7 +77069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:17:38.350238+00:00"
+                "validatedAt": "2026-05-05T18:46:41.660544+00:00"
               },
               "deterministic": true
             },
@@ -76844,7 +77134,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.351711+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661222+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76868,7 +77158,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.351761+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661246+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -76888,23 +77178,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.351796+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.661263+00:00"
               },
               "deterministic": true
             },
@@ -76917,7 +77207,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463157+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.442818+00:00"
           }
         },
         "x-f5xc-description-short": "CreateResponse is the response format for the credential's create request.",
@@ -76956,16 +77246,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.351829+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.661279+00:00"
               },
               "deterministic": true
             },
@@ -76978,7 +77273,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463185+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.442841+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/schemaoidc_providerCustomCreateSpecType"
@@ -77022,7 +77317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.351885+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77049,7 +77344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.351932+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661324+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77137,23 +77432,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.351970+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.661342+00:00"
               },
               "deterministic": true
             },
@@ -77166,7 +77461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463295+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.442924+00:00"
           },
           "namespace": {
             "type": "string",
@@ -77181,16 +77476,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.352000+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.661357+00:00"
               },
               "deterministic": true
             },
@@ -77203,7 +77503,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463332+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.442950+00:00"
           }
         },
         "x-f5xc-description-short": "DeleteRequest is the request payload for deleting an OIDC provider/SSO configuration.",
@@ -77305,7 +77605,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.352052+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661380+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77363,7 +77663,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:17:38.352092+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661399+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77410,7 +77710,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.352143+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661422+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77433,23 +77733,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.352176+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.661438+00:00"
               },
               "deterministic": true
             },
@@ -77462,7 +77762,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.443051+00:00"
           },
           "namespace": {
             "type": "string",
@@ -77477,16 +77777,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:17:38.352208+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:41.661454+00:00"
               },
               "deterministic": true
             },
@@ -77499,7 +77804,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463477+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.443075+00:00"
           },
           "provider_type": {
             "$ref": "#/components/schemas/oidc_providerProviderType"
@@ -77519,7 +77824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:17:38.352237+00:00"
+                "validatedAt": "2026-05-05T18:46:41.661467+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77533,7 +77838,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:20.463513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:09.443103+00:00"
           }
         },
         "x-f5xc-description-short": "Shape of the OIDC provider object in a list request's response body.",
@@ -77765,7 +78070,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.919653+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77841,7 +78146,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.919732+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -77889,7 +78194,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:18:59.919778+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930417+00:00"
               },
               "deterministic": true
             },
@@ -77991,7 +78296,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.919839+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930442+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78023,7 +78328,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.919886+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930463+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78048,7 +78353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.919936+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930484+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78077,7 +78382,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.919978+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930502+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78109,7 +78414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920020+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930520+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78122,7 +78427,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:22.451683+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:11.545966+00:00"
           },
           "email": {
             "type": "string",
@@ -78149,7 +78454,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:59.920060+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930540+00:00"
               },
               "deterministic": true
             },
@@ -78175,7 +78480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920108+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930561+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78204,7 +78509,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920154+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930581+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78236,7 +78541,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920199+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78262,7 +78567,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920253+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930631+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78288,7 +78593,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920302+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930653+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78326,7 +78631,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:18:59.920359+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78354,7 +78659,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920408+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930697+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78381,7 +78686,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920458+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930718+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78408,7 +78713,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920504+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930739+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78437,7 +78742,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920555+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930760+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78546,7 +78851,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:59.920615+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930787+00:00"
               },
               "deterministic": true
             },
@@ -78572,7 +78877,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920660+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78617,7 +78922,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920724+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930834+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78642,7 +78947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920769+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930855+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78668,7 +78973,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920808+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930873+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78700,7 +79005,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920858+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930894+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78727,7 +79032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920908+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930916+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78752,7 +79057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.920953+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930936+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78830,7 +79135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921002+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78893,7 +79198,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921053+00:00"
+                "validatedAt": "2026-05-05T18:44:57.930980+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78919,7 +79224,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921100+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -78974,7 +79279,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:22.452022+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:11.546165+00:00"
           }
         },
         "x-f5xc-description-short": "Signup object including its status. Use it when you want to see the progress of the signup flow.",
@@ -79163,7 +79468,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921196+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931043+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79205,7 +79510,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:59.921239+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931064+00:00"
               },
               "deterministic": true
             },
@@ -79311,7 +79616,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921289+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79337,7 +79642,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921342+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79435,7 +79740,7 @@
             "maxLength": 18,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:22.452218+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:11.546286+00:00"
           },
           "user": {
             "type": "array",
@@ -79491,23 +79796,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:59.921442+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:57.931149+00:00"
               },
               "deterministic": true
             },
@@ -79520,7 +79825,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:22.452255+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:11.546316+00:00"
           },
           "namespace": {
             "type": "string",
@@ -79536,16 +79841,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:59.921474+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:57.931165+00:00"
               },
               "deterministic": true
             },
@@ -79558,7 +79868,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:22.452280+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:11.546334+00:00"
           },
           "spec": {
             "$ref": "#/components/schemas/schemacontactGlobalSpecType"
@@ -79674,7 +79984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:18:59.921540+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931193+00:00"
               },
               "deterministic": true
             },
@@ -79712,7 +80022,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:18:59.921585+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931213+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79803,7 +80113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921639+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79828,7 +80138,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:18:59.921687+00:00"
+                "validatedAt": "2026-05-05T18:44:57.931257+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79953,7 +80263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:48.090813+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -79978,7 +80288,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.090861+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821067+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80005,7 +80315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.090894+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80034,7 +80344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:19:48.090941+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80125,7 +80435,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:48.091002+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821140+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80169,7 +80479,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091058+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821166+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80268,7 +80578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091141+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821214+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80344,7 +80654,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091184+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80369,7 +80679,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091222+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821249+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80381,7 +80691,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.022595+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.600818+00:00"
           }
         },
         "x-f5xc-description-short": "Email for user can be primary or secondary.",
@@ -80431,7 +80741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091277+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821277+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80503,7 +80813,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:48.091333+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821302+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80528,7 +80838,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091377+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821362+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80555,7 +80865,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091406+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821376+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80584,7 +80894,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:19:48.091449+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821397+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80610,23 +80920,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:48.091487+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:21.821414+00:00"
               },
               "deterministic": true
             },
@@ -80639,7 +80949,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.022692+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.600874+00:00"
           },
           "schemas": {
             "type": "array",
@@ -80699,7 +81009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091533+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821435+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80724,7 +81034,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091570+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821453+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80736,7 +81046,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.022742+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.600901+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -80799,7 +81109,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091636+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80849,7 +81159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091698+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821510+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80876,7 +81186,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091746+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -80956,7 +81266,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091816+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821569+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81012,7 +81322,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091883+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821599+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81045,7 +81355,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091936+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821641+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81102,7 +81412,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.091985+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821669+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81135,7 +81445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092036+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821693+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81167,7 +81477,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092080+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81179,7 +81489,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.022880+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.600984+00:00"
           },
           "resourceType": {
             "type": "string",
@@ -81203,7 +81513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092131+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81236,7 +81546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092178+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821763+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81248,7 +81558,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.022918+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.601005+00:00"
           }
         },
         "x-f5xc-example": "Meta",
@@ -81290,7 +81600,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092225+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821784+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81316,7 +81626,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092270+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821805+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81341,7 +81651,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092314+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81366,7 +81676,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092372+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81392,7 +81702,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092420+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821868+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81417,7 +81727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092467+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821888+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81501,7 +81811,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092520+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821911+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81574,7 +81884,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092568+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821935+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81602,7 +81912,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:48.092619+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821958+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81629,7 +81939,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.023051+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.601081+00:00"
           }
         },
         "x-f5xc-description-short": "PatchOperation is the PATCH operation where user can be updated replaced or remove..",
@@ -81705,7 +82015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092677+00:00"
+                "validatedAt": "2026-05-05T18:45:21.821992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81786,7 +82096,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:19:48.092739+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822021+00:00"
               },
               "deterministic": true
             },
@@ -81820,7 +82130,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092772+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81852,23 +82162,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:19:48.092811+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:21.822055+00:00"
               },
               "deterministic": true
             },
@@ -81881,7 +82191,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.023142+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.601132+00:00"
           },
           "schema": {
             "type": "string",
@@ -81903,7 +82213,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092853+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822080+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81984,7 +82294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092914+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822108+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -81996,7 +82306,7 @@
             "x-original-maxLength": 1024,
             "minLength": 4,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.023188+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.601160+00:00"
           },
           "resourceType": {
             "type": "string",
@@ -82021,7 +82331,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.092965+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822131+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82066,7 +82376,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093006+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822151+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82139,7 +82449,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093074+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82151,7 +82461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.023250+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.601197+00:00"
           },
           "totalResults": {
             "type": "string",
@@ -82177,7 +82487,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093124+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822205+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82264,7 +82574,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093200+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822237+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82415,7 +82725,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:19:48.093267+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822270+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82466,7 +82776,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093336+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822300+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82525,7 +82835,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093382+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822321+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82556,7 +82866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093426+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822340+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82644,7 +82954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093494+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82705,7 +83015,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093538+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82732,7 +83042,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:19:48.093565+00:00"
+                "validatedAt": "2026-05-05T18:45:21.822410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82834,7 +83144,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.128555+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564724+00:00"
               },
               "deterministic": true
             },
@@ -82949,7 +83259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.128667+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -82996,7 +83306,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.128713+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564790+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83052,7 +83362,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.128759+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564811+00:00"
               },
               "deterministic": true
             },
@@ -83079,7 +83389,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.128804+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564831+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83102,23 +83412,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.128844+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:34.564849+00:00"
               },
               "deterministic": true
             },
@@ -83131,7 +83441,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.446264+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.829764+00:00"
           },
           "reason": {
             "$ref": "#/components/schemas/tenantDeletionReason"
@@ -83203,7 +83513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.128878+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564864+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83260,7 +83570,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.128936+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83338,7 +83648,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.128993+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564915+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83362,7 +83672,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129032+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564932+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83390,7 +83700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.129074+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564952+00:00"
               },
               "deterministic": true
             },
@@ -83414,7 +83724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129121+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564972+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83443,7 +83753,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:20:14.129169+00:00"
+                "validatedAt": "2026-05-05T18:45:34.564994+00:00"
               },
               "deterministic": true
             },
@@ -83474,7 +83784,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129206+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565011+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83736,7 +84046,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129364+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565071+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83759,7 +84069,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129396+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565086+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83803,7 +84113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129453+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565111+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83849,7 +84159,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129513+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565137+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83874,7 +84184,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129560+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565158+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83898,7 +84208,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129600+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565176+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -83911,7 +84221,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.446551+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.829922+00:00"
           },
           "max_credentials_expiry": {
             "$ref": "#/components/schemas/tenantCredentialsExpiry"
@@ -83930,23 +84240,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.129636+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:34.565193+00:00"
               },
               "deterministic": true
             },
@@ -83959,7 +84269,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.446589+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.829943+00:00"
           },
           "original_tenant": {
             "type": "string",
@@ -83977,7 +84287,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129686+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565215+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84089,7 +84399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.129737+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565239+00:00"
               },
               "deterministic": true
             },
@@ -84134,7 +84444,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129786+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565261+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84160,7 +84470,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129822+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84340,7 +84650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:14.129894+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565310+00:00"
               },
               "deterministic": true
             },
@@ -84423,7 +84733,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.129954+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565335+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84448,7 +84758,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:14.130002+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565357+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -84507,7 +84817,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:14.130081+00:00"
+                "validatedAt": "2026-05-05T18:45:34.565396+00:00"
               },
               "deterministic": true
             },
@@ -84916,23 +85226,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:18.321575+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.531654+00:00"
               },
               "deterministic": true
             },
@@ -84945,7 +85255,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567077+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892044+00:00"
           },
           "namespace": {
             "type": "string",
@@ -84961,16 +85271,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:18.321608+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.531671+00:00"
               },
               "deterministic": true
             },
@@ -84983,7 +85298,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567103+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892059+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -85086,7 +85401,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567193+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892113+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -85186,7 +85501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:18.321724+00:00"
+                "validatedAt": "2026-05-05T18:45:36.531724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85249,7 +85564,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:18.321786+00:00"
+                "validatedAt": "2026-05-05T18:45:36.531754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85261,7 +85576,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567333+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892170+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -85311,23 +85626,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:18.321823+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.531773+00:00"
               },
               "deterministic": true
             },
@@ -85340,7 +85655,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567433+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892207+00:00"
           },
           "namespace": {
             "type": "string",
@@ -85355,16 +85670,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:18.321855+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:36.531790+00:00"
               },
               "deterministic": true
             },
@@ -85377,7 +85697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567462+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892223+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -85416,7 +85736,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:18.321909+00:00"
+                "validatedAt": "2026-05-05T18:45:36.531815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85429,7 +85749,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567512+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892254+00:00"
           },
           "uid": {
             "type": "string",
@@ -85447,7 +85767,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:18.321938+00:00"
+                "validatedAt": "2026-05-05T18:45:36.531829+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85461,7 +85781,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.567540+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.892270+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tenant_configuration is returned in 'List'.",
@@ -85712,7 +86032,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:24.152193+00:00"
+                "validatedAt": "2026-05-05T18:45:39.312536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85737,7 +86057,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:24.152244+00:00"
+                "validatedAt": "2026-05-05T18:45:39.312559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85793,16 +86113,21 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.153718+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313248+00:00"
               },
               "deterministic": true
             },
@@ -85815,7 +86140,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645016+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934030+00:00"
           },
           "role": {
             "type": "string",
@@ -85845,7 +86170,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.153778+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -85959,7 +86284,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.153841+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313311+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86014,7 +86339,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.153918+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313350+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86078,23 +86403,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:24.153957+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:39.313367+00:00"
               },
               "deterministic": true
             },
@@ -86107,7 +86432,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645165+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934116+00:00"
           },
           "namespace": {
             "type": "string",
@@ -86123,16 +86448,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:24.153991+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:39.313385+00:00"
               },
               "deterministic": true
             },
@@ -86145,7 +86475,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645192+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934131+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -86287,7 +86617,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.154101+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313436+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86342,7 +86672,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.154177+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86401,23 +86731,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:24.154216+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:39.313491+00:00"
               },
               "deterministic": true
             },
@@ -86430,7 +86760,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645354+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934221+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -86460,7 +86790,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.154271+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313519+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86527,7 +86857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:24.154330+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313541+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86590,7 +86920,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:24.154389+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313568+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86602,7 +86932,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645423+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934261+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -86652,23 +86982,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:24.154424+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:39.313586+00:00"
               },
               "deterministic": true
             },
@@ -86681,7 +87011,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645484+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934298+00:00"
           },
           "namespace": {
             "type": "string",
@@ -86696,16 +87026,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:24.154455+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:39.313602+00:00"
               },
               "deterministic": true
             },
@@ -86718,7 +87053,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645513+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934313+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -86741,7 +87076,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:24.154495+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86754,7 +87089,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645558+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934339+00:00"
           },
           "uid": {
             "type": "string",
@@ -86771,7 +87106,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:24.154525+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313640+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86785,7 +87120,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.645588+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:12.934355+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of tenant_profile is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -86888,7 +87223,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.154587+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -86943,7 +87278,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:24.154667+00:00"
+                "validatedAt": "2026-05-05T18:45:39.313711+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87361,16 +87696,21 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:28.209809+00:00"
+                "validatedAt": "2026-05-05T18:46:10.720316+00:00"
               },
               "deterministic": true
             },
@@ -87383,7 +87723,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.764469+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.545798+00:00"
           },
           "role": {
             "type": "string",
@@ -87413,7 +87753,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:28.209875+00:00"
+                "validatedAt": "2026-05-05T18:46:10.720352+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87547,16 +87887,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.211187+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.721414+00:00"
               },
               "deterministic": true
             },
@@ -87569,7 +87914,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765201+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546230+00:00"
           },
           "tos_accepted": {
             "type": "string",
@@ -87587,7 +87932,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211235+00:00"
+                "validatedAt": "2026-05-05T18:46:10.721471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87614,7 +87959,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211286+00:00"
+                "validatedAt": "2026-05-05T18:46:10.721625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87639,7 +87984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211343+00:00"
+                "validatedAt": "2026-05-05T18:46:10.721702+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87728,16 +88073,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.211379+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.721774+00:00"
               },
               "deterministic": true
             },
@@ -87750,7 +88100,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765258+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546263+00:00"
           },
           "namespaces_role": {
             "$ref": "#/components/schemas/userNamespacesRoleType"
@@ -87816,7 +88166,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211446+00:00"
+                "validatedAt": "2026-05-05T18:46:10.721882+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87944,7 +88294,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211501+00:00"
+                "validatedAt": "2026-05-05T18:46:10.721927+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87969,7 +88319,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211550+00:00"
+                "validatedAt": "2026-05-05T18:46:10.721974+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -87994,7 +88344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211597+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722020+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88019,7 +88369,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211641+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722063+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88086,7 +88436,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.211689+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722121+00:00"
               },
               "deterministic": true
             },
@@ -88110,16 +88460,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.211723+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.722171+00:00"
               },
               "deterministic": true
             },
@@ -88132,7 +88487,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765402+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546341+00:00"
           }
         },
         "x-f5xc-description-short": "CascadeDeleteRequest is the request to DELETE the user along with the associated namespace role objects.",
@@ -88193,7 +88548,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:28.211767+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722209+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88253,23 +88608,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.211807+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.722266+00:00"
               },
               "deterministic": true
             },
@@ -88282,7 +88637,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765461+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546375+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -88320,7 +88675,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211845+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722483+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88345,7 +88700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211887+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722562+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88357,7 +88712,7 @@
             "x-original-maxLength": 1024,
             "minLength": 1,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765499+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546397+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -88399,7 +88754,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.211944+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722657+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88455,7 +88810,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212013+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722740+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88481,7 +88836,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212052+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88507,7 +88862,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212094+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722842+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88532,7 +88887,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212145+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722884+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88599,7 +88954,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.212191+00:00"
+                "validatedAt": "2026-05-05T18:46:10.722955+00:00"
               },
               "deterministic": true
             },
@@ -88624,7 +88979,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212238+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723021+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88666,7 +89021,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212297+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723102+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88713,7 +89068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212375+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723162+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88738,7 +89093,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212418+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723235+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88764,23 +89119,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.212452+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.723307+00:00"
               },
               "deterministic": true
             },
@@ -88793,7 +89148,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765691+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546512+00:00"
           },
           "namespace": {
             "type": "string",
@@ -88809,16 +89164,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.212485+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.723331+00:00"
               },
               "deterministic": true
             },
@@ -88831,7 +89191,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765716+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546528+00:00"
           },
           "namespace_access": {
             "$ref": "#/components/schemas/schemaNamespaceAccessType"
@@ -88871,7 +89231,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212548+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723367+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88912,7 +89272,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212589+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88925,7 +89285,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.765809+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546588+00:00"
           },
           "tenant_flags": {
             "type": "object",
@@ -88955,7 +89315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212639+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723418+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -88996,7 +89356,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212692+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723446+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89023,7 +89383,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212742+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723470+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89048,7 +89408,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212794+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723494+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89073,7 +89433,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212841+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89102,7 +89462,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212886+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89227,7 +89587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.212946+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723573+00:00"
               },
               "deterministic": true
             },
@@ -89253,7 +89613,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.212991+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723746+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89298,7 +89658,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213055+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723821+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89323,7 +89683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213100+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723849+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89349,7 +89709,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213141+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723875+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89381,7 +89741,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213188+00:00"
+                "validatedAt": "2026-05-05T18:46:10.723976+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89408,7 +89768,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213237+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724047+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89433,7 +89793,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213286+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724072+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89498,7 +89858,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:28.213336+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724094+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89543,7 +89903,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213388+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724118+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89610,7 +89970,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.213433+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724144+00:00"
               },
               "deterministic": true
             },
@@ -89636,7 +89996,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213477+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89683,7 +90043,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213542+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89708,7 +90068,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213585+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89731,23 +90091,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.213618+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.724334+00:00"
               },
               "deterministic": true
             },
@@ -89760,7 +90120,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.766153+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546796+00:00"
           },
           "namespace": {
             "type": "string",
@@ -89776,16 +90136,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.213651+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.724360+00:00"
               },
               "deterministic": true
             },
@@ -89798,7 +90163,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.766179+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546812+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -89849,7 +90214,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213707+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724392+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89862,7 +90227,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.766230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546843+00:00"
           },
           "tenant_type": {
             "$ref": "#/components/schemas/schemaTenantType"
@@ -89921,7 +90286,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213749+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -89950,7 +90315,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213800+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724545+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90055,7 +90420,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.213860+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724596+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90149,7 +90514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.213910+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724668+00:00"
               },
               "deterministic": true
             },
@@ -90213,7 +90578,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.213955+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724697+00:00"
               },
               "deterministic": true
             },
@@ -90237,16 +90602,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.213984+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.724713+00:00"
               },
               "deterministic": true
             },
@@ -90259,7 +90629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.766388+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546931+00:00"
           }
         },
         "x-f5xc-description-short": "SendPasswordEmailRequest is the request parameters for sending the password update.",
@@ -90373,7 +90743,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:28.214073+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724855+00:00"
               },
               "byteLength": {
                 "max": 320,
@@ -90463,7 +90833,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.214118+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724904+00:00"
               },
               "deterministic": true
             },
@@ -90496,7 +90866,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.214164+00:00"
+                "validatedAt": "2026-05-05T18:46:10.724928+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90549,7 +90919,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:28.214226+00:00"
+                "validatedAt": "2026-05-05T18:46:10.725024+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90574,23 +90944,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.214260+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.725092+00:00"
               },
               "deterministic": true
             },
@@ -90603,7 +90973,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.766503+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.546998+00:00"
           },
           "namespace": {
             "type": "string",
@@ -90619,16 +90989,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:28.214292+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:10.725129+00:00"
               },
               "deterministic": true
             },
@@ -90641,7 +91016,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.766530+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.547014+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -90727,7 +91102,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.306606+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979089+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -90914,7 +91289,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848009+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592071+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -90968,7 +91343,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:32.306744+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979154+00:00"
               },
               "deterministic": true
             },
@@ -91034,7 +91409,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:32.306795+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979179+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91097,7 +91472,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:32.306855+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91109,7 +91484,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848088+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592117+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -91159,23 +91534,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:32.306894+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:12.979224+00:00"
               },
               "deterministic": true
             },
@@ -91188,7 +91563,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848153+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592154+00:00"
           },
           "namespace": {
             "type": "string",
@@ -91203,16 +91578,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:32.306927+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:12.979240+00:00"
               },
               "deterministic": true
             },
@@ -91225,7 +91605,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848180+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592170+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -91264,7 +91644,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.306978+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91277,7 +91657,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592201+00:00"
           },
           "uid": {
             "type": "string",
@@ -91294,7 +91674,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.307009+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979278+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91308,7 +91688,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848257+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592217+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of user_group is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -91395,23 +91775,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:32.307058+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:12.979301+00:00"
               },
               "deterministic": true
             },
@@ -91424,7 +91804,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848296+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592240+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -91492,7 +91872,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:32.307150+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979345+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91528,7 +91908,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:32.307226+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91588,7 +91968,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:32.307266+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979410+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91701,7 +92081,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:32.307359+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979448+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91713,7 +92093,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848420+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592306+00:00"
           },
           "display_name": {
             "type": "string",
@@ -91735,7 +92115,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:32.307392+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91758,23 +92138,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:32.307427+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:12.979480+00:00"
               },
               "deterministic": true
             },
@@ -91787,7 +92167,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848458+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592327+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -91821,7 +92201,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.307481+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979504+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91895,7 +92275,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:32.307549+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979535+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91907,7 +92287,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848515+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592359+00:00"
           },
           "display_name": {
             "type": "string",
@@ -91929,7 +92309,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:32.307585+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979551+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91959,7 +92339,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.307613+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -91982,23 +92362,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:32.307646+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:12.979580+00:00"
               },
               "deterministic": true
             },
@@ -92011,7 +92391,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848566+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592390+00:00"
           },
           "namespace_roles": {
             "type": "array",
@@ -92060,7 +92440,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.307702+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92089,7 +92469,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:32.307731+00:00"
+                "validatedAt": "2026-05-05T18:46:12.979626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92103,7 +92483,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.848631+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.592428+00:00"
           },
           "usernames": {
             "type": "array",
@@ -92242,7 +92622,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.198445+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856147+00:00"
               },
               "deterministic": true
             },
@@ -92301,23 +92681,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:36.198479+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:14.856164+00:00"
               },
               "deterministic": true
             },
@@ -92330,7 +92710,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911278+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629497+00:00"
           },
           "namespace": {
             "type": "string",
@@ -92346,16 +92726,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:36.198509+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:14.856181+00:00"
               },
               "deterministic": true
             },
@@ -92368,7 +92753,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911307+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629514+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -92471,7 +92856,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911404+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629567+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -92538,7 +92923,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.198636+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856243+00:00"
               },
               "deterministic": true
             },
@@ -92605,7 +92990,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:21:36.198681+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92668,7 +93053,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:36.198740+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856290+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92680,7 +93065,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911485+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629621+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -92730,23 +93115,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:36.198778+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:14.856308+00:00"
               },
               "deterministic": true
             },
@@ -92759,7 +93144,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911546+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629660+00:00"
           },
           "namespace": {
             "type": "string",
@@ -92774,16 +93159,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:36.198809+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:46:14.856324+00:00"
               },
               "deterministic": true
             },
@@ -92796,7 +93186,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911572+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629676+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -92835,7 +93225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:36.198862+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856347+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92848,7 +93238,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911623+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629707+00:00"
           },
           "uid": {
             "type": "string",
@@ -92866,7 +93256,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:36.198891+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856361+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -92880,7 +93270,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.911650+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.629724+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of user_identification is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -92990,7 +93380,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.198962+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856403+00:00"
               },
               "deterministic": true
             },
@@ -93128,7 +93518,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.199076+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93187,7 +93577,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.199158+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856493+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93246,7 +93636,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.199243+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856533+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93312,7 +93702,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.199328+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856572+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93371,7 +93761,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:21:36.199409+00:00"
+                "validatedAt": "2026-05-05T18:46:14.856610+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93467,7 +93857,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276133+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93528,7 +93918,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276176+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858508+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93557,7 +93947,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:21:38.276242+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858536+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93569,7 +93959,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:25.983238+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.666226+00:00"
           },
           "enabled": {
             "type": "boolean",
@@ -93602,7 +93992,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276282+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858555+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93723,7 +94113,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276367+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858586+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93910,7 +94300,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276438+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858625+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93936,7 +94326,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276478+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858643+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -93983,7 +94373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276525+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858664+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94033,7 +94423,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:21:38.276572+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858685+00:00"
               },
               "deterministic": true
             },
@@ -94061,7 +94451,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276618+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858707+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94088,7 +94478,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276656+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94190,7 +94580,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276734+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858758+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94217,7 +94607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276770+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858775+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94242,7 +94632,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276816+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858796+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94308,7 +94698,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:21:38.276859+00:00"
+                "validatedAt": "2026-05-05T18:46:15.858817+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94480,7 +94870,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:32.588024+00:00"
+                "validatedAt": "2026-05-05T18:46:44.469148+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94507,7 +94897,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:22:32.588125+00:00"
+                "validatedAt": "2026-05-05T18:46:44.469183+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -94533,7 +94923,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:22:32.588189+00:00"
+                "validatedAt": "2026-05-05T18:46:44.469202+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/threat_campaign.json
+++ b/docs/specifications/api/threat_campaign.json
@@ -484,7 +484,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.728799+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734557+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -508,7 +508,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.728853+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -557,23 +557,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.728901+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734604+00:00"
               },
               "deterministic": true
             },
@@ -586,7 +586,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.289973+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077555+00:00"
           },
           "namespace": {
             "type": "string",
@@ -602,16 +602,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.728936+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734635+00:00"
               },
               "deterministic": true
             },
@@ -624,7 +629,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290003+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077572+00:00"
           },
           "path": {
             "type": "string",
@@ -655,7 +660,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729018+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734678+00:00"
               },
               "deterministic": true
             },
@@ -740,7 +745,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729101+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734719+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -803,7 +808,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729194+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734768+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -827,23 +832,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729233+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734788+00:00"
               },
               "deterministic": true
             },
@@ -856,7 +861,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077633+00:00"
           },
           "namespace": {
             "type": "string",
@@ -872,16 +877,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729267+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734805+00:00"
               },
               "deterministic": true
             },
@@ -894,7 +904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077650+00:00"
           },
           "user_id": {
             "type": "string",
@@ -918,7 +928,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729368+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734840+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -972,23 +982,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729405+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734858+00:00"
               },
               "deterministic": true
             },
@@ -1001,7 +1011,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290165+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077679+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -1059,7 +1069,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729474+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734892+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1089,23 +1099,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729510+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734909+00:00"
               },
               "deterministic": true
             },
@@ -1118,7 +1128,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290237+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077725+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1134,16 +1144,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729543+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734926+00:00"
               },
               "deterministic": true
             },
@@ -1156,7 +1171,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290262+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077741+00:00"
           },
           "tls_fingerprint_matcher": {
             "$ref": "#/components/schemas/policyTlsFingerprintMatcherType"
@@ -1210,7 +1225,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.729598+00:00"
+                "validatedAt": "2026-05-05T18:40:17.734950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1277,23 +1292,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729650+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734973+00:00"
               },
               "deterministic": true
             },
@@ -1306,7 +1321,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290356+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077793+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1322,16 +1337,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729681+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.734989+00:00"
               },
               "deterministic": true
             },
@@ -1344,7 +1364,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290382+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077810+00:00"
           },
           "path": {
             "type": "string",
@@ -1375,7 +1395,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729761+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735028+00:00"
               },
               "deterministic": true
             },
@@ -1461,23 +1481,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729801+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735044+00:00"
               },
               "deterministic": true
             },
@@ -1490,7 +1510,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290461+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077859+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1506,16 +1526,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729833+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735060+00:00"
               },
               "deterministic": true
             },
@@ -1528,7 +1553,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290487+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077875+00:00"
           },
           "path": {
             "type": "string",
@@ -1559,7 +1584,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.729909+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735098+00:00"
               },
               "deterministic": true
             },
@@ -1639,23 +1664,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729946+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735115+00:00"
               },
               "deterministic": true
             },
@@ -1668,7 +1693,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290552+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077914+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1684,16 +1709,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.729977+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735131+00:00"
               },
               "deterministic": true
             },
@@ -1706,7 +1736,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290580+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077930+00:00"
           },
           "path": {
             "type": "string",
@@ -1737,7 +1767,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730048+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735169+00:00"
               },
               "deterministic": true
             },
@@ -1822,7 +1852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730127+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735206+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1885,7 +1915,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730214+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735250+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -1925,23 +1955,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730255+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735269+00:00"
               },
               "deterministic": true
             },
@@ -1954,7 +1984,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290672+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.077985+00:00"
           },
           "namespace": {
             "type": "string",
@@ -1970,16 +2000,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730287+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735285+00:00"
               },
               "deterministic": true
             },
@@ -1992,7 +2027,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290699+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078002+00:00"
           },
           "sec_event_name": {
             "type": "string",
@@ -2009,7 +2044,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.730347+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735307+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2048,7 +2083,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730407+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2096,7 +2131,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730479+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735373+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2154,23 +2189,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730515+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735390+00:00"
               },
               "deterministic": true
             },
@@ -2183,7 +2218,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290771+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078047+00:00"
           },
           "rule": {
             "$ref": "#/components/schemas/common_wafSimpleClientSrcRule"
@@ -2239,7 +2274,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730592+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2252,7 +2287,7 @@
             "minLength": 26,
             "format": "hostname",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290821+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078076+00:00"
           },
           "exclude_bot_names": {
             "type": "array",
@@ -2283,7 +2318,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730651+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735457+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2322,7 +2357,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730706+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735488+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2361,7 +2396,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730763+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735518+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2385,23 +2420,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730797+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735535+00:00"
               },
               "deterministic": true
             },
@@ -2414,7 +2449,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290874+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078108+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2430,16 +2465,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.730828+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735551+00:00"
               },
               "deterministic": true
             },
@@ -2452,7 +2492,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290902+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078125+00:00"
           },
           "req_path": {
             "type": "string",
@@ -2476,7 +2516,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730895+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735585+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2510,7 +2550,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.730987+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735639+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2566,23 +2606,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731025+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735659+00:00"
               },
               "deterministic": true
             },
@@ -2595,7 +2635,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.290958+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078158+00:00"
           },
           "waf_exclusion_policy": {
             "$ref": "#/components/schemas/schemaviewsObjectRefType"
@@ -2640,23 +2680,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731061+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735677+00:00"
               },
               "deterministic": true
             },
@@ -2669,7 +2709,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291005+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078186+00:00"
           },
           "namespace": {
             "type": "string",
@@ -2684,16 +2724,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731094+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735693+00:00"
               },
               "deterministic": true
             },
@@ -2706,7 +2751,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291030+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078202+00:00"
           },
           "request_data": {
             "$ref": "#/components/schemas/app_securityRequestData"
@@ -2754,7 +2799,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731136+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735713+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2782,7 +2827,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731179+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2810,7 +2855,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731220+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735754+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2873,7 +2918,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.731279+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735783+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -2885,7 +2930,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291120+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078278+00:00"
           }
         },
         "x-f5xc-description-short": "Metric label filter can be specified to query specific metrics based on label match.",
@@ -2979,7 +3024,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.731347+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735814+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3003,16 +3048,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731380+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735831+00:00"
               },
               "deterministic": true
             },
@@ -3025,7 +3075,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291161+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078303+00:00"
           }
         },
         "x-f5xc-description-short": "GET a list of virtual hosts in all the namespaces matching filter provided in the request.",
@@ -3156,7 +3206,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731449+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735861+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3180,16 +3230,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731482+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735877+00:00"
               },
               "deterministic": true
             },
@@ -3202,7 +3257,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291223+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078340+00:00"
           },
           "query": {
             "type": "string",
@@ -3222,7 +3277,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.731529+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3255,7 +3310,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731577+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735921+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3322,7 +3377,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731629+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3377,7 +3432,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731676+00:00"
+                "validatedAt": "2026-05-05T18:40:17.735966+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3435,16 +3490,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.731737+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.735994+00:00"
               },
               "deterministic": true
             },
@@ -3457,7 +3517,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291329+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078397+00:00"
           },
           "start_time": {
             "type": "string",
@@ -3482,7 +3542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731783+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736015+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3515,7 +3575,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731820+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736032+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3590,7 +3650,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731869+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736054+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3639,7 +3699,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731907+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736073+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3667,7 +3727,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731948+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3695,7 +3755,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.731990+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736112+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3764,7 +3824,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732040+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736134+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3793,7 +3853,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732082+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736153+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3817,16 +3877,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732115+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736169+00:00"
               },
               "deterministic": true
             },
@@ -3839,7 +3904,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291450+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078524+00:00"
           },
           "query": {
             "type": "string",
@@ -3859,7 +3924,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732163+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736192+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3904,7 +3969,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732206+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736211+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3937,7 +4002,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732254+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736232+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4024,7 +4089,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732314+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736259+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4053,7 +4118,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732369+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736279+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4101,16 +4166,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732403+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736296+00:00"
               },
               "deterministic": true
             },
@@ -4123,7 +4193,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291561+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078595+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -4141,7 +4211,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732445+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736316+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4212,7 +4282,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732494+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736337+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4236,16 +4306,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732526+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736353+00:00"
               },
               "deterministic": true
             },
@@ -4258,7 +4333,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291617+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078641+00:00"
           },
           "query": {
             "type": "string",
@@ -4278,7 +4353,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732571+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736375+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4311,7 +4386,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732619+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736395+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4378,7 +4453,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732667+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736417+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4447,7 +4522,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732718+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736440+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4476,7 +4551,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732757+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736459+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4500,16 +4575,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.732790+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736475+00:00"
               },
               "deterministic": true
             },
@@ -4522,7 +4602,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291711+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078702+00:00"
           },
           "query": {
             "type": "string",
@@ -4542,7 +4622,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.732836+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736497+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4587,7 +4667,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732877+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736516+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4620,7 +4700,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732924+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736537+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4707,7 +4787,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.732984+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736563+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4736,7 +4816,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733028+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736583+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4784,16 +4864,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733061+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736600+00:00"
               },
               "deterministic": true
             },
@@ -4806,7 +4891,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291822+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078769+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -4824,7 +4909,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733104+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4895,7 +4980,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733160+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736649+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4919,16 +5004,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733194+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736665+00:00"
               },
               "deterministic": true
             },
@@ -4941,7 +5031,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291880+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078804+00:00"
           },
           "query": {
             "type": "string",
@@ -4961,7 +5051,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.733246+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736687+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4994,7 +5084,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733297+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736708+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5061,7 +5151,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733360+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736729+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5130,7 +5220,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733415+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736750+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5159,7 +5249,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.733454+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736769+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5183,16 +5273,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733487+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736785+00:00"
               },
               "deterministic": true
             },
@@ -5205,7 +5300,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.291972+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078861+00:00"
           },
           "query": {
             "type": "string",
@@ -5225,7 +5320,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.733536+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736806+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5270,7 +5365,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733584+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736824+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5303,7 +5398,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733635+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736845+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5390,7 +5485,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733694+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5419,7 +5514,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733740+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5467,16 +5562,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.733776+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.736907+00:00"
               },
               "deterministic": true
             },
@@ -5489,7 +5589,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.292080+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078928+00:00"
           },
           "scroll_id": {
             "type": "string",
@@ -5507,7 +5607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733818+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5556,7 +5656,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733868+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736950+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5585,7 +5685,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:49.733925+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5597,7 +5697,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.292125+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078961+00:00"
           },
           "id": {
             "type": "string",
@@ -5623,7 +5723,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733956+00:00"
+                "validatedAt": "2026-05-05T18:40:17.736992+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5648,7 +5748,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.733998+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5681,7 +5781,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734051+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737036+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5736,23 +5836,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.734106+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.737061+00:00"
               },
               "deterministic": true
             },
@@ -5765,7 +5865,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.292185+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.078999+00:00"
           },
           "references": {
             "type": "array",
@@ -5806,7 +5906,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734164+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737087+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5907,7 +6007,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734225+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737115+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6229,7 +6329,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734315+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6438,7 +6538,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734423+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737195+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6511,7 +6611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.734485+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737221+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6590,7 +6690,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734570+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737264+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6635,7 +6735,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734649+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737304+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6735,7 +6835,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734712+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737336+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6773,7 +6873,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734794+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737376+00:00"
               },
               "deterministic": true
             },
@@ -6840,7 +6940,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734880+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737416+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6886,7 +6986,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.734960+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737454+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6984,7 +7084,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735019+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7051,7 +7151,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735102+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737523+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7090,7 +7190,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735177+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737559+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7163,7 +7263,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735253+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737601+00:00"
               },
               "deterministic": true
             },
@@ -7227,7 +7327,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.75,
-                "validatedAt": "2026-05-05T06:04:49.735300+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737633+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7451,7 +7551,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735385+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737672+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7525,7 +7625,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735452+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737704+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7588,7 +7688,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735528+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737744+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7627,7 +7727,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735601+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737782+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7668,7 +7768,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735683+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737822+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7742,7 +7842,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.735748+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737854+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7811,7 +7911,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.735828+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737887+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7846,7 +7946,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.735878+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7884,7 +7984,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.735932+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737934+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7928,7 +8028,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736012+00:00"
+                "validatedAt": "2026-05-05T18:40:17.737975+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8078,7 +8178,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736075+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738008+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8720,7 +8820,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736151+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8775,23 +8875,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 256,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736223+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738085+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -8807,7 +8907,7 @@
             },
             "x-original-maxLength": 256,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293250+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079667+00:00"
           },
           "presence": {
             "type": "boolean",
@@ -8852,7 +8952,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.736309+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738125+00:00"
               },
               "byteLength": {
                 "max": 256
@@ -8913,7 +9013,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736356+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738142+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -8926,7 +9026,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293300+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079696+00:00"
           },
           "name": {
             "type": "string",
@@ -8943,23 +9043,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.736390+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.738158+00:00"
               },
               "deterministic": true
             },
@@ -8972,7 +9072,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293335+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079712+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8989,16 +9089,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.736425+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.738177+00:00"
               },
               "deterministic": true
             },
@@ -9011,7 +9116,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293360+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079729+00:00"
           },
           "tenant": {
             "type": "string",
@@ -9030,7 +9135,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736465+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738196+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9044,7 +9149,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293385+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079745+00:00"
           },
           "uid": {
             "type": "string",
@@ -9063,7 +9168,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736495+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738210+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9078,7 +9183,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293411+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079762+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -9118,7 +9223,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079780+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Avg Aggregation Data\" Average Aggregation data.",
@@ -9154,7 +9259,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736555+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738233+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9203,7 +9308,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736597+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738252+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9242,7 +9347,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.9,
-                "validatedAt": "2026-05-05T06:04:49.736647+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738274+00:00"
               },
               "deterministic": true
             },
@@ -9309,7 +9414,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736699+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738297+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9354,7 +9459,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736740+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738315+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9377,7 +9482,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736769+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738328+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9389,7 +9494,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293551+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079850+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -9482,7 +9587,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736831+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738356+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9506,7 +9611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736860+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738370+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9518,7 +9623,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293624+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079895+00:00"
           },
           "order_by": {
             "$ref": "#/components/schemas/logOrderByData"
@@ -9560,7 +9665,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736901+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738388+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9584,7 +9689,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736932+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738402+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9596,7 +9701,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293670+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079924+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Field Sub Field Aggregation Bucket\" Field sub aggregation bucket containing field values and the number of logs.",
@@ -9634,7 +9739,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.736971+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738419+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9691,7 +9796,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737014+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738438+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9715,7 +9820,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737043+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738452+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9727,7 +9832,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293727+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.079977+00:00"
           },
           "sub_aggs": {
             "type": "object",
@@ -9777,7 +9882,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293764+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080001+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Max Aggregation Data\" Max Aggregation data.",
@@ -9834,7 +9939,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293802+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080026+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Min Aggregation Data\" Min Aggregation data.",
@@ -9870,7 +9975,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737112+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738485+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -9981,7 +10086,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737173+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10047,7 +10152,7 @@
             "maxLength": 16,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293901+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080091+00:00"
           },
           "value": {
             "type": "number",
@@ -10063,7 +10168,7 @@
             "maxLength": 15,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293926+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080109+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Percentile Aggregation Data\" Percentile Aggregation data.",
@@ -10100,7 +10205,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737235+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738542+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10201,16 +10306,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:04:49.737301+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:40:17.738571+00:00"
               },
               "deterministic": true
             },
@@ -10223,7 +10333,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.293992+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080149+00:00"
           },
           "sec_event_type": {
             "type": "string",
@@ -10240,7 +10350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737359+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738592+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10265,7 +10375,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737406+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738619+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10290,7 +10400,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737448+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738638+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10315,7 +10425,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737490+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738658+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10396,7 +10506,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737531+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738677+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10408,7 +10518,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294073+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080198+00:00"
           }
         },
         "x-f5xc-description-short": "Label based filtering for Security Events metrics. Security Events metrics are tagged with labels mentioned in MetricLabel.",
@@ -10486,7 +10596,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.737585+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10498,7 +10608,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294110+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080221+00:00"
           }
         },
         "x-f5xc-description-short": "Value returned for a Security Events Metrics query.",
@@ -10549,7 +10659,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737670+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738741+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10612,7 +10722,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737735+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10650,7 +10760,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737791+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738801+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10687,7 +10797,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737852+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738832+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10724,7 +10834,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737907+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738862+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10786,7 +10896,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.737984+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738900+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10875,7 +10985,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738083+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738945+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -10949,7 +11059,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738146+00:00"
+                "validatedAt": "2026-05-05T18:40:17.738978+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11008,7 +11118,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738203+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739006+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11061,7 +11171,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.738252+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739028+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11196,23 +11306,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738346+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739070+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11228,7 +11338,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294413+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080397+00:00"
           }
         },
         "x-f5xc-description-short": "Cookie matcher specifies the name of a single cookie and the criteria to match it.",
@@ -11603,7 +11713,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738401+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739099+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11709,7 +11819,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738458+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739129+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11771,7 +11881,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738517+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739159+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -11849,23 +11959,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738590+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739196+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -11881,7 +11991,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294525+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080470+00:00"
           }
         },
         "x-f5xc-description-short": "JWT claim matcher specifies the name of a single JWT claim and the criteria for the input request to match it.",
@@ -11978,7 +12088,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738649+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739226+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12024,7 +12134,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738700+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739254+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12062,7 +12172,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738753+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739283+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12141,7 +12251,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738813+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739314+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12198,7 +12308,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738868+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739343+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12235,7 +12345,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738932+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739378+00:00"
               },
               "deterministic": true
             },
@@ -12271,7 +12381,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.738986+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739404+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12306,7 +12416,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739041+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739432+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12382,7 +12492,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739127+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739473+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12415,7 +12525,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.739179+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739496+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12458,7 +12568,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739239+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739527+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12494,7 +12604,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739317+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739564+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12537,7 +12647,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739400+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739601+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12582,7 +12692,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739482+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739646+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12659,7 +12769,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739537+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739675+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12700,7 +12810,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739610+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12742,7 +12852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739668+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739734+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12913,7 +13023,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739722+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -12970,7 +13080,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739812+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739807+00:00"
               },
               "deterministic": true
             },
@@ -12983,7 +13093,7 @@
             "x-original-maxLength": 256,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294783+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080629+00:00"
           },
           "name": {
             "type": "string",
@@ -13011,23 +13121,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 1024,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.739876+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739841+00:00"
               },
               "deterministic": true
             },
@@ -13039,7 +13149,7 @@
             },
             "x-original-maxLength": 1024,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294809+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080646+00:00"
           }
         },
         "x-f5xc-description-short": "MessageMetaType is metadata (common attributes) of a message that only certain messages have.",
@@ -13153,7 +13263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:04:49.739933+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739867+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13165,7 +13275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294844+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080667+00:00"
           },
           "previous_value": {
             "type": "string",
@@ -13180,7 +13290,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.739981+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739889+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13206,7 +13316,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.740022+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739908+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13218,7 +13328,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.294890+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080694+00:00"
           }
         },
         "x-f5xc-description-short": "X-displayName: \"Trend Value\" Trend value contains trend value, trend sentiment and trend calculation description and window size.",
@@ -13281,7 +13391,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:49.740063+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739926+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13680,23 +13790,23 @@
               "category": "discovery",
               "maxLength": 256,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740187+00:00"
+                "validatedAt": "2026-05-05T18:40:17.739984+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13712,7 +13822,7 @@
             "x-original-maxLength": 256,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295092+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080815+00:00"
           }
         },
         "x-f5xc-description-short": "Header matcher specifies the name of a single HTTP header and the criteria for the input request to match it.",
@@ -13772,7 +13882,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740245+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740013+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13855,7 +13965,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740309+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740046+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -13867,7 +13977,7 @@
             "x-original-maxLength": 256,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295167+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080859+00:00"
           }
         },
         "x-f5xc-description-short": "Query parameter matcher specifies the name of a single query parameter and the criteria for the input request to match it.",
@@ -13922,23 +14032,23 @@
               "category": "discovery",
               "minLength": 1,
               "maxLength": 128,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740383+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740080+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -13954,7 +14064,7 @@
             },
             "x-original-maxLength": 128,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295195+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080877+00:00"
           },
           "namespace": {
             "type": "string",
@@ -13977,16 +14087,21 @@
               "category": "discovery",
               "maxLength": 64,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740446+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740112+00:00"
               },
               "deterministic": true,
               "byteLength": {
@@ -14002,7 +14117,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295220+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080893+00:00"
           },
           "tenant": {
             "type": "string",
@@ -14031,7 +14146,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:04:49.740513+00:00"
+                "validatedAt": "2026-05-05T18:40:17.740146+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -14045,7 +14160,7 @@
             "x-original-maxLength": 64,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:04.295248+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:00.080909+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a direct reference from one object(the referrer) to another(the referred).",
@@ -14190,7 +14305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:04:55.662384+00:00"
+                "validatedAt": "2026-05-05T18:40:20.563083+00:00"
               }
             },
             "x-f5xc-required-for": {

--- a/docs/specifications/api/users.json
+++ b/docs/specifications/api/users.json
@@ -3387,7 +3387,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:12:48.959956+00:00"
+                "validatedAt": "2026-05-05T18:44:19.064780+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3399,7 +3399,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.059650+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.100608+00:00"
           },
           "key": {
             "type": "string",
@@ -3416,7 +3416,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:48.959994+00:00"
+                "validatedAt": "2026-05-05T18:44:19.064798+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3428,7 +3428,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.059680+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.100634+00:00"
           },
           "value": {
             "type": "string",
@@ -3445,7 +3445,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:12:48.960032+00:00"
+                "validatedAt": "2026-05-05T18:44:19.064816+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3457,7 +3457,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:15.059709+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.100651+00:00"
           }
         },
         "x-f5xc-description-short": "Generic Label type label.key(label.value).",
@@ -3501,7 +3501,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:54.183838+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015346+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3513,7 +3513,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305048+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773243+00:00"
           },
           "key": {
             "type": "string",
@@ -3530,7 +3530,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:54.183880+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015364+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3542,7 +3542,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305078+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773260+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3557,16 +3557,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:54.183922+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:50.015384+00:00"
               },
               "deterministic": true
             },
@@ -3579,7 +3584,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305104+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773276+00:00"
           },
           "value": {
             "type": "string",
@@ -3602,7 +3607,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:54.183975+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015406+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3614,7 +3619,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305133+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773292+00:00"
           }
         },
         "x-f5xc-description-short": "Create label request in shared namespace. Only shared namespace supported.",
@@ -3678,7 +3683,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:54.184012+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015427+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3690,7 +3695,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305174+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773315+00:00"
           },
           "namespace": {
             "type": "string",
@@ -3705,16 +3710,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:54.184050+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:50.015446+00:00"
               },
               "deterministic": true
             },
@@ -3727,7 +3737,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305201+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773331+00:00"
           },
           "value": {
             "type": "string",
@@ -3750,7 +3760,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:54.184093+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015464+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3762,7 +3772,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305227+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773346+00:00"
           }
         },
         "x-f5xc-description-short": "Deletes Label matching label.key=label.value.",
@@ -3857,7 +3867,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:54.184170+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015498+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3869,7 +3879,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305268+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773371+00:00"
           },
           "key": {
             "type": "string",
@@ -3886,7 +3896,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:54.184201+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3898,7 +3908,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305294+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773386+00:00"
           },
           "value": {
             "type": "string",
@@ -3915,7 +3925,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:54.184241+00:00"
+                "validatedAt": "2026-05-05T18:44:50.015530+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3927,7 +3937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.305329+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.773401+00:00"
           }
         },
         "x-f5xc-description-short": "Generic Label type label.key(label.value).",
@@ -3971,7 +3981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:59.813697+00:00"
+                "validatedAt": "2026-05-05T18:44:52.657982+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -3983,7 +3993,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375786+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810804+00:00"
           },
           "key": {
             "type": "string",
@@ -4000,7 +4010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:59.813740+00:00"
+                "validatedAt": "2026-05-05T18:44:52.658001+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4012,7 +4022,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375817+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810821+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4027,16 +4037,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:59.813780+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:52.658021+00:00"
               },
               "deterministic": true
             },
@@ -4049,7 +4064,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375844+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810837+00:00"
           }
         },
         "x-f5xc-description-short": "Create label Key request in shared namespace. Only shared namespace supported.",
@@ -4112,7 +4127,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:59.813819+00:00"
+                "validatedAt": "2026-05-05T18:44:52.658037+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4124,7 +4139,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375884+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810861+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4140,16 +4155,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:13:59.813855+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:44:52.658056+00:00"
               },
               "deterministic": true
             },
@@ -4162,7 +4182,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375912+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810878+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4256,7 +4276,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:13:59.813939+00:00"
+                "validatedAt": "2026-05-05T18:44:52.658092+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4268,7 +4288,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375954+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810902+00:00"
           },
           "key": {
             "type": "string",
@@ -4285,7 +4305,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:13:59.813968+00:00"
+                "validatedAt": "2026-05-05T18:44:52.658106+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4297,7 +4317,7 @@
             "x-original-maxLength": 1024,
             "minLength": 7,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:16.375982+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:06.810919+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -4330,7 +4350,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.745854+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982626+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4353,7 +4373,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.745918+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982659+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4365,7 +4385,7 @@
             "x-original-maxLength": 1024,
             "minLength": 3,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906660+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.079950+00:00"
           }
         },
         "x-f5xc-description-short": "Contains an arbitrary serialized protocol buffer message along with a URL that describes the type of the serialized message.",
@@ -4411,7 +4431,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.745969+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982683+00:00"
               },
               "deterministic": true
             },
@@ -4437,7 +4457,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746021+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982705+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4464,7 +4484,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746063+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982724+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4476,7 +4496,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906712+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.079978+00:00"
           },
           "service_name": {
             "type": "string",
@@ -4493,7 +4513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746110+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982747+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4526,7 +4546,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746162+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982771+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4538,7 +4558,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906748+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080000+00:00"
           },
           "type": {
             "type": "string",
@@ -4563,7 +4583,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746205+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982789+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4651,7 +4671,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746254+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982810+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -4697,23 +4717,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746296+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.982831+00:00"
               },
               "deterministic": true
             },
@@ -4726,7 +4746,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906815+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080038+00:00"
           }
         },
         "x-f5xc-description-short": "Initializer is information about an initializer that has not yet completed.",
@@ -4844,7 +4864,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:38.746444+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982890+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -4860,7 +4880,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906874+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080073+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -4914,23 +4934,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746490+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.982911+00:00"
               },
               "deterministic": true
             },
@@ -4943,7 +4963,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906922+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080100+00:00"
           },
           "namespace": {
             "type": "string",
@@ -4960,16 +4980,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746523+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.982927+00:00"
               },
               "deterministic": true
             },
@@ -4982,7 +5007,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906947+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080116+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectCreateMetaType is metadata that can be specified in Create request of an object.",
@@ -5064,7 +5089,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:38.746621+00:00"
+                "validatedAt": "2026-05-05T18:45:46.982973+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5080,7 +5105,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.906986+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080138+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5136,23 +5161,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746663+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.982995+00:00"
               },
               "deterministic": true
             },
@@ -5165,7 +5190,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907030+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080165+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5182,16 +5207,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746697+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983013+00:00"
               },
               "deterministic": true
             },
@@ -5204,7 +5234,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907057+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080180+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectGetMetaType is metadata that can be specified in GET/Create response of an object.",
@@ -5286,7 +5316,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:38.746790+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983090+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5302,7 +5332,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907099+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080203+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5358,23 +5388,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746835+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983119+00:00"
               },
               "deterministic": true
             },
@@ -5387,7 +5417,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907145+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080229+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5404,16 +5434,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746867+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983137+00:00"
               },
               "deterministic": true
             },
@@ -5426,7 +5461,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907172+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080245+00:00"
           },
           "uid": {
             "type": "string",
@@ -5445,7 +5480,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746896+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983152+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5460,7 +5495,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907201+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080261+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectMetaType is metadata(common attributes) of an object that all configuration objects will have.",
@@ -5507,7 +5542,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.746934+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983170+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5520,7 +5555,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907230+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080277+00:00"
           },
           "name": {
             "type": "string",
@@ -5537,23 +5572,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.746968+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983187+00:00"
               },
               "deterministic": true
             },
@@ -5566,7 +5601,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907256+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080293+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5583,16 +5618,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.747000+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983206+00:00"
               },
               "deterministic": true
             },
@@ -5605,7 +5645,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907282+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080309+00:00"
           },
           "tenant": {
             "type": "string",
@@ -5624,7 +5664,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747041+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983225+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5638,7 +5678,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907308+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080324+00:00"
           },
           "uid": {
             "type": "string",
@@ -5657,7 +5697,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747071+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983239+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5672,7 +5712,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907347+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080340+00:00"
           }
         },
         "x-f5xc-description-short": "Type establishes a 'direct reference' from one object(the referrer) to another(the referred).",
@@ -5754,7 +5794,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:38.747167+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983290+00:00"
               },
               "byteLength": {
                 "max": 1200
@@ -5770,7 +5810,7 @@
             "x-original-maxLength": 1200,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907390+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080363+00:00"
           },
           "disable": {
             "type": "boolean",
@@ -5824,23 +5864,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.747211+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983311+00:00"
               },
               "deterministic": true
             },
@@ -5853,7 +5893,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907438+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080390+00:00"
           },
           "namespace": {
             "type": "string",
@@ -5870,16 +5910,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.747243+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983327+00:00"
               },
               "deterministic": true
             },
@@ -5892,7 +5937,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907464+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080405+00:00"
           }
         },
         "x-f5xc-description-short": "ObjectReplaceMetaType is metadata that can be specified in Replace request of an object.",
@@ -5937,7 +5982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747297+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983349+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5965,7 +6010,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747356+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983371+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -5993,7 +6038,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747403+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983391+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6022,7 +6067,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747449+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983412+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6049,7 +6094,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747479+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983426+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6063,7 +6108,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907536+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080448+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6079,7 +6124,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747521+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983445+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6188,7 +6233,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747580+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983471+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6200,7 +6245,7 @@
             "x-original-maxLength": 1024,
             "minLength": 27,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907592+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080481+00:00"
           },
           "status": {
             "type": "string",
@@ -6218,7 +6263,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747621+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983489+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6230,7 +6275,7 @@
             "x-original-maxLength": 1024,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907617+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080497+00:00"
           }
         },
         "x-f5xc-description-short": "Status is a return value for calls that don't return other objects.",
@@ -6272,7 +6317,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747672+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983512+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6299,7 +6344,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747720+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983532+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6326,7 +6371,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747765+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983552+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6354,7 +6399,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747817+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983574+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6419,7 +6464,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747887+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983605+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6468,7 +6513,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747944+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983642+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6481,7 +6526,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907732+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080565+00:00"
           },
           "uid": {
             "type": "string",
@@ -6500,7 +6545,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.747975+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983656+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6514,7 +6559,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907759+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080581+00:00"
           }
         },
         "x-f5xc-description-short": "SystemObjectGetMetaType is metadata generated or populated by the system for all persisted objects and cannot be updated directly by users.",
@@ -6566,7 +6611,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748028+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983679+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6594,7 +6639,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748077+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983700+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6623,7 +6668,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748126+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983721+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6650,7 +6695,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748170+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983742+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6679,7 +6724,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748220+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983764+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6704,7 +6749,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748271+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983785+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6769,7 +6814,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748349+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983815+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6807,7 +6852,7 @@
               "metadata": {
                 "source": "discovery",
                 "confidence": 0.99,
-                "validatedAt": "2026-05-05T06:20:38.748410+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983846+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6819,7 +6864,7 @@
             "maxLength": 6,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907874+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080664+00:00"
           },
           "object_index": {
             "type": "integer",
@@ -6860,7 +6905,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748468+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983870+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6904,7 +6949,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748508+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983890+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6918,7 +6963,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907935+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080700+00:00"
           },
           "trace_info": {
             "type": "string",
@@ -6937,7 +6982,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748555+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983910+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6964,7 +7009,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748585+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983924+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -6979,7 +7024,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.907974+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080721+00:00"
           },
           "vtrp_id": {
             "type": "string",
@@ -6994,7 +7039,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748627+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983943+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7075,7 +7120,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748668+00:00"
+                "validatedAt": "2026-05-05T18:45:46.983964+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7087,7 +7132,7 @@
             "x-original-maxLength": 1024,
             "minLength": 12,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908019+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080748+00:00"
           },
           "name": {
             "type": "string",
@@ -7104,23 +7149,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.748702+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.983987+00:00"
               },
               "deterministic": true
             },
@@ -7133,7 +7178,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908047+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080763+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7150,16 +7195,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.748734+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984003+00:00"
               },
               "deterministic": true
             },
@@ -7172,7 +7222,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908074+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080779+00:00"
           },
           "uid": {
             "type": "string",
@@ -7189,7 +7239,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748764+00:00"
+                "validatedAt": "2026-05-05T18:45:46.984018+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7203,7 +7253,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908101+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080795+00:00"
           }
         },
         "x-f5xc-description-short": "ViewRefType represents a reference to a view.",
@@ -7329,23 +7379,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.748808+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984037+00:00"
               },
               "deterministic": true
             },
@@ -7358,7 +7408,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908182+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080844+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7374,16 +7424,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.748841+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984054+00:00"
               },
               "deterministic": true
             },
@@ -7396,7 +7451,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908208+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080859+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7433,7 +7488,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.748893+00:00"
+                "validatedAt": "2026-05-05T18:45:46.984076+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7445,7 +7500,7 @@
             "x-original-maxLength": 1024,
             "minLength": 279,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908239+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080876+00:00"
           }
         },
         "x-f5xc-minimum-configuration": {
@@ -7546,7 +7601,7 @@
             "maxLength": 17,
             "minLength": 17,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908334+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080928+00:00"
           },
           "system_metadata": {
             "$ref": "#/components/schemas/schemaSystemObjectGetMetaType"
@@ -7662,7 +7717,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.7,
-                "validatedAt": "2026-05-05T06:20:38.749013+00:00"
+                "validatedAt": "2026-05-05T18:45:46.984128+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7724,7 +7779,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.8,
-                "validatedAt": "2026-05-05T06:20:38.749075+00:00"
+                "validatedAt": "2026-05-05T18:45:46.984155+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7736,7 +7791,7 @@
             "x-original-maxLength": 1024,
             "minLength": 21,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908424+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.080978+00:00"
           },
           "disabled": {
             "type": "boolean",
@@ -7786,23 +7841,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.749117+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984175+00:00"
               },
               "deterministic": true
             },
@@ -7815,7 +7870,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908490+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.081014+00:00"
           },
           "namespace": {
             "type": "string",
@@ -7830,16 +7885,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.749149+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984191+00:00"
               },
               "deterministic": true
             },
@@ -7852,7 +7912,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908517+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.081030+00:00"
           },
           "owner_view": {
             "$ref": "#/components/schemas/schemaViewRefType"
@@ -7891,7 +7951,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.749201+00:00"
+                "validatedAt": "2026-05-05T18:45:46.984219+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7904,7 +7964,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908568+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.081060+00:00"
           },
           "uid": {
             "type": "string",
@@ -7921,7 +7981,7 @@
               "metadata": {
                 "source": "inferred",
                 "confidence": 0.85,
-                "validatedAt": "2026-05-05T06:20:38.749232+00:00"
+                "validatedAt": "2026-05-05T18:45:46.984234+00:00"
               }
             },
             "x-f5xc-required-for": {
@@ -7935,7 +7995,7 @@
             "minLength": 36,
             "format": "uuid",
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908595+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.081076+00:00"
           }
         },
         "x-f5xc-description-short": "By default a summary of token is returned in 'List'. By setting 'report_fields' in the ListRequest more details of each item can be got.",
@@ -8146,23 +8206,23 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
                 "restricted": "[^a-z0-9-]",
                 "required": "[a-z0-9]",
-                "description": "Lowercase alphanumeric with hyphens, not at start/end"
+                "description": "Lowercase letter start, alphanumeric with hyphens, alphanumeric end"
               },
               "format": "dns-label",
-              "formatDescription": "RFC 1123 DNS label: lowercase, alphanumeric, hyphens allowed but not at start/end",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter, may contain lowercase alphanumeric and hyphens, must end with alphanumeric",
               "validation": {
-                "rfc": "RFC 1123",
-                "standard": "Kubernetes resource naming"
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
               },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.749278+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984255+00:00"
               },
               "deterministic": true
             },
@@ -8175,7 +8235,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908690+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.081133+00:00"
           },
           "namespace": {
             "type": "string",
@@ -8190,16 +8250,21 @@
               "category": "naming",
               "maxLength": 1024,
               "minLength": 1,
-              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$",
+              "pattern": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
               "characterSet": {
                 "allowed": "[a-z0-9-]",
-                "description": "Kubernetes namespace format"
+                "description": "DNS-1035 label format (alpha-first)"
               },
               "format": "dns-label",
+              "formatDescription": "DNS-1035 label: must start with a lowercase letter",
+              "validation": {
+                "rfc": "RFC 1035",
+                "standard": "DNS-1035 label (alpha-first)"
+              },
               "metadata": {
                 "source": "inferred",
-                "confidence": 0.95,
-                "validatedAt": "2026-05-05T06:20:38.749309+00:00"
+                "confidence": 0.99,
+                "validatedAt": "2026-05-05T18:45:46.984271+00:00"
               },
               "deterministic": true
             },
@@ -8212,7 +8277,7 @@
             "x-original-maxLength": 1024,
             "minLength": 6,
             "x-reconciled-from-discovery": true,
-            "x-reconciled-at": "2026-05-05T06:23:24.908715+00:00"
+            "x-reconciled-at": "2026-05-05T18:47:13.081149+00:00"
           },
           "state": {
             "$ref": "#/components/schemas/tokenState"

--- a/docs/specifications/api/validation.json
+++ b/docs/specifications/api/validation.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "version": "2.1.0",
   "description": "Centralized validation specification for F5 XC API",
-  "generated_at": "2026-05-05T06:23:51.460868+00:00",
+  "generated_at": "2026-05-05T18:47:29.625853+00:00",
   "source": "api-specs-enriched",
   "required_fields": {
     "common": {
@@ -946,8 +946,5 @@
     "oneof_defaults_exported": 0,
     "ui_vs_server_defaults_exported": 1,
     "warnings": []
-  },
-  "info": {
-    "version": "2.1.68"
   }
 }

--- a/scripts/utils/constraint_enricher.py
+++ b/scripts/utils/constraint_enricher.py
@@ -530,16 +530,26 @@ class ConstraintEnricher:
         # Check for resource-specific constraint override
         resource_override = self._get_resource_override(schema_name, field_name)
         if resource_override:
-            override_result: dict[str, Any] = {
-                **resource_override.get("constraints", {}),
-            }
+            override_constraints = resource_override.get("constraints", {})
             override_metadata = resource_override.get("metadata", {})
-            if override_metadata:
-                override_result["metadata"] = override_metadata
+            confidence = override_metadata.get("confidence", 0)
+            threshold = (
+                self.config.get("metadata", {}).get("confidence_thresholds", {}).get("high", 0.9)
+            )
+            override_result: dict[str, Any] = {
+                "constraintType": resource_override.get("type", "number"),
+                "category": override_metadata.get("category", "api-probed"),
+                **override_constraints,
+                "deterministic": confidence >= threshold,
+                "metadata": {
+                    **override_metadata,
+                    "validatedAt": datetime.now(timezone.utc).isoformat(),
+                },
+            }
             schema["x-f5xc-constraints"] = override_result
             self.stats["constraints_added"] += 1
-            if "confidence" in override_metadata:
-                self.stats["confidence_scores"].append(override_metadata["confidence"])
+            if confidence:
+                self.stats["confidence_scores"].append(confidence)
             return
 
         # Extract inferred constraints based on type

--- a/tests/test_constraint_enricher.py
+++ b/tests/test_constraint_enricher.py
@@ -69,8 +69,8 @@ class TestPatternMatcher:
         """Test matching 'name' field against string patterns"""
         result = pattern_matcher.match_string_pattern("name")
         assert result is not None
-        assert result["description"] == "DNS label format resource name"
-        assert result["metadata"]["confidence"] == 0.95
+        assert result["description"] == "DNS-1035 label format resource name"
+        assert result["metadata"]["confidence"] == 0.99
 
     def test_match_string_email_pattern(self, pattern_matcher):
         """Test matching 'email' field against string patterns"""
@@ -720,8 +720,13 @@ class TestResourceConstraintOverrides:
             "jitter_percent"
         ]
         constraints = field["x-f5xc-constraints"]
-        assert constraints["minimum"] == 0
-        assert constraints["maximum"] == 50
+        assert "ranges" in constraints
+        assert "minimum" not in constraints
+        assert "maximum" not in constraints
+        ranges = constraints["ranges"]
+        assert len(ranges) == 2
+        assert ranges[0] == {"minimum": 0, "maximum": 0}
+        assert ranges[1] == {"minimum": 10, "maximum": 50}
 
     def test_interval_uses_global_pattern(self, enricher, healthcheck_spec):
         """interval has no resource override — should use global pattern (max 600)."""
@@ -750,6 +755,38 @@ class TestResourceConstraintOverrides:
         timeout = result["components"]["schemas"]["someOtherSpecType"]["properties"]["timeout"]
         constraints = timeout["x-f5xc-constraints"]
         assert constraints["maximum"] == 3600
+
+    def test_override_includes_constraint_type(self, enricher, healthcheck_spec):
+        result = enricher.enrich_spec(healthcheck_spec)
+        timeout = result["components"]["schemas"]["healthcheckCreateSpecType"]["properties"][
+            "timeout"
+        ]
+        constraints = timeout["x-f5xc-constraints"]
+        assert constraints["constraintType"] == "number"
+
+    def test_override_includes_deterministic(self, enricher, healthcheck_spec):
+        result = enricher.enrich_spec(healthcheck_spec)
+        timeout = result["components"]["schemas"]["healthcheckCreateSpecType"]["properties"][
+            "timeout"
+        ]
+        constraints = timeout["x-f5xc-constraints"]
+        assert constraints["deterministic"] is True
+
+    def test_override_includes_validated_at(self, enricher, healthcheck_spec):
+        result = enricher.enrich_spec(healthcheck_spec)
+        timeout = result["components"]["schemas"]["healthcheckCreateSpecType"]["properties"][
+            "timeout"
+        ]
+        constraints = timeout["x-f5xc-constraints"]
+        assert "validatedAt" in constraints["metadata"]
+
+    def test_override_includes_category(self, enricher, healthcheck_spec):
+        result = enricher.enrich_spec(healthcheck_spec)
+        timeout = result["components"]["schemas"]["healthcheckCreateSpecType"]["properties"][
+            "timeout"
+        ]
+        constraints = timeout["x-f5xc-constraints"]
+        assert constraints["category"] == "timing"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Fix global `metadata.name` and `namespace` regex from `^[a-z0-9]` to `^[a-z]` per DNS-1035 API enforcement (#301)
- Represent `jitter_percent` as non-contiguous range `{0} ∪ [10, 50]` using new `ranges` constraint field (#295)
- Align resource constraint override output structure with standard path — adds `constraintType`, `category`, `deterministic`, `validatedAt`
- Document `expected_status_codes` item format and `jitter` response-only field (#296)
- Update extension registry to document new `ranges` field

## Test plan
- [ ] 2055 tests pass (updated jitter range test + 4 new structural tests)
- [ ] Pipeline generates all 38 domain specs without errors
- [ ] Name pattern is `^[a-z]([-a-z0-9]*[a-z0-9])?$` across all specs
- [ ] `jitter_percent` has `ranges` field, no top-level `minimum`/`maximum`
- [ ] Override constraints include `constraintType`, `deterministic`, `validatedAt`

Closes #295, Closes #296, Closes #301, Closes #302