### PR TITLE
fix(config): preserve maxLength and format constraints in blocking_page override

### DIFF
--- a/config/constraint_patterns.yaml
+++ b/config/constraint_patterns.yaml
@@ -1146,7 +1146,9 @@ resource_constraint_overrides:
     fields:
       blocking_page:
         type: "string"
-        constraints: {}
+        constraints:
+          maxLength: 4096
+          format: "uri"
         metadata:
           source: "api-probed"
           confidence: 0.99


### PR DESCRIPTION
## Summary

- Fixes the `blocking_page` resource override in `constraint_patterns.yaml` to preserve the `maxLength: 4096` and `format: "uri"` constraints instead of using an empty `constraints: {}` that overwrites auto-inferred values
- The schema's `x-ves-validation-rules` has both `string.max_len: "4096"` and `string.uri_ref: "true"` which map to these constraints via discovery

Closes #328

## Test plan

- [ ] CI checks pass
- [ ] Verify enriched output includes `maxLength` and `format` constraints for `blocking_page` field