### PR TITLE
fix: phase 5 remaining gaps — healthcheck fields, catalog version sync

### DIFF
--- a/.github/workflows/sync-and-enrich.yml
+++ b/.github/workflows/sync-and-enrich.yml
@@ -411,6 +411,16 @@ jobs:
 
           echo "Version consistent: $INDEX_VERSION"
 
+      - name: Align catalog version with release
+        if: steps.version.outputs.has_changes == 'true'
+        run: |
+          VERSION="${{ steps.version.outputs.new_version }}"
+          if [ -f release/api-catalog.json ]; then
+            jq --arg v "$VERSION" '.version = $v' release/api-catalog.json > /tmp/catalog.json
+            mv /tmp/catalog.json release/api-catalog.json
+            echo "Catalog version aligned to $VERSION"
+          fi
+
       - name: Generate discovery summary
         id: discovery-summary
         if: steps.check-discovery.outputs.has_discovery == 'true'

--- a/config/discovered_defaults.yaml
+++ b/config/discovered_defaults.yaml
@@ -79,6 +79,8 @@ resources:
           use_http2: false
           # Expected status codes (empty = accept 200-299)
           expected_status_codes: []
+          # Expected response body text (empty string = no body matching)
+          expected_response: ""
         # Recommended values for UI/CLI/AI assistants
         # These match F5 XC web interface pre-populated values
         recommended:

--- a/config/field_metadata.yaml
+++ b/config/field_metadata.yaml
@@ -186,6 +186,9 @@ field_patterns:
     x-f5xc-description: 'List of expected HTTP status codes or code ranges for health check validation'
     x-f5xc-validation:
       type: array
+      items:
+        type: string
+        description: 'HTTP status code (e.g. "200") or range (e.g. "200-299")'
       maxItems: 16
     x-f5xc-examples:
       - value: '200'

--- a/scripts/compile_catalog.py
+++ b/scripts/compile_catalog.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import argparse
+import os
 import json
 import re
 import sys
@@ -563,8 +564,9 @@ def compile_catalog(openapi: dict[str, Any]) -> dict[str, Any]:
 
     _deduplicate_global_op_names(categories)
 
+    env_version = os.environ.get("CATALOG_VERSION", "")
     tag_version = get_version_from_tags()
-    version = tag_version if tag_version != "0.0.0" else "1.0.0"
+    version = env_version or (tag_version if tag_version != "0.0.0" else "1.0.0")
 
     return {
         "service": "f5xc",


### PR DESCRIPTION
## Summary

Phase 5 TTFT determinism verification cleanup. Fixes 2 of 3 remaining issues, partially addresses the third.

## Changes

### #316 — Healthcheck response-only and typing gaps (FIXED)
- **discovered_defaults.yaml**: Added `expected_response: ""` to `http_health_check` defaults. API returns this field on all http health check objects.
- **field_metadata.yaml**: Added explicit `items.type: string` and description to `expected_status_codes` validation. Items are strings supporting range notation (e.g., "200-299").
- **jitter**: Already tracked in `readonly_fields.yaml` and `discovered_defaults.yaml` — no change needed.

### #318 — Catalog version metadata stale (FIXED)
- **Root cause**: `compile_catalog.py` called `get_version_from_tags()` during enrichment, before the new git tag was created. Result: catalog always one version behind.
- **compile_catalog.py**: Added `CATALOG_VERSION` environment variable override. When set, uses the provided version instead of git tag.
- **sync-and-enrich.yml**: Added "Align catalog version with release" step after version verification. Uses `jq` to stamp the correct version into `api-catalog.json`.

### #317 — use_tls.tls_config conditional required (PARTIALLY ADDRESSED)
- The conditional requirement is already documented in `minimum_configs.yaml`:
  ```yaml
  context_requirements:
    - field: "spec.use_tls.tls_config"
      contexts: ["tls", "secure"]
      reason: "Required when use_tls is chosen — API returns 400 without it"
  ```
- The misattribution of `Required For: minimum_config, create` to `max_session_keys` is in the `MinimumConfigurationEnricher` field resolution logic — needs separate investigation of how context_requirements map to `x-f5xc-required-for` extensions.

## Testing

Config files are declarative — validated by existing pipeline tests. The `CATALOG_VERSION` env var is backward-compatible (falls back to git tag when unset).

Closes #316
Closes #318
Refs #317